### PR TITLE
History List Handling for Staff Filings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -72,6 +72,12 @@ p {
   color: $app-blue !important;
 }
 
+.info-text {
+  font-size: .875rem;
+  color: $gray7;
+  font-weight: normal;
+}
+
 .error-text {
   color: $app-red !important;
 }

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -787,9 +787,9 @@ export default {
               break
           }
 
-          item.notationOrOrder = baseFiling.orderDetails
-          item.fileNumber = baseFiling.fileNumber
-          item.planOfArrangement = baseFiling.effectOfOrder ? 'Pursuant to a Plan of Arrangement' : ''
+          item.notationOrOrder = baseFiling?.orderDetails
+          item.fileNumber = baseFiling?.fileNumber
+          item.planOfArrangement = baseFiling?.effectOfOrder ? 'Pursuant to a Plan of Arrangement' : ''
         }
 
         // add receipt

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -285,6 +285,14 @@
               <!-- NB: no documents so no divider needed -->
             </template>
 
+            <!-- is this a staff only filing? -->
+            <template v-else-if="isStaffFiling(filing.filingType)" id="staff-filings-info">
+              <p class="info-text">{{filing.notationOrOrder}}</p>
+              <p class="info-text my-0">Court Order Number: {{filing.fileNumber}}</p>
+              <p class="info-text my-0">{{filing.planOfArrangement}}</p>
+              <!-- NB: no documents so no divider needed -->
+            </template>
+
             <!-- else must be a COMPLETED filing -->
             <!-- NB: no details -->
             <template v-else />
@@ -765,6 +773,23 @@ export default {
           isCorrected: (header.isCorrected || false),
           isCorrectionPending: (header.isCorrectionPending || false),
           comments: this.flattenAndSortComments(header.comments)
+        }
+
+        // Apply additional properties for Staff Only Filings
+        if (this.isStaffFiling(filingType)) {
+          let baseFiling
+          switch (filingType) {
+            case FilingTypes.REGISTRARS_NOTATION: baseFiling = filing.registrarsNotation
+              break
+            case FilingTypes.REGISTRARS_ORDER: baseFiling = filing.registrarsOrder
+              break
+            case FilingTypes.COURT_ORDER: baseFiling = filing.courtOrder
+              break
+          }
+
+          item.notationOrOrder = baseFiling.orderDetails
+          item.fileNumber = baseFiling.fileNumber
+          item.planOfArrangement = baseFiling.effectOfOrder ? 'Pursuant to a Plan of Arrangement' : ''
         }
 
         // add receipt

--- a/src/enums/filingTypes.ts
+++ b/src/enums/filingTypes.ts
@@ -9,5 +9,9 @@ export enum FilingTypes {
   ALTERATION = 'alteration',
   SPECIAL_RESOLUTION = 'specialResolution',
   VOLUNTARY_DISSOLUTION = 'voluntaryDissolution',
-  TRANSITION = 'transition'
+  TRANSITION = 'transition',
+  REGISTRARS_NOTATION = 'registrarsNotation',
+  REGISTRARS_ORDER = 'registrarsOrder',
+  COURT_ORDER = 'courtOrder',
+  UNKNOWN = 'unknown'
 }

--- a/src/interfaces/filing-interface.ts
+++ b/src/interfaces/filing-interface.ts
@@ -11,5 +11,8 @@ export interface FilingIF {
   header: HeaderIF,
   incorporationApplication?: any;
   alteration?: AlterationIF;
+  registrarsNotation?: any;
+  registrarsOrder?: any;
+  courtOrder?: any;
   [propName: string]: any; // excess properties
 }

--- a/src/interfaces/historyItem-interface.ts
+++ b/src/interfaces/historyItem-interface.ts
@@ -40,4 +40,9 @@ export interface HistoryItemIF {
   newLegalType?: CorpTypeCd
   courtOrderNumber?: string
   isArrangement?: boolean
+
+  // Staff only filings
+  notationOrOrder?: string
+  fileNumber?: string
+  planOfArrangement?: string
 }

--- a/src/interfaces/historyItem-interface.ts
+++ b/src/interfaces/historyItem-interface.ts
@@ -9,7 +9,7 @@ export interface HistoryItemIF {
   filingDate: string;
   filingDateTime?: string;
   filingId: number;
-  filingType: FilingTypes | 'unknown';
+  filingType: FilingTypes;
   filingYear?: string;
   isCorrected?: boolean;
   isPaid: boolean;

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -2161,3 +2161,216 @@ describe('Filing History List - transition filing', () => {
     wrapper.destroy()
   })
 })
