### PR TITLE
change paymentErrorCode to paymentStatusCode

### DIFF
--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -606,7 +606,7 @@ export default {
           ? date = filing.annualReport.annualReportDate
           : date = filing.annualReport.nextARDate
 
-        const bcolErr = filing.header.paymentErrorType || null
+        const bcolErr = filing.header.paymentStatusCode || null
         const bcolObj = bcolErr && await this.getErrorObj(bcolErr)
 
         if (date) {
@@ -636,7 +636,7 @@ export default {
     async loadChangeOfDirectors (task) {
       const filing = task.task.filing
       if (filing && filing.header && filing.changeOfDirectors) {
-        const bcolErr = filing.header.paymentErrorType || null
+        const bcolErr = filing.header.paymentStatusCode || null
         const bcolObj = bcolErr && await this.getErrorObj(bcolErr)
 
         this.taskItems.push({
@@ -659,7 +659,7 @@ export default {
     async loadChangeOfAddress (task) {
       const filing = task.task.filing
       if (filing && filing.header && filing.changeOfAddress) {
-        const bcolErr = filing.header.paymentErrorType || null
+        const bcolErr = filing.header.paymentStatusCode || null
         const bcolObj = bcolErr && await this.getErrorObj(bcolErr)
 
         this.taskItems.push({
@@ -706,7 +706,7 @@ export default {
     async loadIncorporationApplication (task) {
       const filing = task.task.filing
       if (filing && filing.header && filing.incorporationApplication) {
-        const bcolErr = filing.header.paymentErrorType || null
+        const bcolErr = filing.header.paymentStatusCode || null
         const bcolObj = bcolErr && await this.getErrorObj(bcolErr)
 
         this.taskItems.push({

--- a/src/components/dialogs/BcolErrorDialog.vue
+++ b/src/components/dialogs/BcolErrorDialog.vue
@@ -7,7 +7,7 @@
         <p class="genErr" id="dialog-header">
           This {{filingTypeToName(filingType)}} could not be filed for the following reason:
         </p>
-        <p class="genErr" id="dialog-content">{{bcolObject.detail}}</p>
+        <p class="genErr" id="dialog-content" v-html="bcolObject.detail"></p>
 
         <template v-if="!isRoleStaff">
           <p class="genErr">

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -718,7 +718,8 @@ export default {
         const filingId: number = +filing.header.filingId
 
         // whether this is a staff or no-fee filing
-        const prePaidFiling = (this.isRoleStaff || !this.isPayRequired)
+        const paymentCompleted = filing.header?.paymentStatusCode === 'COMPLETED'
+        const prePaidFiling = (this.isRoleStaff || !this.isPayRequired || paymentCompleted)
 
         // if filing needs to be paid, redirect to Pay URL
         if (!prePaidFiling) {

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -539,7 +539,8 @@ export default {
         const filingId: number = +filing.header.filingId
 
         // whether this is a staff or no-fee filing
-        const prePaidFiling = (this.isRoleStaff || !this.isPayRequired)
+        const paymentCompleted = filing.header?.paymentStatusCode === 'COMPLETED'
+        const prePaidFiling = (this.isRoleStaff || !this.isPayRequired || paymentCompleted)
 
         // if filing needs to be paid, redirect to Pay URL
         if (!prePaidFiling) {

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -487,7 +487,8 @@ export default {
         const filingId: number = +filing.header.filingId
 
         // whether this is a staff or no-fee filing
-        const prePaidFiling = (this.isRoleStaff || !this.isPayRequired)
+        const paymentCompleted = filing.header?.paymentStatusCode === 'COMPLETED'
+        const prePaidFiling = (this.isRoleStaff || !this.isPayRequired || paymentCompleted)
 
         // if filing needs to be paid, redirect to Pay URL
         if (!prePaidFiling) {

--- a/tests/unit/AnnualReport.spec.ts
+++ b/tests/unit/AnnualReport.spec.ts
@@ -2104,7 +2104,6 @@ describe('AnnualReport - Part 7 - Concurrent Saves', () => {
   })
 })
 
-
 describe('AnnualReport - BCOL error dialog on save', () => {
   let wrapper: Wrapper<Vue>
   let vm: any
@@ -2159,7 +2158,7 @@ describe('AnnualReport - BCOL error dialog on save', () => {
       .stub(axios, 'post')
       .withArgs('businesses/CP0001191/filings')
       .returns(p1)
-    
+
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -2202,7 +2201,7 @@ describe('AnnualReport - BCOL error dialog on save', () => {
     const get = sinon.stub(axios, 'get')
 
     get.withArgs('businesses/CP0001191/tasks')
-    .returns(new Promise(resolve => resolve({ data: { tasks: [] } })))
+      .returns(new Promise(resolve => resolve({ data: { tasks: [] } })))
 
     // make sure form is validated
     vm.staffPaymentFormValid = true
@@ -2229,13 +2228,13 @@ describe('AnnualReport - BCOL error dialog on save', () => {
 
     const button = wrapper.find('#ar-file-pay-btn')
     expect(button.attributes('disabled')).toBeUndefined()
-    
+
     // Stub out a response from the Error endpoint in Pay API
     get.withArgs('codes/errors/BCOL_ERROR')
-    .returns(new Promise(resolve => resolve({ data: {
-      detail: 'An Error has occured',
-      title: 'Error'
-    }})))
+      .returns(new Promise(resolve => resolve({ data: {
+        detail: 'An Error has occured',
+        title: 'Error'
+      } })))
     // click the File & Pay button
     await button.trigger('click')
     await flushPromises()
@@ -2248,5 +2247,4 @@ describe('AnnualReport - BCOL error dialog on save', () => {
 
     wrapper.destroy()
   })
-
 })

--- a/tests/unit/BcolErrorDialog.spec.ts
+++ b/tests/unit/BcolErrorDialog.spec.ts
@@ -17,8 +17,8 @@ describe('BcolErrorDialog - Verify parameters passed in are displayed correctly'
         propsData: {
           filingType: FilingTypes.ANNUAL_REPORT,
           bcolObject: {
-              title: "Error",
-              detail: "A BCOL payment error has occured"
+            title: 'Error',
+            detail: 'A BCOL payment error has occured'
           }
         },
         store,
@@ -30,7 +30,7 @@ describe('BcolErrorDialog - Verify parameters passed in are displayed correctly'
     expect(wrapper.find('#dialog-content').text())
       .toContain('A BCOL payment error has occured')
     expect(wrapper.find('#dialog-header').text())
-    .toBe('This Annual Report could not be filed for the following reason:')
+      .toBe('This Annual Report could not be filed for the following reason:')
     expect(wrapper.find('#dialog-retry-button')).toBeDefined()
 
     wrapper.destroy()

--- a/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -1450,7 +1450,7 @@ describe('Change of Directors - BCOL error dialog on save', () => {
     const get = sinon.stub(axios, 'get')
 
     get.withArgs('businesses/CP0001191/tasks')
-    .returns(new Promise(resolve => resolve({ data: { tasks: [] } })))
+      .returns(new Promise(resolve => resolve({ data: { tasks: [] } })))
 
     const $route = { params: { filingId: 0 } } // new filing id
     wrapper = mount(StandaloneDirectorsFiling, {
@@ -1498,13 +1498,13 @@ describe('Change of Directors - BCOL error dialog on save', () => {
 
     const button = wrapper.find('#cod-file-pay-btn')
     expect(button.attributes('disabled')).toBeUndefined()
-    
+
     // Stub out a response from the Error endpoint in Pay API
     get.withArgs('codes/errors/BCOL_ERROR')
-    .returns(new Promise(resolve => resolve({ data: {
-      detail: 'An Error has occured',
-      title: 'Error'
-    }})))
+      .returns(new Promise(resolve => resolve({ data: {
+        detail: 'An Error has occured',
+        title: 'Error'
+      } })))
     // click the File & Pay button
     await button.trigger('click')
     await flushPromises()
@@ -1517,6 +1517,4 @@ describe('Change of Directors - BCOL error dialog on save', () => {
 
     wrapper.destroy()
   })
-
 })
-

--- a/tests/unit/StandaloneOfficeAddressFiling.spec.ts
+++ b/tests/unit/StandaloneOfficeAddressFiling.spec.ts
@@ -1803,7 +1803,7 @@ describe('Change of Directors - BCOL error dialog on save', () => {
     const get = sinon.stub(axios, 'get')
 
     get.withArgs('businesses/CP0001191/tasks')
-    .returns(new Promise(resolve => resolve({ data: { tasks: [] } })))
+      .returns(new Promise(resolve => resolve({ data: { tasks: [] } })))
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)
@@ -1852,13 +1852,13 @@ describe('Change of Directors - BCOL error dialog on save', () => {
 
     const button = wrapper.find('#coa-file-pay-btn')
     expect(button.attributes('disabled')).toBeUndefined()
-    
+
     // Stub out a response from the Error endpoint in Pay API
     get.withArgs('codes/errors/BCOL_ERROR')
-    .returns(new Promise(resolve => resolve({ data: {
-      detail: 'An Error has occured',
-      title: 'Error'
-    }})))
+      .returns(new Promise(resolve => resolve({ data: {
+        detail: 'An Error has occured',
+        title: 'Error'
+      } })))
     // click the File & Pay button
     await button.trigger('click')
     await flushPromises()
@@ -1871,7 +1871,4 @@ describe('Change of Directors - BCOL error dialog on save', () => {
 
     wrapper.destroy()
   })
-
 })
-
-

--- a/tests/unit/TodoList.spec.ts
+++ b/tests/unit/TodoList.spec.ts
@@ -1518,7 +1518,7 @@ describe('TodoList - Click Tests', () => {
   })
 
   it('Confirm BCOL error is captured in todo list', async () => {
-    sessionStorage.setItem('PAY_API_URL', '') 
+    sessionStorage.setItem('PAY_API_URL', '')
     // Store a task with a filing associated to a BCOL error
     store.state.tasks = [
       {
@@ -1529,7 +1529,7 @@ describe('TodoList - Click Tests', () => {
               'ARFilingYear': 2019,
               'status': 'DRAFT',
               'filingId': 123,
-              'paymentErrorType': 'BCOL_ERROR'
+              'paymentStatusCode': 'BCOL_ERROR'
             },
             'annualReport': {
               'annualGeneralMeetingDate': '2019-07-15',
@@ -1546,10 +1546,10 @@ describe('TodoList - Click Tests', () => {
 
     // Stub out a response from the Error endpoint in Pay API
     sinon.stub(axios, 'get').withArgs('codes/errors/BCOL_ERROR')
-    .returns(new Promise(resolve => resolve({ data: {
-      detail: 'An Error has occured',
-      title: 'Error'
-    }})))
+      .returns(new Promise(resolve => resolve({ data: {
+        detail: 'An Error has occured',
+        title: 'Error'
+      } })))
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
@@ -1574,7 +1574,6 @@ describe('TodoList - Click Tests', () => {
     const bcolPanel = vm.$el.querySelector('.bcol-todo-list-detail')
     expect(todoItem).toBeDefined()
     expect(bcolPanel.textContent).toContain('An Error has occured')
-    
   })
 })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3713

*Description of changes:*
Payments that have completed should not result in a redirect. This goes for free filing changes as well as BCONLINE. The payment status is now propogated to the front end and is stored with the filing for any other future wizardry that needs to occur. This is a fairly minor change

P.S - Hopefully no lint errors...I did run linting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
