### PR TITLE
correction filing (part 3)

### DIFF
--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -393,7 +393,7 @@ export default {
         this.filedItems.push(item)
       } else {
         // eslint-disable-next-line no-console
-        console.log(`ERROR - missing section in filing =`, filing)
+        console.log('ERROR - missing section in filing =', filing)
       }
     },
 
@@ -408,7 +408,7 @@ export default {
 
       let title: string
       if (filing.annualReport && filing.annualReport.annualReportDate) {
-        const agmYear = +filing.annualReport.annualReportDate.slice(0, 4)
+        const agmYear: number = +filing.annualReport.annualReportDate.slice(0, 4)
         title = this.typeToTitle(type, agmYear)
       } else {
         title = this.typeToTitle(type)
@@ -475,32 +475,31 @@ export default {
       if (!item || !item.type) return // safety check
       switch (item.type) {
         case FilingTypes.ANNUAL_REPORT:
-          // FUTURE:
+          // FUTURE?
           // this.$router.push({ name: 'annual-report', params: { id: item.filingId, isCorrection: true } })
           // FOR NOW:
-          this.$router.push({ name: 'correction', params: { id: item.filingId } })
+          this.$router.push({ name: 'correction', params: { correctedFilingId: item.filingId } })
           break
         case FilingTypes.CHANGE_OF_DIRECTORS:
-          // FUTURE:
+          // FUTURE?
           // this.$router.push({ name: 'standalone-directors', params: { id: item.filingId, isCorrection: true } })
           // FOR NOW:
-          this.$router.push({ name: 'correction', params: { id: item.filingId } })
+          this.$router.push({ name: 'correction', params: { correctedFilingId: item.filingId } })
           break
         case FilingTypes.CHANGE_OF_ADDRESS:
-          // FUTURE:
+          // FUTURE?
           // this.$router.push({ name: 'standalone-addresses', params: { id: item.filingId, isCorrection: true } })
           // FOR NOW:
-          this.$router.push({ name: 'correction', params: { id: item.filingId } })
+          this.$router.push({ name: 'correction', params: { correctedFilingId: item.filingId } })
           break
         case FilingTypes.CORRECTION:
-          // FUTURE:
-          // this.$router.push({ name: 'correction', params: { id: item.filingId, isCorrection: true } })
-          // FOR NOW:
-          this.$router.push({ name: 'correction', params: { id: item.filingId } })
+          // FUTURE: allow a correction to a correction (design TBD)
+          // this.$router.push({ name: 'correction', params: { correctedFilingId: item.filingId } })
+          alert('At this time, you cannot correct a correction. Please contact Ops if needed.')
           break
         default:
           // fallback for all other filings
-          this.$router.push({ name: 'correction', params: { id: item.filingId } })
+          this.$router.push({ name: 'correction', params: { correctedFilingId: item.filingId } })
           break
       }
     },

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -454,7 +454,7 @@ export default {
 
     loadCorrection (task) {
       // eslint-disable-next-line no-console
-      console.log('loading correction not yet implemented')
+      console.log('loading correction not yet implemented, task =', task)
     },
 
     doFileNow (item) {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1,3 +1,5 @@
+import { FilingTypes } from '@/enums'
+
 export default {
   isRoleStaff (state): boolean {
     return state.keycloakRoles.includes('staff')
@@ -31,7 +33,7 @@ export default {
       let filing = state.filings[i].filing
       let filingDate = filing.header.effectiveDate || filing.header.date
       filingDate = filingDate.slice(0, 10)
-      if (filing.hasOwnProperty('changeOfDirectors')) {
+      if (filing.hasOwnProperty(FilingTypes.CHANGE_OF_DIRECTORS)) {
         if (lastCOD === null || filingDate.split('-').join('') > lastCOD.split('-').join('')) {
           lastCOD = filingDate
         }
@@ -48,7 +50,7 @@ export default {
       let filing = state.filings[i].filing
       let filingDate = filing.header.effectiveDate || filing.header.date
       filingDate = filingDate.slice(0, 10)
-      if (filing.hasOwnProperty('changeOfAddress')) {
+      if (filing.hasOwnProperty(FilingTypes.CHANGE_OF_ADDRESS)) {
         if (lastCOA === null || filingDate.split('-').join('') > lastCOA.split('-').join('')) {
           lastCOA = filingDate
         }

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -182,7 +182,7 @@ import { PAYMENT_REQUIRED, BAD_REQUEST } from 'http-status-codes'
 import { EntityFilterMixin, ResourceLookupMixin } from '@/mixins'
 
 // Enums
-import { EntityTypes, FilingCodes } from '@/enums'
+import { EntityTypes, FilingCodes, FilingTypes } from '@/enums'
 
 export default {
   name: 'StandaloneOfficeAddressFiling',
@@ -229,7 +229,8 @@ export default {
 
       // enums
       EntityTypes,
-      FilingCodes
+      FilingCodes,
+      FilingTypes
     }
   },
 
@@ -346,7 +347,7 @@ export default {
             if (!filing) throw new Error('missing filing')
             if (!filing.header) throw new Error('missing header')
             if (!filing.business) throw new Error('missing business')
-            if (filing.header.name !== 'changeOfAddress') throw new Error('invalid filing type')
+            if (filing.header.name !== FilingTypes.CHANGE_OF_ADDRESS) throw new Error('invalid filing type')
             if (filing.business.identifier !== this.entityIncNo) throw new Error('invalid business identifier')
             if (filing.business.legalName !== this.entityName) throw new Error('invalid business legal name')
 
@@ -387,7 +388,7 @@ export default {
             }
           } catch (err) {
             // eslint-disable-next-line no-console
-            console.log(`fetchData() error - ${err.message}, filing =`, filing)
+            console.log(`fetchData() error - ${err.message}, filing = ${filing}`)
             this.resumeErrorDialog = true
             throw new Error('invalid change of address')
           }
@@ -423,7 +424,7 @@ export default {
 
       if (filing) {
         // save Filing ID for future PUTs
-        this.filingId = +filing.header.filingId
+        this.filingId = +filing.header.filingId // number
       }
       this.saving = false
     },
@@ -450,7 +451,7 @@ export default {
 
       // on success, redirect to Pay URL
       if (filing && filing.header) {
-        const filingId = +filing.header.filingId
+        const filingId: number = +filing.header.filingId
 
         // whether this is a staff or no-fee filing
         const prePaidFiling = (this.isRoleStaff || !this.isPayRequired)
@@ -490,7 +491,7 @@ export default {
 
       const header = {
         header: {
-          name: 'changeOfAddress',
+          name: FilingTypes.CHANGE_OF_ADDRESS,
           certifiedBy: this.certifiedBy || '',
           email: 'no_one@never.get',
           date: this.currentDate

--- a/tests/unit/AnnualReport.spec.ts
+++ b/tests/unit/AnnualReport.spec.ts
@@ -143,7 +143,6 @@ describe('AnnualReport - Part 1 - UI', () => {
 
     // confirm that flags are set correctly
     expect(vm.validated).toEqual(false)
-    expect(vm.isSaveButtonEnabled).toEqual(false)
 
     wrapper.destroy()
   })
@@ -162,7 +161,6 @@ describe('AnnualReport - Part 1 - UI', () => {
 
     // confirm that flags are set correctly
     expect(vm.validated).toEqual(false)
-    expect(vm.isSaveButtonEnabled).toEqual(false)
 
     wrapper.destroy()
   })
@@ -295,7 +293,6 @@ describe('AnnualReport - Part 1 - UI', () => {
 
     // confirm that flags are set correctly
     expect(vm.validated).toEqual(false)
-    expect(vm.isSaveButtonEnabled).toEqual(false)
 
     wrapper.destroy()
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2654

*Description of changes:*
This is Part 3 of the the Correction Filing task, which includes:
- implemented loading draft correction
- renamed some route params to correctedFilingId
- blocked correcting a correction (for now)
- enabled Save for corrections
- changed Save buttons to always be enabled (in all filings, per Scott)
- changed some strings to Filing Types
- added some explicit types

Part 4 will implement:
- updates to unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).