### PR TITLE
6650 update alterations ledger to include court of order fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ k8s/*.param
 */*/.idea/*
 /**/.idea/*
 .idea/*
+*.iml
 
 # Log files
 npm-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1177,12 +1177,22 @@
       }
     },
     "@bcrs-shared-components/interfaces": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.0.13.tgz",
-      "integrity": "sha512-B2pqjvqUc5C5+l/vlwfDvItENC8mMmddmG3RmYrf5ZRP4B3I/r0NkehpgIJw2Z7CSaO3kdJ+Na8ZR4/CGqODXg==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.0.17.tgz",
+      "integrity": "sha512-5zXO7G2+hIR1KTLtwuuCxwEtvXBTfgmhoiF5yCiaroinkXlFkLYuPD1TSKMiN2M1cQsQHGlobLhYgf4kzJ2thg==",
       "requires": {
-        "@bcrs-shared-components/enums": "^1.0.8",
+        "@bcrs-shared-components/enums": "^1.0.10",
         "vue": "^2.6.11"
+      },
+      "dependencies": {
+        "@bcrs-shared-components/enums": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.10.tgz",
+          "integrity": "sha512-JfeJmFTWTduWTXiSMjdFvP2oyeBwlV7Z1xZaslkZ2Wgl26fyJz8++J7q4apFcaRNppfCt1bjqDTXG4Mu1nawuQ==",
+          "requires": {
+            "@bcrs-shared-components/corp-type-module": "^1.0.3"
+          }
+        }
       }
     },
     "@bcrs-shared-components/staff-comments": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "private": true,
   "appName": "Manage UI",
   "sbcName": "SBC Common Components",
@@ -18,7 +18,7 @@
     "@babel/compat-data": "^7.9.0",
     "@bcrs-shared-components/corp-type-module": "1.0.3",
     "@bcrs-shared-components/enums": "1.0.8",
-    "@bcrs-shared-components/interfaces": "1.0.13",
+    "@bcrs-shared-components/interfaces": "1.0.17",
     "@bcrs-shared-components/staff-comments": "1.0.3",
     "@mdi/font": "^5.0.45",
     "@sentry/browser": "^5.21.1",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -375,7 +375,7 @@ import { AddCommentDialog, DownloadErrorDialog, LoadCorrectionDialog } from '@/c
 
 // Enums and Interfaces
 import { FilingStatus, FilingTypes, Routes } from '@/enums'
-import { FilingIF, HistoryItemIF } from '@/interfaces'
+import { CourtOrderIF, FilingIF, HistoryItemIF } from '@/interfaces'
 
 // Mixins
 import { DateMixin, EnumMixin, FilingMixin, LegalApiMixin } from '@/mixins'
@@ -647,8 +647,11 @@ export default {
       if (header && alteration && business) {
         const newLegalType = this.getCorpTypeDescription(alteration.business?.legalType)
         const oldLegalType = this.getCorpTypeDescription(business.legalType)
-        const courtOrderNumber = '' // FUTURE
-        const isArrangement = false // FUTURE
+        const courtOrder = alteration.courtOrder
+        const courtOrderNumber = courtOrder?.fileNumber ? courtOrder.fileNumber : ''
+
+        // isArrangement is true when effect of order value returned by BE is 'planOfArrangement'
+        const isArrangement = this.isPlanOfArrangement(courtOrder)
 
         let title = 'Alteration'
         if (newLegalType !== oldLegalType) {
@@ -794,6 +797,15 @@ export default {
         }
       }
       return false
+    },
+
+    /** Whether this filing(alteration) is pursuant to a plan of arrangement  */
+    isPlanOfArrangement (courtOrder: CourtOrderIF): boolean {
+      if (!courtOrder || !courtOrder.effectOfOrder) {
+        return false
+      }
+
+      return this.isEffectOfOrderPlanOfArrangement(courtOrder)
     },
 
     loadCorrection (filing: FilingIF) {

--- a/src/enums/effectOfOrderTypes.ts
+++ b/src/enums/effectOfOrderTypes.ts
@@ -1,0 +1,3 @@
+export enum EffectOfOrderTypes {
+  PLAN_OF_ARRANGEMENT = 'planOfArrangement'
+}

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -10,6 +10,7 @@ export * from './paymentMethod'
 export * from './roles'
 export * from './routes'
 export * from './staffPaymentsOptions'
+export * from './effectOfOrderTypes'
 
 // external enums
 export { CorpTypeCd, CorpClass } from '@bcrs-shared-components/corp-type-module'

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,11 +3,13 @@
 // https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/
 import type { CorpInfoIF } from '@bcrs-shared-components/corp-type-module'
 import type { AlterationIF, BusinessIF, ContactPointIF, NameRequestIF, NameTranslationIF, NameRequestDetailsIF,
-  NameRequestApplicantIF, ShareStructureIF } from '@bcrs-shared-components/interfaces'
+  NameRequestApplicantIF, ShareStructureIF, CourtOrderIF, IncorporationApplicationIF, IncorporationAddressIf,
+  ShareClassIF } from '@bcrs-shared-components/interfaces'
 export type { CorpInfoIF }
 
 export type { AlterationIF, BusinessIF, ContactPointIF, NameRequestIF, NameTranslationIF, NameRequestDetailsIF,
-  NameRequestApplicantIF, ShareStructureIF }
+  NameRequestApplicantIF, ShareStructureIF, CourtOrderIF, IncorporationApplicationIF, IncorporationAddressIf,
+  ShareClassIF }
 
 export * from './address-interfaces'
 export * from './alertMessage-interface'

