### PR TITLE
Added CP as a supported business legal type

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -125,7 +125,8 @@ export default {
         CorpTypeCd.BENEFIT_COMPANY,
         CorpTypeCd.BC_COMPANY,
         CorpTypeCd.BC_ULC_COMPANY,
-        CorpTypeCd.BC_CCC
+        CorpTypeCd.BC_CCC,
+        CorpTypeCd.COOP
       ],
 
       // enums


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*

At the moment, it is not possible to test a CP IA, because the Entity Dashboard (this project) rejects the `filing.business.legalType` of "CP". This PR adds COOP as a support business legal type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).