### PR TITLE
Filings UI Bug Fix - Watcher to handle Emit

### DIFF
--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -519,18 +519,6 @@ export default {
           console.log('ERROR - got unknown task =', task)
         }
       })
-
-      this.$emit('task-count', this.taskItems.length)
-      this.$emit('task-items', this.taskItems)
-
-      // If there are any draft/pending/error/paid/correction tasks, emit this event to the parent component.
-      // This indicates that a new filing cannot be started because this item has to be completed first.
-      this.$emit('has-blocker-task',
-        this.taskItems.filter(item => {
-          return (this.isStatusDraft(item) || this.isStatusPending(item) || this.isStatusError(item) ||
-            this.isStatusPaid(item) || this.isTypeCorrection(item))
-        }).length > 0
-      )
     },
 
     loadTodoItem (task) {
@@ -1043,6 +1031,20 @@ export default {
       // if tasks changes, reload them
       // (does not fire on initial page load)
       this.loadData()
+    },
+    taskItems () {
+      // Update dashboard when the tasks items change
+      this.$emit('task-count', this.taskItems.length)
+      this.$emit('task-items', this.taskItems)
+
+      // If there are any draft/pending/error/paid/correction tasks, emit this event to the parent component.
+      // This indicates that a new filing cannot be started because this item has to be completed first.
+      this.$emit('has-blocker-task',
+        this.taskItems.filter(item => {
+          return (this.isStatusDraft(item) || this.isStatusPending(item) || this.isStatusError(item) ||
+            this.isStatusPaid(item) || this.isTypeCorrection(item))
+        }).length > 0
+      )
     }
   }
 }

--- a/tests/unit/TodoList.spec.ts
+++ b/tests/unit/TodoList.spec.ts
@@ -115,7 +115,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(3)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(3)
@@ -911,7 +911,7 @@ describe('TodoList - UI - BCOMP', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(3)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(3)

--- a/tests/unit/TodoList.spec.ts
+++ b/tests/unit/TodoList.spec.ts
@@ -212,7 +212,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -253,7 +253,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -294,7 +294,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -347,7 +347,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -637,7 +637,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -685,7 +685,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -727,7 +727,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -767,7 +767,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 123 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -809,7 +809,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 456 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1111,7 +1111,7 @@ describe('TodoList - UI - BCOMP', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1158,7 +1158,7 @@ describe('TodoList - UI - BCOMP', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1199,7 +1199,7 @@ describe('TodoList - UI - BCOMP', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1239,7 +1239,7 @@ describe('TodoList - UI - BCOMP', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 123 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1281,7 +1281,7 @@ describe('TodoList - UI - BCOMP', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 456 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1333,7 +1333,7 @@ describe('TodoList - UI - Incorp Apps', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1381,7 +1381,7 @@ describe('TodoList - UI - Incorp Apps', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1428,7 +1428,7 @@ describe('TodoList - UI - Incorp Apps', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1477,7 +1477,7 @@ describe('TodoList - UI - Incorp Apps', () => {
 
     const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 0 } })
     const vm = wrapper.vm as any
-    await Vue.nextTick()
+    await flushPromises()
 
     expect(vm.taskItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4354

*Description of changes:*
* Bux fix where filings UI was updating the parent before the tasks/filings were loaded.
* Added a watcher on the taskItems and updates the parent (Dashboard) when changes occur in the taskItems array.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
