### PR TITLE
Display Transition Filing in the filing history list

### DIFF
--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -840,11 +840,11 @@ export default {
         // If Effective Date is empty, use Filing Date instead.
         const effectiveDateTime = this.convertUTCTimeToLocalTime(header.effectiveDate) || filingDateTime
 
-        // is this a Future Effective Incorp NOA?
-        const isFutureEffectiveNoa = !!filing.header.isFutureEffective
+        // is this a Future Effective Transition Filing?
+        const isFutureEffectiveTransition = !!filing.header.isFutureEffective
 
-        // is this a Future Effective NOA pending completion?
-        const isFutureEffectiveNoaPending = isFutureEffectiveNoa && this.isEffectiveDatePast(filing)
+        // is this a Future Effective Transition pending completion?
+        const isFutureEffectiveTransitionPending = isFutureEffectiveTransition && this.isEffectiveDatePast(filing)
 
         // build filing item
         const item: HistoryItemIF = {

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -436,6 +436,9 @@ export default {
               case FilingTypes.NOTICE_OF_ALTERATION:
                 this.loadNoticeOfAlteration(filing)
                 break
+              case FilingTypes.TRANSITION_APPLICATION:
+                this.loadTransitionFiling(filing)
+                break
               default:
                 // fallback for unknown filings
                 this.loadPaperFiling(filing)
@@ -819,6 +822,64 @@ export default {
       }
     },
 
+    /** Loads A Transition filing into the historyItems list. */
+    loadTransitionFiling (filing: FilingIF) {
+      const header = filing?.header
+      const business = filing?.business
+
+      if (header && business) {
+        const filingType = FilingTypes.TRANSITION_APPLICATION
+
+        let subtitle = ''
+
+        const filingDateTime = this.convertUTCTimeToLocalTime(header.date)
+        const filingDate = filingDateTime?.slice(0, 10)
+
+        // Effective Date is assigned by the backend when the filing is completed (normally right away).
+        // Effective Date may be in the future (eg, for BCOMP COA filings).
+        // If Effective Date is empty, use Filing Date instead.
+        const effectiveDateTime = this.convertUTCTimeToLocalTime(header.effectiveDate) || filingDateTime
+
+        // is this a Future Effective Incorp NOA?
+        const isFutureEffectiveNoa = !!filing.header.isFutureEffective
+
+        // is this a Future Effective NOA pending completion?
+        const isFutureEffectiveNoaPending = isFutureEffectiveNoa && this.isEffectiveDatePast(filing)
+
+        // build filing item
+        const item: HistoryItemIF = {
+          filingType,
+          title: this.filingTypeToName(filingType),
+          subtitle,
+          filingId: header.filingId,
+          filingAuthor: 'Registry Staff', // TBD
+          filingDate,
+          effectiveDateTime, // used in Future Effective IA components
+          isPaid: header.status === FilingStatus.PAID,
+          documents: filing?.documents || ([] as Array<any>),
+          status: header.status,
+          comments: this.flattenAndSortComments(header.comments)
+        }
+
+        // add receipt
+        if (header.paymentToken) {
+          item.documents.push({
+            type: this.DOCUMENT_TYPE_RECEIPT,
+            corpName: this.entityName || this.entityTypeToNumberedDescription(this.entityType),
+            filingDateTime,
+            paymentToken: header.paymentToken,
+            title: 'Receipt',
+            filename: `${this.getEntityIncNo} - Receipt - ${filingDate}.pdf`
+          })
+        }
+
+        this.historyItems.push(item)
+      } else {
+        // eslint-disable-next-line no-console
+        console.log('ERROR - missing section in filing =', filing)
+      }
+    },
+
     /** Loads a "paper filing" into the historyItems list. */
     loadPaperFiling (filing: FilingIF) {
       const header = filing?.header
@@ -1156,8 +1217,10 @@ export default {
       const disableThisIaCorrection = (item.filingType === FilingTypes.INCORPORATION_APPLICATION &&
         !featureFlags.getFlag('correction-ui-enabled'))
 
+      const isTransitionFiling = item.filingType === FilingTypes.TRANSITION_APPLICATION
+
       return (this.disableChanges || item.isNoa || item.isCorrection || item.isFutureEffectiveIa ||
-        item.isColinFiling || disableThisIaCorrection)
+        item.isColinFiling || disableThisIaCorrection || isTransitionFiling)
     }
   },
 

--- a/src/enums/filingNames.ts
+++ b/src/enums/filingNames.ts
@@ -9,4 +9,5 @@ export enum FilingNames {
   NOTICE_OF_ALTERATION = 'Alteration Notice',
   SPECIAL_RESOLUTION = 'Special Resolution',
   VOLUNTARY_DISSOLUTION = 'Voluntary Dissolution',
+  TRANSITION_APPLICATION = 'Transition Application'
 }

--- a/src/enums/filingTypes.ts
+++ b/src/enums/filingTypes.ts
@@ -9,4 +9,5 @@ export enum FilingTypes {
   NOTICE_OF_ALTERATION = 'alteration',
   SPECIAL_RESOLUTION = 'specialResolution',
   VOLUNTARY_DISSOLUTION = 'voluntaryDissolution',
+  TRANSITION_APPLICATION = 'transition'
 }

--- a/src/mixins/enum-mixin.ts
+++ b/src/mixins/enum-mixin.ts
@@ -138,6 +138,7 @@ export default class EnumMixin extends Vue {
       case FilingTypes.NOTICE_OF_ALTERATION: return FilingNames.NOTICE_OF_ALTERATION
       case FilingTypes.SPECIAL_RESOLUTION: return FilingNames.SPECIAL_RESOLUTION
       case FilingTypes.VOLUNTARY_DISSOLUTION: return FilingNames.VOLUNTARY_DISSOLUTION
+      case FilingTypes.TRANSITION_APPLICATION: return FilingNames.TRANSITION_APPLICATION
     }
     // fallback for unknown filings
     return type.split(/(?=[A-Z])/).join(' ').replace(/^\w/, c => c.toUpperCase())

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -2074,3 +2074,77 @@ describe('Filing History List - redirections', () => {
     wrapper.destroy()
   })
 })
