### PR TITLE
9782 Fixed multiple reloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -220,8 +220,8 @@ export default {
   },
 
   created (): void {
-    // listen for dashboard reload trigger events
-    this.$root.$on('triggerDashboardReload', () => this.fetchData())
+    // listen for reload data events
+    this.$root.$on('reloadData', () => this.fetchData())
 
     // listen for spinner show/hide events
     this.$root.$on('showSpinner', (flag = false) => { this.showSpinner = flag })
@@ -238,8 +238,8 @@ export default {
   },
 
   destroyed (): void {
-    // stop listening for dashboard reload trigger events
-    this.$root.$off('triggerDashboardReload')
+    // stop listening for reload data events
+    this.$root.$off('reloadData')
 
     // stop listening for spinner show/hide events
     this.$root.$off('showSpinner')
@@ -294,6 +294,7 @@ export default {
       }
       this.setCurrentDate(this.dateToYyyyMmDd(serverDate))
 
+      // check authorizations
       try {
         // get Keycloak roles
         const jwt = this.getJWT()
@@ -737,7 +738,7 @@ export default {
 
   watch: {
     async '$route' (): Promise<void> {
-      // if we (re)route to the dashboard then re-fetch all data
+      // re-fetch all data when we (re)route to the dashboard
       // - does not fire on initial dashboard load
       // - fires after successful signin
       if (this.$route.name === Routes.DASHBOARD) {

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -391,8 +391,8 @@ import { DateMixin, EnumMixin, FilingMixin, LegalApiMixin } from '@/mixins'
 export default class FilingHistoryList extends Mixins(
   DateMixin, EnumMixin, FilingMixin, LegalApiMixin
 ) {
-  @Prop({ default: false })
-  readonly disableChanges: boolean
+  @Prop({ default: false }) readonly disableChanges: boolean
+  @Prop({ default: null }) readonly highlightId: number
 
   @Getter isBComp!: boolean
   @Getter isRoleStaff!: boolean
@@ -427,7 +427,7 @@ export default class FilingHistoryList extends Mixins(
   private loadData (): void {
     this.historyItems = []
 
-    // create history items from 'filings' array from API
+    // create 'history items' list from 'filings' array from API
     for (const filing of this.getFilings) {
       // safety check for required fields
       if (!filing.name || !filing.displayName || !filing.effectiveDate || !filing.submittedDate || !filing.status) {
@@ -439,8 +439,8 @@ export default class FilingHistoryList extends Mixins(
       this.loadFiling(filing)
     }
 
+    // report number of items back to parent (dashboard)
     this.$emit('history-count', this.historyItems.length)
-    this.$emit('history-items', this.historyItems)
 
     // Check if there is a pending (ie, paid / not yet completed) filing.
     // This is a blocker because it needs to be completed first.
@@ -462,9 +462,7 @@ export default class FilingHistoryList extends Mixins(
     this.setHasBlockerFiling(!!blockerFiling)
 
     // if needed, highlight a specific filing
-    // NB: use unary plus operator to cast string to number
-    const highlightId = +this.$route.query.filing_id // may be NaN (which is falsy)
-    if (highlightId) { this.highlightFiling(highlightId) }
+    if (this.highlightId) this.highlightFiling(this.highlightId)
   }
 
   /** Loads a filing into the historyItems list. */
@@ -592,8 +590,8 @@ export default class FilingHistoryList extends Mixins(
   }
 
   /** Expands the panel of the specified filing ID. */
-  private highlightFiling (filingId: number): void {
-    const index = this.historyItems.findIndex(h => h.filingId === filingId)
+  private highlightFiling (id: number): void {
+    const index = this.historyItems.findIndex(h => h.filingId === id)
     if (index >= 0) this.togglePanel(index, this.historyItems[index])
   }
 

--- a/src/mixins/pay-api-mixin.ts
+++ b/src/mixins/pay-api-mixin.ts
@@ -21,6 +21,6 @@ export default class PayApiMixin extends Vue {
     const url = `${this.payApiUrl}codes/errors/${code}`
     return axios.get(url)
       .then(response => response?.data)
-      .catch() // ignore errors
+      .catch(() => {}) // ignore errors
   }
 }

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -238,7 +238,7 @@ describe('App as a COOP', () => {
   beforeEach(async () => {
     const get = sinon.stub(axios, 'get')
 
-    // GET authorizations (role) from auth API
+    // GET authorizations (role) from Auth API
     get.withArgs('entities/CP0001191/authorizations')
       .returns(new Promise((resolve) => resolve({
         data:
@@ -247,7 +247,7 @@ describe('App as a COOP', () => {
         }
       })))
 
-    // GET user info from auth API
+    // GET user info from Auth API
     get.withArgs('users/@me')
       .returns(new Promise((resolve) => resolve({
         data: USER_INFO
@@ -536,7 +536,7 @@ describe('App as a BCOMP', () => {
   beforeEach(async () => {
     const get = sinon.stub(axios, 'get')
 
-    // GET authorizations (role) from auth API
+    // GET authorizations (role) from Auth API
     get.withArgs('entities/BC0007291/authorizations')
       .returns(new Promise((resolve) => resolve({
         data:
@@ -545,7 +545,7 @@ describe('App as a BCOMP', () => {
         }
       })))
 
-    // GET user info from auth API
+    // GET user info from Auth API
     get.withArgs('users/@me')
       .returns(new Promise((resolve) => resolve({
         data: USER_INFO
@@ -796,7 +796,7 @@ describe('App as a Draft IA with approved NR', () => {
   beforeEach(async () => {
     const get = sinon.stub(axios, 'get')
 
-    // GET authorizations (role) from auth API
+    // GET authorizations (role) from Auth API
     get.withArgs('entities/T123456789/authorizations')
       .returns(new Promise((resolve) => resolve({
         data:
@@ -805,7 +805,7 @@ describe('App as a Draft IA with approved NR', () => {
         }
       })))
 
-    // GET user info from auth API
+    // GET user info from Auth API
     get.withArgs('users/@me')
       .returns(new Promise((resolve) => resolve({
         data: USER_INFO
@@ -921,7 +921,7 @@ describe('App as a Draft IA with conditional-not required NR', () => {
   beforeEach(async () => {
     const get = sinon.stub(axios, 'get')
 
-    // GET authorizations (role) from auth API
+    // GET authorizations (role) from Auth API
     get.withArgs('entities/T123456789/authorizations')
       .returns(new Promise((resolve) => resolve({
         data:
@@ -930,7 +930,7 @@ describe('App as a Draft IA with conditional-not required NR', () => {
         }
       })))
 
-    // GET user info from auth API
+    // GET user info from Auth API
     get.withArgs('users/@me')
       .returns(new Promise((resolve) => resolve({
         data: USER_INFO
@@ -1027,7 +1027,7 @@ describe('App as a Draft IA with conditional-received NR', () => {
   beforeEach(async () => {
     const get = sinon.stub(axios, 'get')
 
-    // GET authorizations (role) from auth API
+    // GET authorizations (role) from Auth API
     get.withArgs('entities/T123456789/authorizations')
       .returns(new Promise((resolve) => resolve({
         data:
@@ -1036,7 +1036,7 @@ describe('App as a Draft IA with conditional-received NR', () => {
         }
       })))
 
-    // GET user info from auth API
+    // GET user info from Auth API
     get.withArgs('users/@me')
       .returns(new Promise((resolve) => resolve({
         data: USER_INFO
@@ -1133,7 +1133,7 @@ describe('App as a Draft IA with conditional-waived NR', () => {
   beforeEach(async () => {
     const get = sinon.stub(axios, 'get')
 
-    // GET authorizations (role) from auth API
+    // GET authorizations (role) from Auth API
     get.withArgs('entities/T123456789/authorizations')
       .returns(new Promise((resolve) => resolve({
         data:
@@ -1142,7 +1142,7 @@ describe('App as a Draft IA with conditional-waived NR', () => {
         }
       })))
 
-    // GET user info from auth API
+    // GET user info from Auth API
     get.withArgs('users/@me')
       .returns(new Promise((resolve) => resolve({
         data: USER_INFO
@@ -1239,7 +1239,7 @@ describe('App as a PAID (pending) Incorporation Application', () => {
   beforeEach(async () => {
     const get = sinon.stub(axios, 'get')
 
-    // GET authorizations (role) from auth API
+    // GET authorizations (role) from Auth API
     get.withArgs('entities/T123456789/authorizations')
       .returns(new Promise((resolve) => resolve({
         data:
@@ -1248,7 +1248,7 @@ describe('App as a PAID (pending) Incorporation Application', () => {
         }
       })))
 
-    // GET user info from auth API
+    // GET user info from Auth API
     get.withArgs('users/@me')
       .returns(new Promise((resolve) => resolve({
         data: USER_INFO
@@ -1389,7 +1389,7 @@ describe('App as a COMPLETED Incorporation Application', () => {
   beforeEach(async () => {
     const get = sinon.stub(axios, 'get')
 
-    // GET authorizations (role) from auth API
+    // GET authorizations (role) from Auth API
     get.withArgs('entities/T123456789/authorizations')
       .returns(new Promise((resolve) => resolve({
         data:
@@ -1398,7 +1398,7 @@ describe('App as a COMPLETED Incorporation Application', () => {
         }
       })))
 
-    // GET user info from auth API
+    // GET user info from Auth API
     get.withArgs('users/@me')
       .returns(new Promise((resolve) => resolve({
         data: USER_INFO

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -52,7 +52,7 @@ describe('Filing History List - misc functionality', () => {
       displayName: 'Change of Address',
       // Effective Date is way in the future so it's always > now
       effectiveDate: '2099-12-13 08:00:00 GMT', // Dec 13, 2099 at 00:00:00 am Pacific
-      filingId: 666,
+      filingId: 222,
       isFutureEffective: true,
       name: 'changeOfAddress',
       status: 'PAID',
@@ -62,13 +62,11 @@ describe('Filing History List - misc functionality', () => {
   ]
 
   it('handles empty data', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.filings = []
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -82,13 +80,11 @@ describe('Filing History List - misc functionality', () => {
   })
 
   it('shows the filing date in the correct format "Mmm dd, yyyy"', async () => {
-    const $route = { query: { filing_id: '222' } }
-
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.filings = SAMPLE_FILINGS
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, propsData: { highlightId: 222 }, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -99,8 +95,6 @@ describe('Filing History List - misc functionality', () => {
   })
 
   it('displays multiple filing items', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.filings = [
@@ -175,7 +169,7 @@ describe('Filing History List - misc functionality', () => {
         commentsCount: 0,
         displayName: 'Change of Address',
         effectiveDate: '2019-11-20 22:17:54 GMT',
-        filingId: 9871,
+        filingId: 666,
         isFutureEffective: false,
         name: 'changeOfAddress',
         status: 'COMPLETED',
@@ -184,7 +178,7 @@ describe('Filing History List - misc functionality', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -198,8 +192,6 @@ describe('Filing History List - misc functionality', () => {
   })
 
   it('expands a paper-only filing', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.filings = [
@@ -218,7 +210,7 @@ describe('Filing History List - misc functionality', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -251,8 +243,6 @@ describe('Filing History List - misc functionality', () => {
   })
 
   it('expands a regular filing', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.filings = [
@@ -271,7 +261,7 @@ describe('Filing History List - misc functionality', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -305,14 +295,12 @@ describe('Filing History List - misc functionality', () => {
 
   // FUTURE: show and verify the tooltip
   xit('displays the tooltip when the filing is a BCOMP Future Effective COA', async () => {
-    const $route = { query: { filing_id: '666' } }
-
     // init store
     store.state.entityType = 'BEN'
     store.state.entityIncNo = 'BC0007291'
     store.state.filings = SAMPLE_FILINGS
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, propsData: { highlightId: 666 }, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -329,13 +317,11 @@ describe('Filing History List - misc functionality', () => {
   })
 
   it('returns correct values for the date comparison methods', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.filings = []
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route } })
+    const wrapper = mount(FilingHistoryList, { store })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -351,17 +337,11 @@ describe('Filing History List - misc functionality', () => {
   })
 
   it('disables corrections when "disable changes" prop is set', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.filings = []
 
-    const wrapper = mount(FilingHistoryList, {
-      store,
-      mocks: { $route },
-      propsData: { disableChanges: true }
-    })
+    const wrapper = mount(FilingHistoryList, { store, propsData: { disableChanges: true } })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -369,17 +349,11 @@ describe('Filing History List - misc functionality', () => {
   })
 
   it('returns correct values for misc helper methods', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.filings = []
 
-    const wrapper = mount(FilingHistoryList, {
-      store,
-      mocks: { $route },
-      propsData: { disableChanges: false }
-    })
+    const wrapper = mount(FilingHistoryList, { store, propsData: { disableChanges: false } })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -670,8 +644,7 @@ describe('Filing History List - redirections', () => {
       }
     ]
 
-    const $route = { query: {} }
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -699,14 +672,12 @@ describe('Filing History List - redirections', () => {
 })
 
 describe('Filing History List - incorporation applications', () => {
-  const $route = { query: {} }
-
   it('displays an "empty" IA filing', async () => {
     // init store
     sessionStorage.setItem('TEMP_REG_NUMBER', 'T123456789')
     store.state.filings = []
 
-    const wrapper = shallowMount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = shallowMount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -741,7 +712,7 @@ describe('Filing History List - incorporation applications', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -783,7 +754,7 @@ describe('Filing History List - incorporation applications', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -825,7 +796,7 @@ describe('Filing History List - incorporation applications', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -889,7 +860,7 @@ describe('Filing History List - incorporation applications', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -953,7 +924,7 @@ describe('Filing History List - incorporation applications', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1016,7 +987,7 @@ describe('Filing History List - incorporation applications', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1079,7 +1050,7 @@ describe('Filing History List - incorporation applications', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1142,7 +1113,7 @@ describe('Filing History List - incorporation applications', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1188,7 +1159,6 @@ describe('Filing History List - incorporation applications', () => {
 })
 
 describe('Filing History List - paper only and other filings', () => {
-  const $route = { query: {} }
   let wrapper
   let vm
 
@@ -1220,7 +1190,7 @@ describe('Filing History List - paper only and other filings', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1276,7 +1246,7 @@ describe('Filing History List - paper only and other filings', () => {
       }
     ]
 
-    wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    wrapper = mount(FilingHistoryList, { store, vuetify })
     vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1337,7 +1307,7 @@ describe('Filing History List - paper only and other filings', () => {
       }
     ]
 
-    wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    wrapper = mount(FilingHistoryList, { store, vuetify })
     vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1400,7 +1370,7 @@ describe('Filing History List - paper only and other filings', () => {
       }
     ]
 
-    wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    wrapper = mount(FilingHistoryList, { store, vuetify })
     vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1463,7 +1433,7 @@ describe('Filing History List - paper only and other filings', () => {
       }
     ]
 
-    wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    wrapper = mount(FilingHistoryList, { store, vuetify })
     vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1526,7 +1496,7 @@ describe('Filing History List - paper only and other filings', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1583,7 +1553,7 @@ describe('Filing History List - paper only and other filings', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1640,7 +1610,7 @@ describe('Filing History List - paper only and other filings', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
@@ -1691,8 +1661,6 @@ describe('Filing History List - documents', () => {
   }
 
   it('does not display the documents list when no documents are present on a filing', async () => {
-    const $route = { query: { } }
-
     // init store
     store.state.filings = [ FILING_WITH_DOCUMENTS_LINK ]
 
@@ -1704,7 +1672,7 @@ describe('Filing History List - documents', () => {
         }
       })))
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     await Vue.nextTick()
 
     // verify that Documents List component does not exist before the item is expanded
@@ -1726,8 +1694,6 @@ describe('Filing History List - documents', () => {
   })
 
   it('display the documents list when documents are present on a filing', async () => {
-    const $route = { query: { } }
-
     // init store
     store.state.filings = [ FILING_WITH_DOCUMENTS_LINK ]
 
@@ -1744,7 +1710,7 @@ describe('Filing History List - documents', () => {
         }
       })))
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     await Vue.nextTick()
 
     // verify that Documents List component does not exist before the item is expanded
@@ -1769,8 +1735,6 @@ describe('Filing History List - documents', () => {
   })
 
   it('computes proper document titles from the documents data', async () => {
-    const $route = { query: { filing_id: '666' } }
-
     // init store
     store.state.filings = [ FILING_WITH_DOCUMENTS_LINK ]
 
@@ -1789,7 +1753,7 @@ describe('Filing History List - documents', () => {
         }
       })))
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, propsData: { highlightId: 666 }, vuetify })
     await Vue.nextTick()
 
     // expand details
@@ -1829,8 +1793,6 @@ describe('Filing History List - detail comments', () => {
   }
 
   it('does not display the details count when count is zero', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.filings = [
       {
@@ -1848,7 +1810,7 @@ describe('Filing History List - detail comments', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     await Vue.nextTick()
 
     // verify that detail comments button does not exist
@@ -1858,8 +1820,6 @@ describe('Filing History List - detail comments', () => {
   })
 
   it('displays the comments count when count is greater than zero', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.filings = [
       {
@@ -1878,7 +1838,7 @@ describe('Filing History List - detail comments', () => {
       }
     ]
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     await Vue.nextTick()
 
     // verify detail comments button
@@ -1888,8 +1848,6 @@ describe('Filing History List - detail comments', () => {
   })
 
   it('does not display the details list when no comments are present on a filing', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.filings = [ FILING_WITH_COMMENTS_LINK ]
 
@@ -1901,7 +1859,7 @@ describe('Filing History List - detail comments', () => {
         }
       })))
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     await Vue.nextTick()
 
     // verify that Details List component does not exist before the item is expanded
@@ -1919,8 +1877,6 @@ describe('Filing History List - detail comments', () => {
   })
 
   it('displays the details list when comments are present on a filing', async () => {
-    const $route = { query: {} }
-
     // init store
     store.state.filings = [ FILING_WITH_COMMENTS_LINK ]
 
@@ -1949,7 +1905,7 @@ describe('Filing History List - detail comments', () => {
         }
       })))
 
-    const wrapper = mount(FilingHistoryList, { store, mocks: { $route }, vuetify })
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
     await Vue.nextTick()
 
     // verify that Details List component does not exist until the item is expanded

--- a/tests/unit/TodoList.spec.ts
+++ b/tests/unit/TodoList.spec.ts
@@ -834,39 +834,35 @@ describe('TodoList - UI', () => {
     wrapper.destroy()
   })
 
-  it('displays a PROCESSING message on a filing that is expected to be complete', async () => {
+  it('displays a PROCESSING message when the In Process variable is set', async () => {
     // init store
     store.state.tasks = [
       {
-        'task': {
-          'filing': {
+        task: {
+          filing: {
             header: {
-              'name': 'changeOfDirectors',
-              'status': 'PENDING',
-              'paymentToken': 12345678,
-              'filingId': 123
+              name: 'changeOfDirectors',
+              status: 'PENDING',
+              paymentToken: 12345678,
+              filingId: 123
             },
             business: {},
             changeOfDirectors: {}
           }
         },
-        'enabled': true,
-        'order': 1
+        enabled: true,
+        order: 1
       }
     ]
 
-    const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 123 } })
+    const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
     await flushPromises()
 
-    expect(vm.todoItems.length).toEqual(1)
-    expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
-    expect(wrapper.emitted('todo-count')).toEqual([[1]])
-    expect(store.state.hasBlockerTask).toEqual(true)
-    expect(vm.$el.querySelector('.no-results')).toBeNull()
+    // set the "in progress" task
+    vm.inProcessFiling = 123
 
     const item = vm.$el.querySelector('.list-item')
-    expect(vm.todoItems[0].filingId).toEqual(wrapper.props('inProcessFiling'))
     expect(item.querySelector('.list-item__title').textContent).toContain('File Director Change')
     expect(item.querySelector('.list-item__subtitle').textContent).toContain('FILING PENDING')
     expect(item.querySelector('.list-item__subtitle').textContent).toContain('PROCESSING...')
@@ -877,46 +873,41 @@ describe('TodoList - UI', () => {
     wrapper.destroy()
   })
 
-  it('does not break if a filing is marked as processing, that is not in the to-do list', async () => {
+  it('does not display a PROCESSING message when the In Process variable is falsy', async () => {
     // init store
     store.state.tasks = [
       {
-        'task': {
-          'filing': {
+        task: {
+          filing: {
             header: {
-              'name': 'changeOfDirectors',
-              'status': 'PENDING',
-              'paymentToken': 12345678,
-              'filingId': 123
+              name: 'changeOfDirectors',
+              status: 'PENDING',
+              paymentToken: 12345678,
+              filingId: 123
             },
             business: {},
             changeOfDirectors: {}
           }
         },
-        'enabled': true,
-        'order': 1
+        enabled: true,
+        order: 1
       }
     ]
 
-    const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 456 } })
+    const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
     await flushPromises()
 
-    expect(vm.todoItems.length).toEqual(1)
-    expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
-    expect(wrapper.emitted('todo-count')).toEqual([[1]])
-    expect(store.state.hasBlockerTask).toEqual(true)
-    expect(vm.$el.querySelector('.no-results')).toBeNull()
+    // clear the "in progress" task
+    vm.inProcessFiling = NaN
 
     const item = vm.$el.querySelector('.list-item')
-    expect(vm.todoItems[0].filingId).not.toEqual(wrapper.props('inProcessFiling'))
     expect(item.querySelector('.list-item__title').textContent).toContain('File Director Change')
     expect(item.querySelector('.list-item__subtitle').textContent).toContain('FILING PENDING')
     expect(item.querySelector('.list-item__subtitle').textContent).toContain('PAYMENT INCOMPLETE')
 
     const button = item.querySelector('.list-item__actions .v-btn')
-    expect(button.disabled).toBe(false)
-    expect(button.querySelector('.v-btn__content').textContent).toContain('Resume Payment')
+    expect(button.getAttribute('disabled')).toBeNull()
 
     wrapper.destroy()
   })
@@ -1313,39 +1304,35 @@ describe('TodoList - UI - BCOMPs', () => {
     wrapper.destroy()
   })
 
-  it('displays a PROCESSING message on a filing that is expected to be complete', async () => {
+  it('displays a PROCESSING message when the In Process variable is set', async () => {
     // init store
     store.state.tasks = [
       {
-        'task': {
-          'filing': {
+        task: {
+          filing: {
             header: {
-              'name': 'changeOfDirectors',
-              'status': 'PENDING',
-              'paymentToken': 12345678,
-              'filingId': 123
+              name: 'changeOfDirectors',
+              status: 'PENDING',
+              paymentToken: 12345678,
+              filingId: 123
             },
             business: {},
             changeOfDirectors: {}
           }
         },
-        'enabled': true,
-        'order': 1
+        enabled: true,
+        order: 1
       }
     ]
 
-    const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 123 } })
+    const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
     await flushPromises()
 
-    expect(vm.todoItems.length).toEqual(1)
-    expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
-    expect(wrapper.emitted('todo-count')).toEqual([[1]])
-    expect(store.state.hasBlockerTask).toEqual(true)
-    expect(vm.$el.querySelector('.no-results')).toBeNull()
+    // set the "in progress" task
+    vm.inProcessFiling = 123
 
     const item = vm.$el.querySelector('.list-item')
-    expect(vm.todoItems[0].filingId).toEqual(wrapper.props('inProcessFiling'))
     expect(item.querySelector('.list-item__title').textContent).toContain('File Director Change')
     expect(item.querySelector('.list-item__subtitle').textContent).toContain('FILING PENDING')
     expect(item.querySelector('.list-item__subtitle').textContent).toContain('PROCESSING...')
@@ -1356,46 +1343,41 @@ describe('TodoList - UI - BCOMPs', () => {
     wrapper.destroy()
   })
 
-  it('does not break if a filing is marked as processing, that is not in the to-do list', async () => {
+  it('does not display a PROCESSING message when the In Process variable is falsy', async () => {
     // init store
     store.state.tasks = [
       {
-        'task': {
-          'filing': {
+        task: {
+          filing: {
             header: {
-              'name': 'changeOfDirectors',
-              'status': 'PENDING',
-              'paymentToken': 12345678,
-              'filingId': 123
+              name: 'changeOfDirectors',
+              status: 'PENDING',
+              paymentToken: 12345678,
+              filingId: 123
             },
             business: {},
             changeOfDirectors: {}
           }
         },
-        'enabled': true,
-        'order': 1
+        enabled: true,
+        order: 1
       }
     ]
 
-    const wrapper = mount(TodoList, { store, vuetify, propsData: { inProcessFiling: 456 } })
+    const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
     await flushPromises()
 
-    expect(vm.todoItems.length).toEqual(1)
-    expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
-    expect(wrapper.emitted('todo-count')).toEqual([[1]])
-    expect(store.state.hasBlockerTask).toEqual(true)
-    expect(vm.$el.querySelector('.no-results')).toBeNull()
+    // clear the "in progress" task
+    vm.inProcessFiling = NaN
 
     const item = vm.$el.querySelector('.list-item')
-    expect(vm.todoItems[0].filingId).not.toEqual(wrapper.props('inProcessFiling'))
     expect(item.querySelector('.list-item__title').textContent).toContain('File Director Change')
     expect(item.querySelector('.list-item__subtitle').textContent).toContain('FILING PENDING')
     expect(item.querySelector('.list-item__subtitle').textContent).toContain('PAYMENT INCOMPLETE')
 
     const button = item.querySelector('.list-item__actions .v-btn')
-    expect(button.disabled).toBe(false)
-    expect(button.querySelector('.v-btn__content').textContent).toContain('Resume Payment')
+    expect(button.getAttribute('disabled')).toBeNull()
 
     wrapper.destroy()
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9782

*Description of changes:*

The previous "check whether to reload when a pending task has become a filing" code (in the Dashboard component) watched both the todo items and the history items, resulting in multiple triggers (events) and resulting in things sometimes running multiple times (or at the same time)... leading to occasional multiple full dashboard reloads after a no-payment AR/COD/COD/Corr filing.

(Also I found that Vue updated the todo items and the history items even before firing their watcher. FYI!)

I realized that we only care about such pending tasks in the todo list. And I saw that the Filing History List handled any "highlighted filing" itself, so I refactored things so that the Todo List now handles its own "highlighted task". This has greatly simplified the Dashboard component, and even the code moved to the Todo List is now pretty succinct.

- renamed a global event
- now pass highlightId as a prop
- no longer emit history/todo lists
- Todo List now checks its own highlighted task (including status poll)
- fixed a broken catch block
- refactored/simplified dashboard
- updated unit tests
- app version: 4.0.12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).