### PR TITLE
Director Name Change Reset

### DIFF
--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -456,6 +456,14 @@
                     >
                       <span>Remove</span>
                     </v-btn>
+                    <v-btn color="error"
+                     class="reset-btn"
+                     v-show="!isNew(director) && editFormShowHide.showName"
+                     @click="restoreDirName(director.id, true)"
+                     :disabled="!isNameChanged(director)"
+                    >
+                      <span>Reset</span>
+                    </v-btn>
                     <v-btn color="primary"
                       class="form-primary-btn done-edit-btn"
                       @click="saveEditDirector(index, director.id)"
@@ -558,6 +566,7 @@ export default class Directors extends Mixins(DateMixin, CommonMixin, DirectorMi
   // Local properties.
   private directors = []
   private directorsOriginal = []
+  private directorPreEdit = null
   private showNewDirectorForm = false
   private draftDate = null
   private showPopup = false
@@ -1063,6 +1072,7 @@ export default class Directors extends Mixins(DateMixin, CommonMixin, DirectorMi
    * @param index The index of the director to edit.
    */
   private editDirectorName (index): void {
+    this.directorPreEdit = { ...this.directors[index].officer }
     this.editFormShowHide = {
       showAddress: false,
       showName: true,
@@ -1151,8 +1161,7 @@ export default class Directors extends Mixins(DateMixin, CommonMixin, DirectorMi
    * @param id Id of the director being edited.
    */
   private cancelEditDirector (id = null): void {
-    this.restoreDirName(id - 1)
-
+    if (id) this.restoreDirName(id, false)
     this.activeIndex = -1
     this.directorEditInProgress = false
 
@@ -1166,17 +1175,26 @@ export default class Directors extends Mixins(DateMixin, CommonMixin, DirectorMi
 
   /**
    * Restores the directors name after cancelling a name change.
-   * @param index Index value of the director currently being edited
+   * @param id Id value of the director currently being edited.
+   * @param isRestore Boolean indicating a hard or soft name reset.
    */
-  private restoreDirName (index: number): void {
-    if (index >= 0) {
-      const director = this.directors[index]
+  private restoreDirName (id: number, isRestore: boolean): void {
+    const index = this.directors.findIndex(director => director.id === id)
+    const director = this.directors[index]
+
+    if (isRestore && id >= 0) {
       this.removeAction(director, NAMECHANGED)
 
       if (director.officer.prevFirstName && director.officer.prevLastName) {
         director.officer.firstName = director.officer.prevFirstName
         director.officer.middleInitial = director.officer.prevMiddleInitial
         director.officer.lastName = director.officer.prevLastName
+      }
+      this.cancelEditDirector()
+    } else {
+      if (this.directorPreEdit && !this.isNew(director)) {
+        director.officer = { ...this.directorPreEdit }
+        this.directorPreEdit = null
       }
     }
   }

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -457,7 +457,7 @@
                       <span>Remove</span>
                     </v-btn>
                     <v-btn color="error"
-                     class="reset-btn"
+                     class="reset-edit-btn"
                      v-show="!isNew(director) && editFormShowHide.showName"
                      @click="restoreDirName(director.id, true)"
                      :disabled="!isNameChanged(director)"

--- a/tests/unit/Directors.spec.ts
+++ b/tests/unit/Directors.spec.ts
@@ -297,6 +297,82 @@ describe('Directors as a COOP', () => {
     expect(vm.editFormShowHide.showDates).toEqual(true)
   })
 
+  it('director reset button is disabled prior to any editing', async () => {
+    // Open the edit director
+    await vm.editDirectorName(0)
+
+    // Verify the reset is disabled prior to any director edit
+    const resetBtn = vm.$el.querySelectorAll('.reset-edit-btn')[0]
+    expect(resetBtn.disabled).toBe(true)
+  })
+
+  it('director reset button is enabled once a director name is edited', async () => {
+    // Open the edit director
+    await vm.editDirectorName(0)
+
+    // Verify the correct data in the text input field
+    expect(vm.$el.querySelectorAll('.edit-director__first-name input')[0].value).toBe('Peter')
+
+    // Change the text input
+    setValue(vm, '.edit-director__first-name input', 'Steve')
+
+    // Verify the name is updated
+    expect(vm.directors[0].officer.firstName).toBe('Steve')
+
+    // Verify the reset is disabled prior to any director edit
+    expect(vm.$el.querySelectorAll('.reset-edit-btn')[0].disabled).toBe(true)
+
+    // Click Done btn and update the directors name
+    await vm.$el.querySelectorAll('.done-edit-btn')[0].click()
+
+    // Re Open the edit director
+    await vm.editDirectorName(0)
+
+    expect(vm.$el.querySelectorAll('.edit-director__first-name input')[0].value).toBe('Steve')
+
+    // Verify the reset is now enabled post director name edit
+    expect(vm.$el.querySelectorAll('.reset-edit-btn')[0].disabled).toBe(false)
+  })
+
+  it('restores the directors name to its value original pre-editing when reset is clicked', async () => {
+    // Open the edit director
+    await vm.editDirectorName(0)
+
+    // Verify the correct data in the text input field
+    expect(vm.$el.querySelectorAll('.edit-director__first-name input')[0].value).toBe('Peter')
+
+    // Change the text input
+    setValue(vm, '.edit-director__first-name input', 'Steve')
+
+    // Verify the name is updated
+    expect(vm.directors[0].officer.firstName).toBe('Steve')
+
+    // Verify the reset is disabled prior to any director edit
+    expect(vm.$el.querySelectorAll('.reset-edit-btn')[0].disabled).toBe(true)
+
+    // Click Done btn and update the directors name
+    await vm.$el.querySelectorAll('.done-edit-btn')[0].click()
+
+    // Verify Updated Data in the directors list
+    expect(vm.directors[0].officer.firstName).toEqual('Steve')
+    expect(vm.directors[0].actions[0]).toEqual('nameChanged')
+
+    // Re Open the edit director
+    await vm.editDirectorName(0)
+
+    expect(vm.$el.querySelectorAll('.edit-director__first-name input')[0].value).toBe('Steve')
+
+    // Verify the reset is now enabled post director name edit
+    expect(vm.$el.querySelectorAll('.reset-edit-btn')[0].disabled).toBe(false)
+
+    // Click the reset btn
+    await vm.$el.querySelectorAll('.reset-edit-btn')[0].click()
+
+    // Verify reset Data in the directors list
+    expect(vm.directors[0].officer.firstName).toEqual('Peter')
+    expect(vm.directors[0].actions[0]).toBeUndefined()
+  })
+
   it('disables buttons/actions when instructed by parent component', done => {
     // clear enabled prop
     vm.componentEnabled = false


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1613

*Description of changes:*
* Implemented director name change reset btn.
* Fixed the cancel btn functionality.
* Updated unit testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
