### PR TITLE
improved app retry handler

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -676,12 +676,14 @@ export default {
     },
 
     /** Handles Retry click event from dialogs. */
-    onClickRetry (): void {
+    async onClickRetry (): Promise<void> {
       this.dashboardUnavailableDialog = false
       this.businessAuthErrorDialog = false
       this.nameRequestAuthErrorDialog = false
       this.nameRequestInvalidDialog = false
-      this.fetchData()
+      this.tokenService = false
+      await this.startTokenService()
+      await this.fetchData()
     }
   },
 


### PR DESCRIPTION
*Issue #:* None

*Description of changes:* When retrying to load app after error (eg, due to KC timeout), force-restart token service (which may force an app reload and subsequent re-login). This will succeed in more situations than just retrying the fetches without a new token.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).