### PR TITLE
Using Feature flags to control the availability of maintenance filing for BComp

### DIFF
--- a/src/common/FeatureFlags.ts
+++ b/src/common/FeatureFlags.ts
@@ -1,7 +1,7 @@
 import { initialize, LDFlagSet } from 'launchdarkly-js-client-sdk'
 
 /** bcrs-create-ui-enabled = whether user is allowed to go to Create UI */
-const defaultFlagSet = { 'bcrs-create-ui-enabled': true }
+const defaultFlagSet = { 'bcrs-create-ui-enabled': true, 'bcomp-allow-maintenance-filing': true }
 
 class FeatureFlags {
     private static instance: FeatureFlags

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -31,8 +31,18 @@
       @okay="resetCancelPaymentErrors"
       attach="#todo-list"
     />
-
-    <v-expansion-panels v-if="taskItems && taskItems.length > 0" accordion  v-model="panel">
+    <v-card class="no-results" v-if="isBComp && !allowBCompMaintenanceFiling" flat>
+      <v-card-text>
+        <div class="no-results__title">
+          Coming Soon - Online Maintenance Filings such as Address and Director Changes
+        </div>
+        <div class="no-results__subtitle">If you need to make changes to your Benefit Company, contact us  </div>
+        <div class="error-contact-container">
+          <ErrorContact/>
+        </div>
+      </v-card-text>
+    </v-card>
+    <v-expansion-panels v-else-if="taskItems && taskItems.length > 0" accordion  v-model="panel">
       <v-expansion-panel
         class="align-items-top todo-item"
         v-for="(task, index) in orderBy(taskItems, 'order')"
@@ -400,7 +410,7 @@
     </v-expansion-panels>
 
     <!-- No Results Message -->
-    <v-card class="no-results" flat v-if="taskItems && !taskItems.length">
+    <v-card class="no-results" flat v-else>
       <v-card-text>
         <div class="no-results__title">You don't have anything to do yet</div>
         <div class="no-results__subtitle">Filings that require your attention will appear here</div>
@@ -415,7 +425,7 @@ import { mapState, mapActions, mapGetters } from 'vuex'
 import Vue2Filters from 'vue2-filters' // needed for orderBy
 
 // Components
-import { DetailsList, NameRequestInfo } from '@/components/common'
+import { DetailsList, ErrorContact, NameRequestInfo } from '@/components/common'
 
 // Dialogs
 import { AddCommentDialog, ConfirmDialog, DeleteErrorDialog, CancelPaymentErrorDialog } from '@/components/dialogs'
@@ -427,6 +437,8 @@ import { BcolMixin, DateMixin, EnumMixin, FilingMixin } from '@/mixins'
 import { EntityTypes, FilingStatus, FilingTypes } from '@/enums'
 import { ANNUAL_REPORT, CORRECTION, STANDALONE_ADDRESSES, STANDALONE_DIRECTORS } from '@/constants'
 
+import { featureFlags } from '@/common/FeatureFlags'
+
 export default {
   name: 'TodoList',
 
@@ -436,6 +448,7 @@ export default {
     ConfirmDialog,
     DeleteErrorDialog,
     DetailsList,
+    ErrorContact,
     NameRequestInfo
   },
 
@@ -480,6 +493,10 @@ export default {
     /** The Incorporation Application's Temporary Registration Number string. */
     tempRegNumber (): string {
       return sessionStorage.getItem('TEMP_REG_NUMBER')
+    },
+
+    allowBCompMaintenanceFiling (): boolean {
+      return featureFlags.getFlag('bcomp-allow-maintenance-filing')
     }
   },
 
@@ -1178,5 +1195,11 @@ export default {
 
 .bcol-todo-list-detail {
   background-color: #f1f1f1 !important;
+}
+
+.error-contact-container {
+  width: 50%;
+  margin-top: 0.5rem;
+  display: inline-block;
 }
 </style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -65,12 +65,23 @@
                       12:01 AM (Pacific Time). No other filings are allowed until then.</span>
                   </v-tooltip>
                 </v-scale-transition>
+                <v-tooltip top v-if="isBComp && !allowBCompMaintenanceFiling"
+                  color="primary">
+                  <template v-slot:activator="{ on }">
+                    <span  v-on="on" >
+                      <v-btn text small disabled>
+                      <v-icon small>mdi-pencil</v-icon>
+                      <span>Change</span>
+                    </v-btn>
+                    </span>
+                  </template>
+                  <span>Online Address Change is coming soon.</span>
+                </v-tooltip>
                 <v-btn text small color="primary"
                   id="standalone-addresses-button"
                   class="change-btn"
                   :disabled="disableChanges"
-                  @click.native.stop="proceedCoa()"
-                >
+                  @click.native.stop="proceedCoa()" v-else>
                   <v-icon small>mdi-pencil</v-icon>
                   <span>Change</span>
                 </v-btn>
@@ -87,12 +98,23 @@
             <section>
               <header class="aside-header mb-3">
                 <h2 data-test-id="dashboard-directors-subtitle">Current Directors</h2>
+                <v-tooltip top v-if="isBComp && !allowBCompMaintenanceFiling"
+                   color="primary">
+                  <template v-slot:activator="{ on }">
+                    <span  v-on="on" >
+                      <v-btn text small disabled>
+                      <v-icon small>mdi-pencil</v-icon>
+                      <span>Change</span>
+                    </v-btn>
+                    </span>
+                  </template>
+                  <span>Online Director Change is coming soon.</span>
+                </v-tooltip>
                 <v-btn text small color="primary"
                   id="standalone-directors-button"
                   class="change-btn"
                   :disabled="disableChanges"
-                  @click.native.stop="goToStandaloneDirectors()"
-                >
+                  @click.native.stop="goToStandaloneDirectors()" v-else>
                   <v-icon small>mdi-pencil</v-icon>
                   <span>Change</span>
                 </v-btn>
@@ -129,6 +151,7 @@ import { CoaWarningDialog } from '@/components/dialogs'
 // Enums and Constants
 import { EntityStatus, FilingStatus } from '@/enums'
 import { STANDALONE_ADDRESSES, STANDALONE_DIRECTORS } from '@/constants'
+import { featureFlags } from '@/common/FeatureFlags'
 
 export default {
   name: 'Dashboard',
@@ -187,6 +210,10 @@ export default {
     /** The Incorporation Application's Temporary Registration Number string. */
     hasTempRegNumber (): boolean {
       return Boolean(sessionStorage.getItem('TEMP_REG_NUMBER'))
+    },
+
+    allowBCompMaintenanceFiling (): boolean {
+      return featureFlags.getFlag('bcomp-allow-maintenance-filing')
     }
   },
 


### PR DESCRIPTION
… for bcomp

*Issue #:* /bcgov/entity#4124

*Description of changes:*
Added a new feature flag that determines the availability of maintenance filing for BComp
Changes in dashboard and Todo list to show different content based on feature flag

Note : If you want to test this locally you can use the ld client id from the dev config map in the local configuration or change the default value of the flag to false in the FeatureFlag.ts file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
