### PR TITLE
3620 - add clear keycloak session logic on token refresh initialization failure

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -158,7 +158,7 @@ export default {
     /** True if user is authenticated. */
     isAuthenticated (): boolean {
       // FUTURE: also check that token isn't expired!
-      return Boolean(sessionStorage.getItem('KEYCLOAK_TOKEN'))
+      return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
     },
 
     /** True if Jest is running the code. */
@@ -329,7 +329,7 @@ export default {
 
     /** Gets Keycloak JWT and parses it. */
     getJWT (): any {
-      const token = sessionStorage.getItem('KEYCLOAK_TOKEN')
+      const token = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
       if (token) {
         return this.parseToken(token)
       }

--- a/src/axios-auth.ts
+++ b/src/axios-auth.ts
@@ -1,10 +1,11 @@
 import axios from 'axios'
+import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 
 const instance = axios.create()
 
 instance.interceptors.request.use(
   config => {
-    config.headers.common['Authorization'] = `Bearer ${sessionStorage.getItem('KEYCLOAK_TOKEN')}`
+    config.headers.common['Authorization'] = `Bearer ${sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)}`
     return config
   },
   error => Promise.reject(error)

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueRouter, { Route } from 'vue-router'
 import routes from '@/routes'
 import { SIGNIN } from '@/constants'
+import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 
 /**
  * Configures and returns Vue Router.
@@ -37,7 +38,7 @@ export function getVueRouter () {
   /** Returns True if user is authenticated, else False. */
   function isAuthenticated (): boolean {
     // FUTURE: also check that token isn't expired!
-    return Boolean(sessionStorage.getItem('KEYCLOAK_TOKEN'))
+    return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
   }
 
   return router


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3620

*Description of changes:*
- added logic to catch error for token refresher failure and refresh the page ( an error is thrown if the refresh token has expired)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
