### PR TITLE
improved app retry handler, take 2

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,14 +11,14 @@
     <business-auth-error-dialog
       :dialog="businessAuthErrorDialog"
       @exit="onClickExit()"
-      @retry="onClickRetry()"
+      @retry="onClickRetry(true)"
       attach="#app"
     />
 
     <name-request-auth-error-dialog
       :dialog="nameRequestAuthErrorDialog"
       @exit="onClickExit()"
-      @retry="onClickRetry()"
+      @retry="onClickRetry(true)"
       attach="#app"
     />
 
@@ -676,10 +676,20 @@ export default {
     },
 
     /** Handles Retry click event from dialogs. */
-    async onClickRetry (): Promise<void> {
-      // clear KC session variables and hard-reload the page to try again
-      this.clearKeycloakSession()
-      location.reload()
+    async onClickRetry (hard = false): Promise<void> {
+      if (hard)
+        // clear KC session variables and hard-reload the page
+        // to force new login and try again
+        this.clearKeycloakSession()
+        location.reload()
+      } else {
+        // try to fetch the data again
+        this.dashboardUnavailableDialog = false
+        this.businessAuthErrorDialog = false
+        this.nameRequestAuthErrorDialog = false
+        this.nameRequestInvalidDialog = false
+        this.fetchData()
+      }
     }
   },
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -677,13 +677,9 @@ export default {
 
     /** Handles Retry click event from dialogs. */
     async onClickRetry (): Promise<void> {
-      this.dashboardUnavailableDialog = false
-      this.businessAuthErrorDialog = false
-      this.nameRequestAuthErrorDialog = false
-      this.nameRequestInvalidDialog = false
-      this.tokenService = false
-      await this.startTokenService()
-      await this.fetchData()
+      // clear KC session variables and hard-reload the page to try again
+      this.clearKeycloakSession()
+      location.reload()
     }
   },
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -676,7 +676,7 @@ export default {
     },
 
     /** Handles Retry click event from dialogs. */
-    async onClickRetry (hard = false): Promise<void> {
+    onClickRetry (hard = false): void {
       if (hard) {
         // clear KC session variables and hard-reload the page
         // to force new login and try again

--- a/src/App.vue
+++ b/src/App.vue
@@ -677,7 +677,7 @@ export default {
 
     /** Handles Retry click event from dialogs. */
     async onClickRetry (hard = false): Promise<void> {
-      if (hard)
+      if (hard) {
         // clear KC session variables and hard-reload the page
         // to force new login and try again
         this.clearKeycloakSession()


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
When retrying to load app after an auth error, clear the current KC session and hard-reload the page to try again; otherwise try to fetch the data again. The previous solution (#161) typically caused 2 error dialogs and app reloads. This solution is more heavy-handed and causes just 1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).