### PR TITLE
Added and used flag to display filings filed by Registry Staff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -541,7 +541,7 @@ export default {
           filingType,
           title: this.filingTypeToName(filingType, agmYear),
           filingId: header.filingId,
-          filingAuthor: header.certifiedBy,
+          filingAuthor: this.filingAuthor(filing),
           filingDate,
           isPaid: (header.status === FilingStatus.PAID),
           documents: filing?.documents || [] as Array<any>,
@@ -607,7 +607,7 @@ export default {
           filingType,
           title: `${this.getCorpTypeDescription(this.entityType)} ${name} - ${corpName}`,
           filingId: header.filingId,
-          filingAuthor: header.certifiedBy,
+          filingAuthor: this.filingAuthor(filing),
           filingDate,
           effectiveDateTime, // used in Future Effective component
           isFutureEffectiveIa,
@@ -681,7 +681,7 @@ export default {
           filingType: FilingTypes.ALTERATION,
           title,
           filingId: header.filingId,
-          filingAuthor: header.certifiedBy || 'Registry Staff',
+          filingAuthor: this.filingAuthor(filing),
           filingDate,
           effectiveDateTime, // used in Future Effective component
           isFutureEffectiveAlteration,
@@ -744,7 +744,7 @@ export default {
           filingType,
           title: this.filingTypeToName(filingType),
           filingId: header.filingId,
-          filingAuthor: header.certifiedBy,
+          filingAuthor: this.filingAuthor(filing),
           filingDate,
           effectiveDate, // used for BCOMP COA Future Effective tooltip
           isBcompCoaFutureEffective,
@@ -822,7 +822,7 @@ export default {
           filingType: FilingTypes.CORRECTION,
           title: `Correction - ${this.filingTypeToName(correction.correctedFilingType)}`,
           filingId: header.filingId,
-          filingAuthor: header.certifiedBy || 'Registry Staff',
+          filingAuthor: this.filingAuthor(filing),
           filingDateTime: this.apiToSimpleDateTime(header.date), // used for receipt
           filingDate,
           isPaid: (header.status === FilingStatus.PAID),
@@ -922,7 +922,7 @@ export default {
           title: this.filingTypeToName(filingType),
           subtitle,
           filingId: header.filingId,
-          filingAuthor: 'Registry Staff', // TBD
+          filingAuthor: 'Registry Staff',
           filingDate,
           effectiveDateTime, // used in Future Effective IA components
           isPaid: (header.status === FilingStatus.PAID),
@@ -989,6 +989,14 @@ export default {
         // eslint-disable-next-line no-console
         console.log('ERROR - missing section in filing =', filing)
       }
+    },
+
+    /** Returns the computed filing author. */
+    filingAuthor (filing: FilingIF): string {
+      const header = filing.header
+      if (header.isStaff) return 'Registry Staff'
+      if (header.certifiedBy) return header.certifiedBy
+      return 'Unknown'
     },
 
     /** Expands the panel of the specified Filing ID. */

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -1255,7 +1255,8 @@ describe('Filing History List - alterations', () => {
             name: 'alteration',
             date: '2020-03-24T19:20:05.670859+00:00',
             status: 'COMPLETED',
-            filingId: 85114
+            filingId: 85114,
+            isStaff: true
           },
           business: {},
           alteration: {}
@@ -1315,7 +1316,8 @@ describe('Filing History List - alterations', () => {
             name: 'alteration',
             date: '2020-03-24T19:20:05.670859+00:00',
             status: 'COMPLETED',
-            filingId: 85114
+            filingId: 85114,
+            isStaff: true
           },
           business: {
             legalType: 'BC' // 'from' type
@@ -1382,7 +1384,8 @@ describe('Filing History List - alterations', () => {
             name: 'alteration',
             date: '2020-03-24T19:20:05.670859+00:00',
             status: 'COMPLETED',
-            filingId: 85114
+            filingId: 85114,
+            isStaff: true
           },
           business: {
             legalType: 'ULC' // 'from' type
@@ -1451,7 +1454,8 @@ describe('Filing History List - alterations', () => {
             isFutureEffective: true,
             effectiveDate: '2020-04-24T19:20:05.670859+00:00', // date in the past
             status: 'PAID',
-            filingId: 85114
+            filingId: 85114,
+            isStaff: true
           },
           business: {
             legalType: 'BC' // 'from' type
@@ -1520,7 +1524,8 @@ describe('Filing History List - alterations', () => {
             isFutureEffective: true,
             effectiveDate: '2099-12-31T23:59:59+00:00', // way in the future so it's always > now
             status: 'PAID',
-            filingId: 85114
+            filingId: 85114,
+            isStaff: true
           },
           business: {
             legalType: 'BC' // 'from' type
@@ -2104,7 +2109,8 @@ describe('Filing History List - transition filing', () => {
             date: '2020-11-01T19:20:05.670859+00:00',
             status: 'COMPLETED',
             filingId: 1234,
-            paymentToken: 111
+            paymentToken: 111,
+            isStaff: true
           },
           documents: [
             {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6814

*Description of changes:*
- displayed Filed By according to staff flag or certified by value, else fall back to Unknown
- saved isStaff flag in AR, Correction, COD and COA
- updated app version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).