### PR TITLE
fixed padding in dashboard office addresses and current directors

### DIFF
--- a/src/components/Dashboard/AddressListSm.vue
+++ b/src/components/Dashboard/AddressListSm.vue
@@ -275,6 +275,10 @@ $icon-width: 2.75rem;
   padding: 0 1rem;
 }
 
+.v-list-item:first-of-type {
+  padding-bottom: 1rem;
+}
+
 .v-list-item__icon {
   margin-top: 0.7rem;
   margin-right: 0;
@@ -290,7 +294,7 @@ $icon-width: 2.75rem;
 }
 
 .v-list-item__content {
-  padding: 0 0 1rem 0;
+  padding: 0;
 }
 
 .address-icon {

--- a/src/components/Dashboard/DirectorListSm.vue
+++ b/src/components/Dashboard/DirectorListSm.vue
@@ -146,6 +146,10 @@ $avatar-width: 2.75rem;
   padding: 0;
 }
 
+.v-list-item:first-of-type {
+  padding-bottom: 1rem;
+}
+
 .v-list-item__title {
   font-size: 0.875rem;
   font-weight: 400;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4653

*Description of changes:*
- removed extra padding below office addresses mailing address
- added extra padding below current directors delivery address


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).