+
+describe('Filing History List - Transition Filing', () => {
+  it('displays a Transition Filing', async () => {
+    const $route = { query: {} }
+
+    // init store
+    sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
+    store.state.entityType = 'BEN'
+    store.state.entityName = 'ACME Benefit Inc'
+    store.state.filings = [
+      {
+        filing: {
+          header: {
+            name: 'transition',
+            date: '2020-11-01T19:20:05.670859+00:00',
+            status: 'COMPLETED',
+            filingId: 1234,
+            paymentToken: 111
+          },
+          documents: [
+            {
+              'filename': 'BC1234567 - Transition Application - 2020-11-01.pdf',
+              'filingId': 1234,
+              'reportType': null,
+              'title': 'Transition Application',
+              'type': 'REPORT'
+            }
+          ],
+          business: {
+            legalType: 'BEN'
+          },
+          transition: {
+          }
+        }
+      }
+    ]
+
+    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const vm = wrapper.vm as any
+    await Vue.nextTick()
+
+    expect(vm.historyItems.length).toEqual(1)
+    expect(wrapper.findAll('.filing-history-item').length).toEqual(1)
+    expect(wrapper.emitted('history-count')).toEqual([[1]])
+
+    expect(wrapper.find('h3.list-item__title').text()).toBe('Transition Application')
+    expect(wrapper.find('.list-item__subtitle span').text())
+      .toBe('FILED AND PAID (filed by Registry Staff on 2020-11-01)')
+    expect(vm.panel).toBeNull() // no row is expanded
+    expect(wrapper.find('.no-results').exists()).toBe(false)
+
+    // verify Request a Copy button and toggle panel
+    const detailsBtn = wrapper.find('.expand-btn')
+    expect(detailsBtn.text()).toContain('View Documents')
+    detailsBtn.trigger('click')
+    await flushPromises()
+
+    // verify Close button
+    expect(wrapper.find('.expand-btn').text()).toContain('Hide Documents')
+
+    expect(vm.panel).toBe(0)
+    expect(wrapper.find(PendingFiling).exists()).toBe(false)
+    expect(wrapper.find(FutureEffectiveIa).exists()).toBe(false)
+    expect(wrapper.find(PaperFiling).exists()).toBe(false)
+    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.find('.download-document-btn').exists()).toBe(true)
+    expect(wrapper.find('.download-receipt-btn').exists()).toBe(true)
+    expect(wrapper.find('.download-all-btn').exists()).toBe(true)
+
+    sessionStorage.removeItem('BUSINESS_ID')
+
+    wrapper.destroy()
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5183

*Description of changes:*
Added code for loading transition filing ( See a lot of duplicate code for loading each type of filing. May need a clean up at some point of time)
Updated enums and mixins needed for handling a new filing type in the history list
Updated tests

The screenshot of the transition filing in the history list has been shared with Scott and he approved it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
