### PR TITLE
removed alert on startup error + redirect to "Cooperatives Online"

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -51,11 +51,10 @@ async function start () {
 // execution and error handling
 start().catch((error) => {
   console.error(error) // eslint-disable-line no-console
-  alert('There was an error starting this page. (See console for details.)\n' +
-    'Click OK to go to the BC Registry home page.')
-  // redirect to BC Registry home page
+  // no alert at this time
+  // just redirect to BC Registry home page
   // NB: this is a hard-coded URL because we are probably missing the config keys
-  const bcRegUrl = 'https://www.bcregistry.ca/' // TODO: update when new URLs are set up
+  const bcRegUrl = 'https://www.bcregistry.ca/cooperatives/auth/'
   // assume BC Registry URL is always reachable
   window.location.assign(bcRegUrl)
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2949

*Description of changes:*
- new UI expects Business ID in route, but users probably don't have new URL bookmarked yet
- we want to handle this as gracefully as possible
- the new behaviour looks like the previous behaviour

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).