### PR TITLE
Fix for annual report filings failing in prod

### DIFF
--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -827,7 +827,7 @@ export default {
           annualReport: {
             annualGeneralMeetingDate: this.agmDate || null, // API doesn't validate empty string
             didNotHoldAgm: this.noAgm || false,
-            annualReportDate: this.convertLocalDateToUTCDateTime(this.asOfDate),
+            annualReportDate: this.asOfDate,
             offices: {
               registeredOffice: {
                 deliveryAddress: this.addresses.registeredOffice['deliveryAddress'],
@@ -840,7 +840,7 @@ export default {
       } else if (this.isBComp) {
         annualReport = {
           annualReport: {
-            annualReportDate: this.convertLocalDateToUTCDateTime(this.asOfDate),
+            annualReportDate: this.asOfDate,
             nextARDate: this.dateToUsableString(new Date(this.nextARDate)),
             offices: {
               registeredOffice: {


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Because the annualReportDate is a date field ( not a datetime field), we should be passing what the user selected in the date component. The UTC issue matters only for datetime fields like effective_date

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