--- a/src/mixins/enum-mixin.ts
+++ b/src/mixins/enum-mixin.ts
@@ -1,5 +1,6 @@
 import { Component, Vue } from 'vue-property-decorator'
-import { CorpTypeCd, EntityStatus, FilingNames, FilingStatus, FilingTypes, PaymentMethod } from '@/enums'
+import { CorpTypeCd, EntityStatus, FilingNames, FilingStatus, FilingTypes, PaymentMethod, EffectOfOrderTypes }
+  from '@/enums'
 import { GetCorpInfoObject, GetCorpFullDescription, GetCorpNumberedDescription }
   from '@bcrs-shared-components/corp-type-module'
 
@@ -108,6 +109,15 @@ export default class EnumMixin extends Vue {
   /** Returns True if payment method is Online Banking. */
   isPayMethodOnlineBanking (item: any): boolean {
     return (item.paymentMethod === PaymentMethod.ONLINE_BANKING)
+  }
+
+  //
+  // Effect of Order helpers
+  //
+
+  /** Returns True if effect of order is Plan of Arrangement. */
+  isEffectOfOrderPlanOfArrangement (item: any): boolean {
+    return (item.effectOfOrder === EffectOfOrderTypes.PLAN_OF_ARRANGEMENT)
   }
 
   //

--- a/vue.config.js
+++ b/vue.config.js
@@ -38,7 +38,7 @@ module.exports = {
     proxy: {
       // this is needed to prevent a CORS error when running locally
       '/local-keycloak-config-url/*': {
-        target: 'https://business-filings-dev.pathfinder.gov.bc.ca/businesses/edit/config/kc/',
+        target: 'https://dev.bcregistry.ca/business/config/kc/',
         pathRewrite: {
           '/local-keycloak-config-url': ''
         }


### PR DESCRIPTION
Issue #: /bcgov/entity#6650

Description of changes:

- Updated package number to 3.8.6
- Updated package.json to use v1.0.17 of bcrs-shared-components/interfaces.  Contains court order related interface updates
- Updated FilingHistoryList.vue component to use court order interface and to properly populate data from BE into history item object
- Created EffectOfOrderTypes enum and added helper methods to enum mixin
- Updated proxy config in vue.config.js as was having issues grabbing keycloak.json locally

Note: existing test already tested the updated fields so no updates were made to tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
