### PR TITLE
Removed Sentry.captureException from axios error and added on specific scenario's (main.start, dashboard unavailable dialog) #3933

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,6 +60,7 @@
 import { mapState, mapActions } from 'vuex'
 import axios from '@/axios-auth'
 import KeycloakService from 'sbc-common-components/src/services/keycloak.services'
+import * as Sentry from '@sentry/browser'
 
 // Components
 import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
@@ -67,8 +68,10 @@ import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
 import EntityInfo from '@/components/EntityInfo.vue'
 
 // Dialogs
-import { DashboardUnavailableDialog, BusinessAuthErrorDialog, NameRequestAuthErrorDialog,
-  NameRequestInvalidDialog } from '@/components/dialogs'
+import {
+  DashboardUnavailableDialog, BusinessAuthErrorDialog, NameRequestAuthErrorDialog,
+  NameRequestInvalidDialog
+} from '@/components/dialogs'
 
 // Mixins
 import { ObjectMixin, DirectorMixin, NameRequestMixin } from '@/mixins'
@@ -242,7 +245,7 @@ export default {
     },
 
     /** Clears Keycloak token information from session storage. */
-    clearKeycloakSession () : void {
+    clearKeycloakSession (): void {
       sessionStorage.removeItem(SessionStorageKeys.KeyCloakToken)
       sessionStorage.removeItem(SessionStorageKeys.KeyCloakRefreshToken)
       sessionStorage.removeItem(SessionStorageKeys.KeyCloakIdToken)
@@ -282,6 +285,7 @@ export default {
         } catch (err) {
           console.log(err) // eslint-disable-line no-console
           this.dashboardUnavailableDialog = true
+          Sentry.captureException(err)
         }
       }
 
@@ -455,7 +459,7 @@ export default {
         .then(response => Promise.resolve(response.data))
     },
 
-    storeIncorpApp (data: any) : void {
+    storeIncorpApp (data: any): void {
       const filing = data?.filing
 
       if (!filing?.business || !filing?.header) {

--- a/src/axios-auth.ts
+++ b/src/axios-auth.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
-import * as Sentry from '@sentry/browser'
 
 const instance = axios.create()
 
@@ -14,10 +13,7 @@ instance.interceptors.request.use(
 
 instance.interceptors.response.use(
   response => response,
-  error => {
-    Sentry.captureException(error)
-    return Promise.reject(error)
-  }
+  error => Promise.reject(error)
 )
 
 export default instance

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,7 @@ async function start () {
 
 // execution and error handling
 start().catch(error => {
+  Sentry.captureException(error)
   console.log(error) // eslint-disable-line no-console
   // bypass alert if this specific error
   if (!error?.message?.startsWith('Missing or invalid')) {


### PR DESCRIPTION
Removed Sentry.captureException from axios error and added on specific scenario's (main.start, dashboard unavailable dialog) #3933

*Issue #:* /bcgov/entity#3933

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
