### PR TITLE
changed retry to app reload

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -677,11 +677,7 @@ export default {
 
     /** Handles Retry click event from dialogs. */
     onClickRetry (): void {
-      this.dashboardUnavailableDialog = false
-      this.businessAuthErrorDialog = false
-      this.nameRequestAuthErrorDialog = false
-      this.nameRequestInvalidDialog = false
-      this.fetchData()
+      location.reload()
     }
   },
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -676,8 +676,14 @@ export default {
     },
 
     /** Handles Retry click event from dialogs. */
-    onClickRetry (): void {
-      location.reload()
+    async onClickRetry (): Promise<void> {
+      this.dashboardUnavailableDialog = false
+      this.businessAuthErrorDialog = false
+      this.nameRequestAuthErrorDialog = false
+      this.nameRequestInvalidDialog = false
+      this.tokenService = false
+      await this.startTokenService()
+      await this.fetchData()
     }
   },
 


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*

Implementation 1: ~When retrying app load (eg, due to KC timeout), reload entire app instead of just local data.~

Implementation 2: When retrying app load (eg, due to KC timeout), reload the token service (which itself will reload the app if it fails); if this works then it may be faster as it may not require reloading all the app files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).