### PR TITLE
9543 Properly open panel when highlighting a filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -397,7 +397,6 @@ export default class FilingHistoryList extends Mixins(
   @Getter isBComp!: boolean
   @Getter isRoleStaff!: boolean
   @Getter getFilings!: Array<ApiFilingIF>
-  @Getter getEntityIncNo!: string
 
   @Action setIsCoaPending!: ActionBindingIF
   @Action setCoaEffectiveDate!: ActionBindingIF
@@ -600,7 +599,7 @@ export default class FilingHistoryList extends Mixins(
   /** Expands the panel of the specified filing ID. */
   private highlightFiling (filingId: number): void {
     const index = this.historyItems.findIndex(h => h.filingId === filingId)
-    if (index >= 0) this.panel = index
+    if (index >= 0) this.togglePanel(index, this.historyItems[index])
   }
 
   private async correctThisFiling (item: HistoryItemIF): Promise<void> {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9543

*Description of changes:*

This fix properly open the panel (thus loading comments and documents) when a filing ID is provided as a URL parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).