### PR TITLE
replaced obsolete Material Design Icon

### DIFF
--- a/src/components/EntityInfo.vue
+++ b/src/components/EntityInfo.vue
@@ -50,7 +50,7 @@
           <v-menu bottom left offset-y content-class="v-menu">
             <template v-slot:activator="{ on }">
               <v-btn id="entity-settings-button" small icon color="primary" v-on="on">
-                <v-icon small>mdi-settings</v-icon>
+                <v-icon small>mdi-cog</v-icon>
               </v-btn>
             </template>
             <v-list class="pt-0 pb-0">


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
This was likely broken by the recent "@mdi/font" package upgrade. (Other icons were also obsoleted but have been fixed.) So this is a simple change to use the new icon name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).