### PR TITLE
correction filing (part 4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -190,12 +190,12 @@ import { AddCommentDialog, DownloadErrorDialog } from '@/components/dialogs'
 import { EntityTypes, FilingNames, FilingStatus, FilingTypes } from '@/enums'
 
 // Mixins
-import { CommonMixin, DateMixin, EntityFilterMixin } from '@/mixins'
+import { DateMixin, EntityFilterMixin, FilingMixin } from '@/mixins'
 
 export default {
   name: 'FilingHistoryList',
 
-  mixins: [CommonMixin, DateMixin, EntityFilterMixin],
+  mixins: [DateMixin, EntityFilterMixin, FilingMixin],
 
   components: {
     AddCommentDialog,

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -280,7 +280,7 @@ import { DetailsList } from '@/components/common'
 import { AddCommentDialog, ConfirmDialog, DeleteErrorDialog, CancelPaymentErrorDialog } from '@/components/dialogs'
 
 // Mixins
-import { CommonMixin, EntityFilterMixin, DateMixin } from '@/mixins'
+import { EntityFilterMixin, DateMixin, FilingMixin } from '@/mixins'
 
 // Enums
 import { EntityTypes, FilingStatus, FilingTypes } from '@/enums'
@@ -296,7 +296,7 @@ export default {
     DetailsList
   },
 
-  mixins: [CommonMixin, EntityFilterMixin, DateMixin, Vue2Filters.mixin],
+  mixins: [EntityFilterMixin, DateMixin, FilingMixin, Vue2Filters.mixin],
 
   data () {
     return {
@@ -701,7 +701,6 @@ export default {
     },
 
     showCommentDialog (filingId: number): void {
-      console.log(filingId)
       this.currentFilingId = filingId
       this.addCommentDialog = true
     },

--- a/src/interfaces/filingData-interfaces.ts
+++ b/src/interfaces/filingData-interfaces.ts
@@ -1,9 +1,9 @@
-import Vue from 'vue'
+import { FilingCodes, EntityTypes } from '@/enums'
 
-export interface FilingData extends Vue {
-  filingTypeCode: string
-  entityType: string
+export interface FilingData {
+  filingTypeCode: FilingCodes
+  entityType: EntityTypes
   waiveFees: boolean
   priority: boolean
-  futureEffective: boolean
+  futureEffective?: boolean
 }

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -1,6 +1,5 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { omit, isEqual } from 'lodash'
-import { FilingTypes, FilingNames } from '@/enums'
 
 /**
  * Mixin that provides some useful common utilities.
@@ -43,43 +42,5 @@ export default class CommonMixin extends Vue {
    */
   isSame (objA: {}, objB: {}, prop: string = null): boolean {
     return isEqual({ ...this.omitProp(objA, [prop]) }, { ...this.omitProp(objB, [prop]) })
-  }
-
-  /**
-   * Flattens and sorts an array of comments
-   *
-   * @param comments The array of comments to sort and deconstruct
-   * @return The sorted and flattened array of comments
-   */
-  flattenAndSortComments (comments: Array<any>): Array<any> {
-    if (comments && comments.length > 0) {
-      // first use map to change comment.comment to comment
-      const flattened: Array<any> = comments.map(c => c.comment)
-      // then sort newest to oldest
-      const sorted = flattened.sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1)
-      return sorted
-    }
-    return []
-  }
-
-  /**
-   * Format the incoming filing type string for better display.
-   *
-   * @param type The filing type string to be formatted
-   * @param agmYear OPTIONAL: The agmYear string to be appended to the formatted filing type string.
-   */
-  typeToTitle (type: string, agmYear: string = null): string {
-    if (!type) return '' // safety check
-    switch (type) {
-      case FilingTypes.ANNUAL_REPORT: return FilingNames.ANNUAL_REPORT + (agmYear ? ` (${agmYear})` : '')
-      case FilingTypes.CHANGE_OF_DIRECTORS: return FilingNames.DIRECTOR_CHANGE
-      case FilingTypes.CHANGE_OF_ADDRESS: return FilingNames.ADDRESS_CHANGE
-      case FilingTypes.CHANGE_OF_NAME: return FilingNames.LEGAL_NAME_CHANGE
-      case FilingTypes.SPECIAL_RESOLUTION: return FilingNames.SPECIAL_RESOLUTION
-      case FilingTypes.VOLUNTARY_DISSOLUTION: return FilingNames.VOLUNTARY_DISSOLUTION
-      case FilingTypes.CORRECTION: return FilingNames.CORRECTION
-    }
-    // fallback for unknown filings
-    return type.split(/(?=[A-Z])/).join(' ').replace(/^\w/, c => c.toUpperCase())
   }
 }

--- a/src/mixins/entityFilter-mixin.ts
+++ b/src/mixins/entityFilter-mixin.ts
@@ -1,5 +1,6 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { mapState } from 'vuex'
+import { EntityTypes } from '@/enums'
 
 /**
  * Mixin that provides an entity filter utility.
@@ -10,15 +11,15 @@ import { mapState } from 'vuex'
   }
 })
 export default class EntityFilterMixin extends Vue {
-  readonly entityType: string
+  readonly entityType!: EntityTypes
 
   /**
    * Compares the conditional entity to the entityType defined from the Store.
    *
-   * @param entity The entity type of the component.
-   * @return boolean A boolean indicating if the entityType given matches the entityType assigned to the component.
+   * @param entity the entity type of the component
+   * @return True if the entityType given matches the entityType assigned to the component, else False
    */
-  entityFilter (entityType: string): boolean {
+  entityFilter (entityType: EntityTypes): boolean {
     return this.entityType === entityType
   }
 }

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -1,0 +1,111 @@
+import { Component, Vue } from 'vue-property-decorator'
+import { mapActions, mapState } from 'vuex'
+import { FilingData } from '@/interfaces'
+import { EntityTypes, FilingCodes, FilingTypes, FilingNames } from '@/enums'
+
+/**
+ * Mixin that provides some useful filing utilities.
+ */
+@Component({
+  computed: {
+    ...mapState(['filingData', 'entityType'])
+  },
+  methods: {
+    ...mapActions(['setFilingData'])
+  }
+})
+export default class FilingMixin extends Vue {
+  // store actions
+  readonly setFilingData!: (x: any) => void
+
+  // store getters
+  readonly filingData!: Array<FilingData>
+  readonly entityType!: EntityTypes
+
+  /**
+   * Flattens and sorts an array of comments.
+   * @param comments the array of comments to sort and deconstruct
+   * @return the sorted and flattened array of comments
+   */
+  flattenAndSortComments (comments: Array<any>): Array<any> {
+    if (comments && comments.length > 0) {
+      // first use map to change comment.comment to comment
+      const flattened: Array<any> = comments.map(c => c.comment)
+      // then sort newest to oldest
+      const sorted = flattened.sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1)
+      return sorted
+    }
+    return []
+  }
+
+  /**
+   * Converts the filing type to a filing name.
+   * @param type the filing type converted
+   * @param agmYear the AGM Year to be appended to the filing name (optional)
+   */
+  typeToTitle (type: FilingTypes | string, agmYear: string = null): string {
+    if (!type) return '' // safety check
+    switch (type) {
+      case FilingTypes.ANNUAL_REPORT: return FilingNames.ANNUAL_REPORT + (agmYear ? ` (${agmYear})` : '')
+      case FilingTypes.CHANGE_OF_DIRECTORS: return FilingNames.DIRECTOR_CHANGE
+      case FilingTypes.CHANGE_OF_ADDRESS: return FilingNames.ADDRESS_CHANGE
+      case FilingTypes.CHANGE_OF_NAME: return FilingNames.LEGAL_NAME_CHANGE
+      case FilingTypes.SPECIAL_RESOLUTION: return FilingNames.SPECIAL_RESOLUTION
+      case FilingTypes.VOLUNTARY_DISSOLUTION: return FilingNames.VOLUNTARY_DISSOLUTION
+      case FilingTypes.CORRECTION: return FilingNames.CORRECTION
+    }
+    // fallback for unknown filings
+    return type.split(/(?=[A-Z])/).join(' ').replace(/^\w/, c => c.toUpperCase())
+  }
+
+  /**
+   * Adds/removes filing code and/or sets flags in the Filing Data object.
+   * @param action whether to add or remove the specified code/flags
+   * @param filingCode the Filing Type Code to add or remove (optional)
+   * @param priority the Priority flag to set or clear (sometimes optional - see examples)
+   * @param waiveFees the Waive Fees flag to set or clear (sometimes optional - see examples)
+   * @example updateFilingData('add', 'CRCTN', true, true) // adds Correction code with both flags set
+   * @example updateFilingData('add', 'CRCTN', false, false) // adds Correction code both flags unset
+   * @example updateFilingData('remove', 'CRCTN') // removes Correction code
+   * @example updateFilingData('add', undefined, undefined, true) // adds Waive Fees flag to all codes
+   * @example updateFilingData('remove', undefined, true, undefined) // removes Priority flag from all codes
+   */
+  updateFilingData (
+    action: 'add' | 'remove',
+    filingCode: FilingCodes | undefined,
+    priority: boolean | undefined,
+    waiveFees: boolean | undefined
+  ): void {
+    let myFilingData: Array<FilingData> = this.filingData
+    if (filingCode) {
+      // always remove code if it already exists
+      myFilingData = myFilingData.filter(el => el.filingTypeCode !== filingCode)
+
+      // conditionally (re)add the code
+      if (action === 'add') {
+        myFilingData.push({
+          filingTypeCode: filingCode,
+          entityType: this.entityType,
+          priority: priority,
+          waiveFees: waiveFees
+        })
+      }
+    } else {
+      // conditionally add/remove the flags to/from all codes
+      myFilingData.forEach(element => {
+        if (priority !== undefined) element.priority = (action === 'add')
+        if (waiveFees !== undefined) element.waiveFees = (action === 'add')
+      })
+    }
+    this.setFilingData(myFilingData)
+  }
+
+  /**
+   * Searches the Filing Data for a filing code.
+   * @param filingCode the Filing Type Code to search for
+   * @return True if the filing code exists, else False
+   */
+  hasFilingCode (filingCode: FilingCodes): boolean {
+    return !!this.filingData.find(o => o.filingTypeCode === filingCode)
+  }
+}

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -30,10 +30,10 @@ export default class FilingMixin extends Vue {
   flattenAndSortComments (comments: Array<any>): Array<any> {
     if (comments && comments.length > 0) {
       // first use map to change comment.comment to comment
-      const flattened: Array<any> = comments.map(c => c.comment)
+      const temp: Array<any> = comments.map(c => c.comment)
       // then sort newest to oldest
-      const sorted = flattened.sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1)
-      return sorted
+      temp.sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1)
+      return temp
     }
     return []
   }

--- a/src/mixins/index.ts
+++ b/src/mixins/index.ts
@@ -1,15 +1,17 @@
-import CommonMixin from '@/mixins/common-mixin'
-import CountriesProvincesMixin from '@/mixins/countries-provinces-mixin'
+import CommonMixin from './common-mixin'
+import CountriesProvincesMixin from './countries-provinces-mixin'
 import DateMixin from './date-mixin'
-import EntityFilterMixin from '@/mixins/entityFilter-mixin'
-import ResourceLookupMixin from '@/mixins/resource-lookup-mixin'
-import DirectorMixin from '@/mixins/director-mixin'
+import DirectorMixin from './director-mixin'
+import EntityFilterMixin from './entityFilter-mixin'
+import FilingMixin from './filing-mixin'
+import ResourceLookupMixin from './resource-lookup-mixin'
 
 export {
   CommonMixin,
   CountriesProvincesMixin,
   DateMixin,
+  DirectorMixin,
   EntityFilterMixin,
-  ResourceLookupMixin,
-  DirectorMixin
+  FilingMixin,
+  ResourceLookupMixin
 }

--- a/src/mixins/resource-lookup-mixin.ts
+++ b/src/mixins/resource-lookup-mixin.ts
@@ -12,7 +12,7 @@ import { FilingCodes } from '@/enums'
 })
 
 export default class ResourceLookupMixin extends Vue {
-    readonly configObject
+    readonly configObject!: any
 
     /**
      * Returns certify message using the configuration lookup object.

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,3 +1,6 @@
+import { EntityTypes, EntityStatus, FilingStatus } from '@/enums'
+import { FilingData } from '@/interfaces'
+
 export default {
   setKeycloakRoles ({ commit }, keycloakRoles: Array<string>) {
     commit('keycloakRoles', keycloakRoles)
@@ -23,10 +26,10 @@ export default {
   setEntityName ({ commit }, entityName: string) {
     commit('entityName', entityName)
   },
-  setEntityType ({ commit }, entityType: string) {
+  setEntityType ({ commit }, entityType: EntityTypes) {
     commit('entityType', entityType)
   },
-  setEntityStatus ({ commit }, entityStatus: string) {
+  setEntityStatus ({ commit }, entityStatus: EntityStatus) {
     commit('entityStatus', entityStatus)
   },
   setEntityIncNo ({ commit }, entityIncNo: string) {
@@ -47,7 +50,7 @@ export default {
   setLastPreLoadFilingDate ({ commit }, lastPreLoadFilingDate: string) {
     commit('lastPreLoadFilingDate', lastPreLoadFilingDate)
   },
-  setCurrentFilingStatus ({ commit }, currentFilingStatus: string) {
+  setCurrentFilingStatus ({ commit }, currentFilingStatus: FilingStatus) {
     commit('currentFilingStatus', currentFilingStatus)
   },
   setTasks ({ commit }, tasks: Array<object>) {
@@ -65,13 +68,16 @@ export default {
   setDirectors ({ commit }, directors: Array<object>) {
     commit('directors', directors)
   },
-  setTriggerDashboardReload ({ commit }, value: boolean) {
-    commit('triggerDashboardReload', value)
+  setTriggerDashboardReload ({ commit }, triggerDashboardReload: boolean) {
+    commit('triggerDashboardReload', triggerDashboardReload)
   },
-  setLastAnnualReportDate ({ commit }, value: string) {
-    commit('lastAnnualReportDate', value)
+  setLastAnnualReportDate ({ commit }, lastAnnualReportDate: string) {
+    commit('lastAnnualReportDate', lastAnnualReportDate)
   },
-  setConfigObject ({ commit }, value: object) {
-    commit('configObject', value)
+  setConfigObject ({ commit }, configObject: object) {
+    commit('configObject', configObject)
+  },
+  setFilingData ({ commit }, filingData: Array<FilingData>) {
+    commit('filingData', filingData)
   }
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,77 +1,83 @@
+import { EntityTypes, EntityStatus, FilingStatus } from '@/enums'
+import { FilingData } from '@/interfaces'
+
 export default {
-  keycloakRoles (state, keycloakRoles) {
+  keycloakRoles (state, keycloakRoles: Array<string>) {
     state.keycloakRoles = keycloakRoles
   },
-  authRoles (state, authRoles) {
+  authRoles (state, authRoles: Array<string>) {
     state.authRoles = authRoles
   },
-  currentDate (state, currentDate) {
+  currentDate (state, currentDate: string) {
     state.currentDate = currentDate
   },
-  lastAgmDate (state, lastAgmDate) {
+  lastAgmDate (state, lastAgmDate: string) {
     state.lastAgmDate = lastAgmDate
   },
-  nextARDate (state, nextARDate) {
+  nextARDate (state, nextARDate: string) {
     state.nextARDate = nextARDate
   },
-  ARFilingYear (state, ARFilingYear) {
+  ARFilingYear (state, ARFilingYear: number) {
     state.ARFilingYear = ARFilingYear
   },
-  entityBusinessNo (state, entityBusinessNo) {
+  entityBusinessNo (state, entityBusinessNo: string) {
     state.entityBusinessNo = entityBusinessNo
   },
-  entityName (state, entityName) {
+  entityName (state, entityName: string) {
     state.entityName = entityName
   },
-  entityType (state, entityType) {
+  entityType (state, entityType: EntityTypes) {
     state.entityType = entityType
   },
-  entityStatus (state, entityStatus) {
+  entityStatus (state, entityStatus: EntityStatus) {
     state.entityStatus = entityStatus
   },
-  entityIncNo (state, entityIncNo) {
+  entityIncNo (state, entityIncNo: string) {
     state.entityIncNo = entityIncNo
   },
-  entityFoundingDate (state, entityFoundingDate) {
+  entityFoundingDate (state, entityFoundingDate: string) {
     state.entityFoundingDate = entityFoundingDate
   },
-  businessEmail (state, businessEmail) {
+  businessEmail (state, businessEmail: string) {
     state.businessEmail = businessEmail
   },
-  businessPhone (state, businessPhone) {
+  businessPhone (state, businessPhone: string) {
     state.businessPhone = businessPhone
   },
-  businessPhoneExtension (state, businessPhoneExtension) {
+  businessPhoneExtension (state, businessPhoneExtension: string) {
     state.businessPhoneExtension = businessPhoneExtension
   },
-  lastPreLoadFilingDate (state, lastPreLoadFilingDate) {
+  lastPreLoadFilingDate (state, lastPreLoadFilingDate: string) {
     state.lastPreLoadFilingDate = lastPreLoadFilingDate
   },
-  currentFilingStatus (state, currentFilingStatus) {
+  currentFilingStatus (state, currentFilingStatus: FilingStatus) {
     state.currentFilingStatus = currentFilingStatus
   },
-  tasks (state, tasks) {
+  tasks (state, tasks: Array<object>) {
     state.tasks = tasks
   },
-  filings (state, filings) {
+  filings (state, filings: Array<object>) {
     state.filings = filings
   },
-  registeredAddress (state, registeredAddress) {
+  registeredAddress (state, registeredAddress: object) {
     state.registeredAddress = registeredAddress
   },
-  recordsAddress (state, recordsAddress) {
+  recordsAddress (state, recordsAddress: object) {
     state.recordsAddress = recordsAddress
   },
-  directors (state, directors) {
+  directors (state, directors: Array<object>) {
     state.directors = directors
   },
-  triggerDashboardReload (state, value) {
-    state.triggerDashboardReload = value
+  triggerDashboardReload (state, triggerDashboardReload: boolean) {
+    state.triggerDashboardReload = triggerDashboardReload
   },
-  lastAnnualReportDate (state, value) {
-    state.lastAnnualReportDate = value
+  lastAnnualReportDate (state, lastAnnualReportDate: string) {
+    state.lastAnnualReportDate = lastAnnualReportDate
   },
-  configObject (state, value) {
-    state.configObject = value
+  configObject (state, configObject: object) {
+    state.configObject = configObject
+  },
+  filingData (state, filingData: Array<FilingData>) {
+    state.filingData = filingData
   }
 }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,3 +1,6 @@
+import { EntityTypes, EntityStatus, FilingStatus } from '@/enums'
+import { FilingData } from '@/interfaces'
+
 export default {
   // tombstone data
   keycloakRoles: [] as Array<string>,
@@ -7,8 +10,8 @@ export default {
 
   // entity info
   entityName: null as string,
-  entityType: null as string,
-  entityStatus: null as string,
+  entityType: null as EntityTypes,
+  entityStatus: null as EntityStatus,
   entityBusinessNo: null as string,
   entityIncNo: null as string,
   lastPreLoadFilingDate: null as string,
@@ -29,6 +32,8 @@ export default {
 
   triggerDashboardReload: false as boolean,
 
-  currentFilingStatus: null as string,
-  configObject: null as object
+  currentFilingStatus: null as FilingStatus,
+  configObject: null as object,
+
+  filingData: [] as Array<FilingData>
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2654

*Description of changes:*
This is Part 4 of the Correction Filing task, which inclues:
- moved some methods to Filing Mixin
- moved Filing Data to global store
- init Filing Data on filing creation
- expanded use of types
- updated version number

Part 5 will implement:
- updates to Summary Staff Filing component
- updates to unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).