### PR TITLE
3955 - handling temporary IA complete state

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -498,14 +498,15 @@ export default {
           ])
           break
 
+        case 'COMPLETED':
         case 'PAID':
           const incorporationApplication = filing.incorporationApplication
           if (!incorporationApplication) {
             throw new Error('Invalid incorporation application object')
           }
 
-          // this is a Paid Incorporation Application
-          this.setEntityStatus(EntityStatus.PAID_INCORP_APP)
+          // this is a paid or completed Incorporation Application
+          this.setEntityStatus(EntityStatus.FILED_INCORP_APP)
 
           // set temporary addresses and directors
           this.storeAddresses({ data: incorporationApplication.offices })

--- a/src/components/Dashboard/CompleteFiling.vue
+++ b/src/components/Dashboard/CompleteFiling.vue
@@ -22,22 +22,17 @@ import { Component, Vue } from 'vue-property-decorator'
 
 @Component({
   computed: {
-    ...mapState(['entityName', 'entityIncNo'])
+    ...mapState(['entityName'])
   }
 })
 export default class CompleteFiling extends Vue {
   readonly entityName!: string
-  readonly entityIncNo!: string
 
   /** Determine the name for the entity.
    * Use the entity name if it is available, otherwise build name for numbered company.
    */
   private get name (): string {
-    // Safety check
-    if (!this.entityName && !this.entityIncNo) {
-      return ''
-    }
-    return this.entityName || `${this.entityIncNo.replace('BC', '')} B.C. LTD.`
+    return this.entityName || 'A numbered benefit company'
   }
 
   private returnToDashboard (): void {

--- a/src/components/Dashboard/CompleteFiling.vue
+++ b/src/components/Dashboard/CompleteFiling.vue
@@ -1,12 +1,10 @@
 <template>
-  <div class="pending-filing body-2">
-    <h4>Filing Pending</h4>
+  <div class="complete-ia-filing body-2">
+    <h4>Incorporation Complete</h4>
 
-    <p>This {{title}} is paid, but the filing has not been completed by the BC
-      Registry yet. Some filings may take longer than expected.</p>
-    <p>If this issue persists, please contact us.</p>
+    <p>{{name}} has been successfully incorporated.</p>
+    <p>Return to your Manage Businesses dashboard to access your business and file changes.</p>
 
-    <ErrorContact />
     <div class="to-dashboard-container">
       <v-btn
         color="primary"
@@ -19,19 +17,25 @@
 </template>
 
 <script lang="ts">
+import { mapState } from 'vuex'
 import { Component, Vue, Prop } from 'vue-property-decorator'
 import { ErrorContact } from '@/components/common'
 
 @Component({
-  components: { ErrorContact }
+  components: { ErrorContact },
+  computed: {
+    ...mapState(['entityName', 'entityIncNo'])
+  }
 })
-export default class PendingFiling extends Vue {
-  /** The subject filing. */
-  @Prop() private filing: any
+export default class CompleteFiling extends Vue {
+  readonly entityName!: string
+  readonly entityIncNo!: string
 
-  /** The tite of the subject filing. */
-  private get title (): string {
-    return this.filing?.title || 'filing'
+  /** Determine the name for the entity.
+   * Use the entity name if it is available, otherwise build name for numbered company.
+   */
+  private get name (): string {
+    return this.entityName || `${this.entityIncNo.replace('BC', '')} B.C. LTD.`
   }
 
   private returnToDashboard (): void {
@@ -62,7 +66,4 @@ p {
   margin-bottom: 0.5rem !important;
 }
 
-.error-contact {
-  padding-top: 0.75rem;
-}
 </style>

--- a/src/components/Dashboard/CompleteFiling.vue
+++ b/src/components/Dashboard/CompleteFiling.vue
@@ -9,7 +9,7 @@
       <v-btn
         color="primary"
         @click.native.stop="returnToDashboard()"
-        >
+      >
         <span>Return to Dashboard</span>
       </v-btn>
     </div>

--- a/src/components/Dashboard/CompleteFiling.vue
+++ b/src/components/Dashboard/CompleteFiling.vue
@@ -18,11 +18,9 @@
 
 <script lang="ts">
 import { mapState } from 'vuex'
-import { Component, Vue, Prop } from 'vue-property-decorator'
-import { ErrorContact } from '@/components/common'
+import { Component, Vue } from 'vue-property-decorator'
 
 @Component({
-  components: { ErrorContact },
   computed: {
     ...mapState(['entityName', 'entityIncNo'])
   }
@@ -35,11 +33,15 @@ export default class CompleteFiling extends Vue {
    * Use the entity name if it is available, otherwise build name for numbered company.
    */
   private get name (): string {
+    // Safety check
+    if (!this.entityName && !this.entityIncNo) {
+      return ''
+    }
     return this.entityName || `${this.entityIncNo.replace('BC', '')} B.C. LTD.`
   }
 
   private returnToDashboard (): void {
-    const businessesUrl = sessionStorage.getItem('BUSINESSES_URL')
+    const businessesUrl = sessionStorage.getItem('BUSINESSES_URL') + 'business'
     window.location.assign(businessesUrl)
   }
 }

--- a/src/components/Dashboard/PendingFiling.vue
+++ b/src/components/Dashboard/PendingFiling.vue
@@ -35,7 +35,7 @@ export default class PendingFiling extends Vue {
   }
 
   private returnToDashboard (): void {
-    const businessesUrl = sessionStorage.getItem('BUSINESSES_URL')
+    const businessesUrl = sessionStorage.getItem('BUSINESSES_URL') + 'business'
     window.location.assign(businessesUrl)
   }
 }

--- a/src/components/EntityInfo.vue
+++ b/src/components/EntityInfo.vue
@@ -143,7 +143,7 @@ export default class EntityInfo extends Mixins(EnumMixin) {
       case EntityStatus.NAME_REQUEST:
         return `${this.entityTypeToName(this.entityType)} Name Request`
       case EntityStatus.DRAFT_INCORP_APP:
-      case EntityStatus.PAID_INCORP_APP:
+      case EntityStatus.FILED_INCORP_APP:
         return `${this.entityTypeToName(this.entityType)} Incorporation Application`
     }
     return '' // should never happen

--- a/src/enums/entityStatus.ts
+++ b/src/enums/entityStatus.ts
@@ -5,5 +5,5 @@ export enum EntityStatus {
   // overloaded values (used only before business exists):
   NAME_REQUEST = 'NAME_REQUEST',
   DRAFT_INCORP_APP = 'DRAFT_INCORP_APP',
-  PAID_INCORP_APP = 'PAID_INCORP_APP',
+  FILED_INCORP_APP = 'FILED_INCORP_APP',
 }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -41,7 +41,6 @@
                 :disableChanges="disableChanges"
                 @filed-count="filedCount = $event"
                 @filings-list="historyFilings = $event"
-                @has-blocker-filing="hasBlockerFiling = $event"
               />
             </section>
           </v-col>
@@ -149,7 +148,6 @@ export default {
     return {
       todoCount: 0,
       hasBlockerTask: false,
-      hasBlockerFiling: false,
       hasPendingFiling: false,
       filedCount: 0,
       historyFilings: [],
@@ -171,14 +169,24 @@ export default {
       return (this.entityStatus === EntityStatus.DRAFT_INCORP_APP)
     },
 
-    /** Whether this is a Paid Incorporation Application. */
+    /** Whether this is a Paid or Completed Incorporation Application. */
     isIncorpAppFiling (): boolean {
-      return (this.entityStatus === EntityStatus.PAID_INCORP_APP)
+      return (this.entityStatus === EntityStatus.FILED_INCORP_APP)
     },
 
-    /** Whether to block a new filing because another item has to be finished first. */
+    /** Whether to block a new filing because another item has to be finished first.
+     * No changes are allowed if
+     * 1) this is a temporary reg number until it switches to a real business number
+     * 2) has a pending filing (is PAID) and waiting for completion
+     * 3) has a blocker task in the todo list (ie. draft, paid, error, correction )
+     */
     disableChanges (): boolean {
-      return (this.hasBlockerTask || this.hasBlockerFiling || this.hasPendingFiling)
+      return (this.hasBlockerTask || this.hasPendingFiling || this.hasTempRegNumber)
+    },
+
+    /** The Incorporation Application's Temporary Registration Number string. */
+    hasTempRegNumber (): boolean {
+      return Boolean(sessionStorage.getItem('TEMP_REG_NUMBER'))
     }
   },
 

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -1434,7 +1434,7 @@ describe('App as a Paid Incorporation Application', () => {
   it('fetches IA filings properly', () => {
     expect(vm.$store.state.entityIncNo).toBe('T123456789')
     expect(vm.$store.state.entityType).toBe('BC')
-    expect(vm.$store.state.entityStatus).toBe('PAID_INCORP_APP')
+    expect(vm.$store.state.entityStatus).toBe('FILED_INCORP_APP')
 
     // spot check addresses and directors
     expect(vm.$store.state.registeredAddress.mailingAddress.streetAddress).toBe('1012 Douglas St')

--- a/tests/unit/CompleteFiling.spec.ts
+++ b/tests/unit/CompleteFiling.spec.ts
@@ -1,0 +1,44 @@
+import Vue from 'vue'
+import { getVuexStore } from '@/store'
+import Vuetify from 'vuetify'
+import { shallowMount } from '@vue/test-utils'
+import CompleteFiling from '@/components/Dashboard/CompleteFiling.vue'
+
+Vue.use(Vuetify)
+const store = getVuexStore()
+const vuetify = new Vuetify({})
+
+describe('Complete Filing', () => {
+  it('Displays expected content with entityName', () => {
+    store.state.entityName = 'My Business'
+    const wrapper = shallowMount(CompleteFiling, { store, vuetify })
+
+    // verify content
+    expect(wrapper.find('h4').text()).toBe('Incorporation Complete')
+    const paragraphs = wrapper.findAll('p')
+    expect(paragraphs.length).toBe(2)
+    expect(paragraphs.at(0).text()).toContain('My Business has been successfully incorporated.')
+    expect(paragraphs.at(1).text())
+      .toContain('Return to your Manage Businesses dashboard to access your business and file changes.')
+    expect(wrapper.find('.to-dashboard-container').exists()).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('Displays expected content with entityIncNo', () => {
+    store.state.entityName = null
+    store.state.entityIncNo = 'BC1234567'
+    const wrapper = shallowMount(CompleteFiling, { store, vuetify })
+
+    // verify content
+    expect(wrapper.find('h4').text()).toBe('Incorporation Complete')
+    const paragraphs = wrapper.findAll('p')
+    expect(paragraphs.length).toBe(2)
+    expect(paragraphs.at(0).text()).toContain('1234567 B.C. LTD. has been successfully incorporated.')
+    expect(paragraphs.at(1).text())
+      .toContain('Return to your Manage Businesses dashboard to access your business and file changes.')
+    expect(wrapper.find('.to-dashboard-container').exists()).toBe(true)
+
+    wrapper.destroy()
+  })
+})

--- a/tests/unit/CompleteFiling.spec.ts
+++ b/tests/unit/CompleteFiling.spec.ts
@@ -34,7 +34,7 @@ describe('Complete Filing', () => {
     expect(wrapper.find('h4').text()).toBe('Incorporation Complete')
     const paragraphs = wrapper.findAll('p')
     expect(paragraphs.length).toBe(2)
-    expect(paragraphs.at(0).text()).toContain('1234567 B.C. LTD. has been successfully incorporated.')
+    expect(paragraphs.at(0).text()).toContain('A numbered benefit company has been successfully incorporated.')
     expect(paragraphs.at(1).text())
       .toContain('Return to your Manage Businesses dashboard to access your business and file changes.')
     expect(wrapper.find('.to-dashboard-container').exists()).toBe(true)

--- a/tests/unit/Dashboard.spec.ts
+++ b/tests/unit/Dashboard.spec.ts
@@ -76,13 +76,16 @@ describe('Dashboard - UI', () => {
     expect(wrapper.find('#standalone-directors-button').attributes('disabled')).toBe('true')
   })
 
-  it('disables standalone filing buttons when there is a blocker filing in the filing history list', () => {
-    wrapper.find(FilingHistoryList).vm.$emit('has-blocker-filing', true)
+  it('disables standalone filing buttons when there is temporary reg number', () => {
+    sessionStorage.setItem('TEMP_REG_NUMBER', 'T1234567')
 
-    expect(vm.hasBlockerFiling).toEqual(true)
-    expect(vm.disableChanges).toEqual(true)
-    expect(wrapper.find('#standalone-addresses-button').attributes('disabled')).toBe('true')
-    expect(wrapper.find('#standalone-directors-button').attributes('disabled')).toBe('true')
+    const localWrapper: Wrapper<Vue> = shallowMount(Dashboard, { store, vuetify })
+    const localVm: any = localWrapper.vm
+
+    expect(localVm.disableChanges).toEqual(true)
+    expect(localWrapper.find('#standalone-addresses-button').attributes('disabled')).toBe('true')
+    expect(localWrapper.find('#standalone-directors-button').attributes('disabled')).toBe('true')
+    sessionStorage.clear()
   })
 
   it('disables filing buttons when there is a future effective filing pending', () => {

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -90,7 +90,7 @@ describe('EntityInfo', () => {
     sessionStorage.setItem('TEMP_REG_NUMBER', 'T123456789')
 
     store.state.entityName = 'My Future Company'
-    store.state.entityStatus = 'PAID_INCORP_APP'
+    store.state.entityStatus = 'FILED_INCORP_APP'
     store.state.entityType = 'BC'
     store.state.nameRequest = { nrNumber: 'NR 1234567' }
 

--- a/tests/unit/PendingFiling.spec.ts
+++ b/tests/unit/PendingFiling.spec.ts
@@ -18,6 +18,7 @@ describe('Pending Filing', () => {
     expect(paragraphs.at(0).text()).toContain('This filing is paid')
     expect(paragraphs.at(1).text()).toContain('If this issue persists')
     expect(wrapper.find(ErrorContact).exists()).toBe(true)
+    expect(wrapper.find('.to-dashboard-container').exists()).toBe(true)
 
     wrapper.destroy()
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3955

*Description of changes:*
- update initialization check to allow COMPLETED state
- changed EntityStatus.PAID_INCORP_APP to EntityStatus.FILED_INCORP_APP
- added component for complete filing (used only for completed IA with temp reg num)
- removed has-blocker-filing event from FilingHistoryList as an IA filing will show up when complete and using the real business identifier which will disable changes(we don't want this). This check has been changed to always disable changes if it we are using a temp reg num (check is in dashboard component) and any pending states in the history filings are already checked in the dashboard component as well.
- removed hasBlockerFiling code from Dashboard component
- update pending filing with return to dashboard button
- Complete Filing unit tests
- update dashboard unit test (temp reg num should disable changes)
- update pending filing test to check for return to dashboard button
- update entity info unit test to use updated entity status (FILED_INCORP_APP)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
