### PR TITLE
10319 Removed formatting for min and max date in error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/StandaloneDirectorChange/CODDate.vue
+++ b/src/components/StandaloneDirectorChange/CODDate.vue
@@ -40,7 +40,7 @@
             Date must be in format YYYY/MM/DD.
           </span>
           <span v-else-if="!$v.dateFormatted.isValidCodDate">
-            Please enter a month between {{formatDate(minDate)}} and {{formatDate(maxDate)}}.
+            Please enter a day between {{formatDate(minDate, false)}} and {{formatDate(maxDate, false)}}.
           </span>
         </div>
       </div>
@@ -119,8 +119,8 @@ export default class CodDate extends Mixins(DateMixin) {
    * Local helper to change date from YYYY-MM-DD to YYYY/MM/DD.
    * @returns The formatted date.
    */
-  private formatDate (date: string): string {
-    if (!this.isValidDate(date, '-')) return ''
+  private formatDate (date: string, validate = true): string {
+    if (validate && !this.isValidDate(date, '-')) return ''
     const [year, month, day] = date.split('-')
     return `${year}/${month}/${day}`
   }

--- a/tests/unit/CODDate.spec.ts
+++ b/tests/unit/CODDate.spec.ts
@@ -109,42 +109,75 @@ describe('COD Date - COOPs', () => {
     expect(valids[1]).toEqual([true])
   })
 
-  it('invalidates the component when entered month is after Max Date', () => {
+  it('invalidates the component when entered date is after Max Date', () => {
     wrapper = mount(CodDate, {
       store,
       vuetify,
       computed: {
         minDate () {
-          return '2019-01-01'
+          return '2019-05-05'
         },
         maxDate () {
-          return '2019-05-05'
+          return '2019-05-10'
+        },
+        codDateRules () {
+          return []
         }
       }
     })
 
-    wrapper.setData({ dateFormatted: '2019/11/11' })
-    wrapper.vm.$v.$touch()
+    // force all dates to appear valid
+    jest.spyOn((wrapper.vm as any), 'isValidDate').mockImplementation(() => true)
+
+    // verify initial validators and error message
+    expect(wrapper.vm.$v.dateFormatted.isNotNull).toBe(false)
+    expect(wrapper.vm.$v.dateFormatted.isValidFormat).toBe(false)
     expect(wrapper.vm.$v.dateFormatted.isValidCodDate).toBe(false)
+    expect(wrapper.find('.validationErrorInfo').exists()).toBe(false)
+
+    // set a date after Max Date
+    wrapper.setData({ date: '2019-05-11' })
+
+    // verify validators and error message
+    expect(wrapper.vm.$v.dateFormatted.isNotNull).toBe(true)
+    expect(wrapper.vm.$v.dateFormatted.isValidFormat).toBe(true)
+    expect(wrapper.vm.$v.dateFormatted.isValidCodDate).toBe(false)
+    expect(wrapper.find('.validationErrorInfo > span').text())
+      .toContain('Please enter a day between 2019/05/05 and 2019/05/10.')
   })
 
-  it('invalidates the component when entered month is before Min Date', () => {
+  it('invalidates the component when entered date is before Min Date', () => {
     wrapper = mount(CodDate, {
       store,
       vuetify,
       computed: {
         minDate () {
-          return '2019-01-01'
+          return '2019-05-05'
         },
         maxDate () {
-          return '2019-05-05'
+          return '2019-05-10'
         }
       }
     })
 
-    wrapper.setData({ dateFormatted: '2018/11/11' })
-    wrapper.vm.$v.$touch()
+    // force all dates to appear valid
+    jest.spyOn((wrapper.vm as any), 'isValidDate').mockImplementation(() => true)
+
+    // verify initial validators and error message
+    expect(wrapper.vm.$v.dateFormatted.isNotNull).toBe(false)
+    expect(wrapper.vm.$v.dateFormatted.isValidFormat).toBe(false)
     expect(wrapper.vm.$v.dateFormatted.isValidCodDate).toBe(false)
+    expect(wrapper.find('.validationErrorInfo').exists()).toBe(false)
+
+    // set a date before Min Date
+    wrapper.setData({ date: '2019-05-04' })
+
+    // verify validators and error message
+    expect(wrapper.vm.$v.dateFormatted.isNotNull).toBe(true)
+    expect(wrapper.vm.$v.dateFormatted.isValidFormat).toBe(true)
+    expect(wrapper.vm.$v.dateFormatted.isValidCodDate).toBe(false)
+    expect(wrapper.find('.validationErrorInfo > span').text())
+      .toContain('Please enter a day between 2019/05/05 and 2019/05/10.')
   })
 })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10319

Note: the _actual_ fix for this bug is [10159](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/10159).

*Description of changes:*
- removed formatting for min and max date in error message
- app version: 4.1.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).