### PR TITLE
Small Fix for Cancelling Address Changes

### DIFF
--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -1087,6 +1087,7 @@ export default class Directors extends Mixins(DateMixin, CommonMixin, DirectorMi
    * @param index The index of the director to edit.
    */
   private editDirectorAddress (index): void {
+    this.directorPreEdit = null
     this.editFormShowHide = {
       showAddress: true,
       showName: false,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#

*Description of changes:*
* Fixes a small bug where a directors name could be overwrote when cancelling an address change. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
