### PR TITLE
Changed button text from File Now to File Annual Report

### DIFF
--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -194,7 +194,7 @@
                   :disabled="!item.enabled || coaPending || !confirmCheckbox"
                   @click.native.stop="doFileNow(item)"
                 >
-                  <span>File Now</span>
+                  <span>File Annual Report</span>
                 </v-btn>
               </div>
             </div>

--- a/tests/unit/TodoList.spec.ts
+++ b/tests/unit/TodoList.spec.ts
@@ -176,7 +176,7 @@ describe('TodoList - UI', () => {
 
     const button = item.querySelector('.list-item__actions .v-btn')
     expect(button.disabled).toBe(false)
-    expect(button.querySelector('.v-btn__content').textContent).toContain('File Now')
+    expect(button.querySelector('.v-btn__content').textContent).toContain('File Annual Report')
 
     wrapper.destroy()
   })
@@ -697,7 +697,7 @@ describe('TodoList - UI - BCOMP', () => {
 
     const button = item.querySelector('.list-item__actions .v-btn')
     expect(button.disabled).toBe(false)
-    expect(button.querySelector('.v-btn__content').textContent).toContain('File Now')
+    expect(button.querySelector('.v-btn__content').textContent).toContain('File Annual Report')
 
     wrapper.destroy()
   })
@@ -741,7 +741,7 @@ describe('TodoList - UI - BCOMP', () => {
 
     const button = item.querySelector('.list-item__actions .v-btn')
     expect(button.disabled).toBe(true)
-    expect(button.querySelector('.v-btn__content').textContent).toContain('File Now')
+    expect(button.querySelector('.v-btn__content').textContent).toContain('File Annual Report')
 
     wrapper.destroy()
   })
@@ -1025,7 +1025,7 @@ describe('TodoList - Click Tests', () => {
 
       const item = vm.$el.querySelector('.list-item')
       const button = item.querySelector('.list-item__actions .v-btn')
-      expect(button.querySelector('.v-btn__content').textContent).toContain('File Now')
+      expect(button.querySelector('.v-btn__content').textContent).toContain('File Annual Report')
 
       await button.click()
 
@@ -1258,7 +1258,7 @@ describe('TodoList - Click Tests - BCOMPs', () => {
       // verify File Now button
       const listItem = vm.$el.querySelector('.list-item')
       const fileNowButton = listItem.querySelector('.list-item__actions .v-btn')
-      expect(fileNowButton.querySelector('.v-btn__content').textContent).toContain('File Now')
+      expect(fileNowButton.querySelector('.v-btn__content').textContent).toContain('File Annual Report')
       expect(fileNowButton.disabled).toBe(true)
 
       // click checkbox to enable File Now button


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2647

*Description of changes:*
Changed button text from File Now to File Annual Report.
Duplication of Richard's changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
