### PR TITLE
8913 Add founding date to dissolution filing business block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.0.17",
+  "version": "4.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.0.17",
+  "version": "4.0.18",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/dissolution-filing-interface.ts
+++ b/src/interfaces/dissolution-filing-interface.ts
@@ -19,6 +19,7 @@ export interface DissolutionFilingIF {
     legalType: string
     legalName: string
     identifier: string
+    foundingDate: string
   }
   dissolution: {
     custodialOffice: OfficeAddressIF,

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -1,4 +1,5 @@
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Mixins } from 'vue-property-decorator'
+import { DateMixin } from '@/mixins'
 import { Action, State, Getter } from 'vuex-class'
 import { CommentIF, CorrectionFilingIF, DissolutionFilingIF, FilingDataIF, OfficeAddressIF } from '@/interfaces'
 import { CorpTypeCd, DissolutionTypes, FilingCodes, FilingTypes } from '@/enums'
@@ -7,7 +8,7 @@ import { CorpTypeCd, DissolutionTypes, FilingCodes, FilingTypes } from '@/enums'
  * Mixin that provides some useful filing utilities.
  */
 @Component({})
-export default class FilingMixin extends Vue {
+export default class FilingMixin extends Mixins(DateMixin) {
   @Action setFilingData!: (x: any) => void
 
   @State filingData!: Array<FilingDataIF>
@@ -16,6 +17,7 @@ export default class FilingMixin extends Vue {
   @Getter getCurrentDate!: string
   @Getter getEntityType!: CorpTypeCd
   @Getter getEntityIncNo!: string
+  @Getter getEntityFoundingDate!: Date
   @Getter getRegisteredOfficeAddress!: OfficeAddressIF
 
   /**
@@ -128,7 +130,8 @@ export default class FilingMixin extends Vue {
       business: {
         legalType: this.getEntityType,
         identifier: this.getEntityIncNo,
-        legalName: this.entityName
+        legalName: this.entityName,
+        foundingDate: this.dateToApi(this.getEntityFoundingDate)
       },
       dissolution: {
         custodialOffice: this.getRegisteredOfficeAddress,

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -153,6 +153,11 @@ export default {
     return state.entityStatus
   },
 
+  /** The Entity Founding Date. */
+  getEntityFoundingDate (state: StateIF): Date {
+    return state.entityFoundingDate
+  },
+
   /** The entity registered office address. */
   getRegisteredOfficeAddress (state: StateIF): OfficeAddressIF {
     return state.registeredAddress


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8913

*Description of changes:*

* Add getter for business founding date (`getEntityFoundingDate`)
* Add `foundingDate` to `business` block of initial draft filing for dissolutions.  This is required as it is used in special resolution date validation logic for Coop voluntary dissolutions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