+
+describe('Filing History List - registrars notation', () => {
+  it('displays a Registrars Notation Filing', async () => {
+    const $route = { query: {} }
+
+    // init store
+    sessionStorage.setItem('BUSINESS_ID', 'BC1230072')
+    store.state.entityType = 'BEN'
+    store.state.entityName = '1230072 B.C. LTD.'
+    store.state.filings = [
+      {
+        filing: {
+          registrarsNotation: {
+            fileNumber: '#1234-5678/90',
+            orderDate: '2021-01-30T09:56:01+08:00',
+            effectOfOrder: 'planOfArrangement',
+            orderDetails: 'A note about order'
+          },
+          business: {
+            foundingDate: '2021-01-13T21:37:19.844203+00:00',
+            identifier: 'BC1230072',
+            legalName: '1230072 B.C. LTD.',
+            legalType: 'BEN'
+          },
+          documents: [],
+          header: {
+            name: 'registrarsNotation',
+            date: '2021-05-06',
+            certifiedBy: 'Cameron',
+            email: 'no_one@never.get',
+            filingId: 112040,
+            effectiveDate: '2021-05-05T20:37:44.613716+00:00'
+          }
+        }
+      }
+    ]
+
+    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const vm = wrapper.vm as any
+    await Vue.nextTick()
+
+    expect(vm.historyItems.length).toEqual(1)
+    expect(wrapper.findAll('.filing-history-item').length).toEqual(1)
+    expect(wrapper.emitted('history-count')).toEqual([[1]])
+
+    expect(wrapper.find('h3.list-item__title').text()).toBe('Registrars Notation')
+    expect(wrapper.find('.list-item__subtitle span').text())
+      .toBe('FILED AND PAID (filed by Cameron on 2021-05-05)')
+    expect(vm.panel).toBeNull() // no row is expanded
+    expect(wrapper.find('.no-results').exists()).toBe(false)
+
+    // verify Request a Copy button and toggle panel
+    const detailsBtn = wrapper.find('.expand-btn')
+    expect(detailsBtn.text()).toContain('View')
+    detailsBtn.trigger('click')
+    await flushPromises()
+
+    // verify Close button
+    expect(wrapper.find('.expand-btn').text()).toContain('Hide')
+
+    expect(vm.panel).toBe(0)
+    expect(wrapper.find(PendingFiling).exists()).toBe(false)
+    expect(wrapper.find(FutureEffective).exists()).toBe(false)
+    expect(wrapper.find(PaperFiling).exists()).toBe(false)
+    expect(wrapper.find(DetailsList).exists()).toBe(false)
+
+    sessionStorage.removeItem('BUSINESS_ID')
+
+    wrapper.destroy()
+  })
+})
+
+describe('Filing History List - registrars order', () => {
+  it('displays a Registrars Order Filing', async () => {
+    const $route = { query: {} }
+
+    // init store
+    sessionStorage.setItem('BUSINESS_ID', 'BC1230072')
+    store.state.entityType = 'BEN'
+    store.state.entityName = '1230072 B.C. LTD.'
+    store.state.filings = [
+      {
+        filing: {
+          registrarsOrder: {
+            fileNumber: '#1234-5678/90',
+            orderDate: '2021-01-30T09:56:01+08:00',
+            effectOfOrder: 'planOfArrangement',
+            orderDetails: 'A note about order'
+          },
+          business: {
+            foundingDate: '2021-01-13T21:37:19.844203+00:00',
+            identifier: 'BC1230072',
+            legalName: '1230072 B.C. LTD.',
+            legalType: 'BEN'
+          },
+          documents: [],
+          header: {
+            name: 'registrarsOrder',
+            date: '2021-05-06',
+            certifiedBy: 'Cameron',
+            email: 'no_one@never.get',
+            filingId: 112040,
+            effectiveDate: '2021-05-05T20:37:44.613716+00:00'
+          }
+        }
+      }
+    ]
+
+    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const vm = wrapper.vm as any
+    await Vue.nextTick()
+
+    expect(vm.historyItems.length).toEqual(1)
+    expect(wrapper.findAll('.filing-history-item').length).toEqual(1)
+    expect(wrapper.emitted('history-count')).toEqual([[1]])
+
+    expect(wrapper.find('h3.list-item__title').text()).toBe('Registrars Order')
+    expect(wrapper.find('.list-item__subtitle span').text())
+      .toBe('FILED AND PAID (filed by Cameron on 2021-05-05)')
+    expect(vm.panel).toBeNull() // no row is expanded
+    expect(wrapper.find('.no-results').exists()).toBe(false)
+
+    // verify Request a Copy button and toggle panel
+    const detailsBtn = wrapper.find('.expand-btn')
+    expect(detailsBtn.text()).toContain('View')
+    detailsBtn.trigger('click')
+    await flushPromises()
+
+    // verify Close button
+    expect(wrapper.find('.expand-btn').text()).toContain('Hide')
+
+    expect(vm.panel).toBe(0)
+    expect(wrapper.find(PendingFiling).exists()).toBe(false)
+    expect(wrapper.find(FutureEffective).exists()).toBe(false)
+    expect(wrapper.find(PaperFiling).exists()).toBe(false)
+    expect(wrapper.find(DetailsList).exists()).toBe(false)
+
+    sessionStorage.removeItem('BUSINESS_ID')
+
+    wrapper.destroy()
+  })
+})
+
+describe('Filing History List - Court Order', () => {
+  it('displays a Court Order Filing', async () => {
+    const $route = { query: {} }
+
+    // init store
+    sessionStorage.setItem('BUSINESS_ID', 'BC1230072')
+    store.state.entityType = 'BEN'
+    store.state.entityName = '1230072 B.C. LTD.'
+    store.state.filings = [
+      {
+        filing: {
+          courtOrder: {
+            fileNumber: '#1234-5678/90',
+            orderDate: '2021-01-30T09:56:01+08:00',
+            effectOfOrder: 'planOfArrangement',
+            orderDetails: 'A note about order'
+          },
+          business: {
+            foundingDate: '2021-01-13T21:37:19.844203+00:00',
+            identifier: 'BC1230072',
+            legalName: '1230072 B.C. LTD.',
+            legalType: 'BEN'
+          },
+          documents: [],
+          header: {
+            name: 'courtOrder',
+            date: '2021-05-06',
+            certifiedBy: 'Cameron',
+            email: 'no_one@never.get',
+            filingId: 112040,
+            effectiveDate: '2021-05-05T20:37:44.613716+00:00'
+          }
+        }
+      }
+    ]
+
+    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const vm = wrapper.vm as any
+    await Vue.nextTick()
+
+    expect(vm.historyItems.length).toEqual(1)
+    expect(wrapper.findAll('.filing-history-item').length).toEqual(1)
+    expect(wrapper.emitted('history-count')).toEqual([[1]])
+
+    expect(wrapper.find('h3.list-item__title').text()).toBe('Court Order')
+    expect(wrapper.find('.list-item__subtitle span').text())
+      .toBe('FILED AND PAID (filed by Cameron on 2021-05-05)')
+    expect(vm.panel).toBeNull() // no row is expanded
+    expect(wrapper.find('.no-results').exists()).toBe(false)
+
+    // verify Request a Copy button and toggle panel
+    const detailsBtn = wrapper.find('.expand-btn')
+    expect(detailsBtn.text()).toContain('View')
+    detailsBtn.trigger('click')
+    await flushPromises()
+
+    // verify Close button
+    expect(wrapper.find('.expand-btn').text()).toContain('Hide')
+
+    expect(vm.panel).toBe(0)
+    expect(wrapper.find(PendingFiling).exists()).toBe(false)
+    expect(wrapper.find(FutureEffective).exists()).toBe(false)
+    expect(wrapper.find(PaperFiling).exists()).toBe(false)
+    expect(wrapper.find(DetailsList).exists()).toBe(false)
+
+    sessionStorage.removeItem('BUSINESS_ID')
+
+    wrapper.destroy()
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4389

*Description of changes:*
- Updated the filing history to include the new "registrar's notation" ledger item
- Updated the filing history to include the new "registrar's order" ledger item
- Updated the filing history to include the new "Court order" ledger item

- These ledger items cannot be corrected
- Detail comments enabled.

- Updated unit tests

*NOTES:*

* This was done off these UXpins, currently all we have: https://preview.uxpin.com/1f3b95dd1c4122ddb79c854e9498f5e8073cbfa1#/pages/130733104/simulate/no-panels

* Also done off the current schema, since these filings don't exist and needed to be mocked out. Schema is subject to change but this won't impact the Filings History List unless the title and/or FilingType changes. I'm assuming that won't.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
