### PR TITLE
Connect Business Summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1164,9 +1164,9 @@
       }
     },
     "@bcrs-shared-components/bread-crumb": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/bread-crumb/-/bread-crumb-1.0.1.tgz",
-      "integrity": "sha512-2Xmv0MOWvUqaRR1Duw1JLXMT9YeHl97qrRpeJ6grqXrNvjmkBhBEIJgIyEFfihzxrk3eHR6w6GUy1nUEpu0AvQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/bread-crumb/-/bread-crumb-1.0.2.tgz",
+      "integrity": "sha512-yM/ZBAppdi4UW+ppYEXiqonnjhVI0ilwTOvLNj4Xgv3UHQiDkt4TB70HhXg9wFaJ6qfUT9p9eDclUdWde77rRA==",
       "requires": {
         "@bcrs-shared-components/interfaces": "^1.0.28",
         "vue-property-decorator": "^8.4.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "vue-cli-service lint",
     "lint:nofix": "vue-cli-service lint --no-fix",
     "test:e2e": "vue-cli-service test:e2e",
-    "test:unit": "vue-cli-service test:unit --testPathPattern",
+    "test:unit": "vue-cli-service test:unit --testPathPattern  --coverage",
     "test:unit-silent": "vue-cli-service test:unit --silent",
     "test:debug": "node --inspect-brk node_modules/.bin/vue-cli-service test:unit --testPathPattern --no-cache --watch --runInBand"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",
@@ -10,13 +10,13 @@
     "lint": "vue-cli-service lint",
     "lint:nofix": "vue-cli-service lint --no-fix",
     "test:e2e": "vue-cli-service test:e2e",
-    "test:unit": "vue-cli-service test:unit --testPathPattern  --coverage",
+    "test:unit": "vue-cli-service test:unit --testPathPattern",
     "test:unit-silent": "vue-cli-service test:unit --silent",
     "test:debug": "node --inspect-brk node_modules/.bin/vue-cli-service test:unit --testPathPattern --no-cache --watch --runInBand"
   },
   "dependencies": {
     "@babel/compat-data": "^7.11.0",
-    "@bcrs-shared-components/bread-crumb": "^1.0.1",
+    "@bcrs-shared-components/bread-crumb": "^1.0.2",
     "@bcrs-shared-components/corp-type-module": "1.0.3",
     "@bcrs-shared-components/court-order-poa": "1.0.14",
     "@bcrs-shared-components/enums": "1.0.14",

--- a/src/App.vue
+++ b/src/App.vue
@@ -840,7 +840,7 @@ export default {
       this.showSpinner = true
       const summaryDocument: DocumentIF = {
         title: 'Summary',
-        filename: `${this.businessId} - Summary - ${this.getCurrentDate}.pdf`,
+        filename: `${this.businessId} Summary - ${this.getCurrentDate}.pdf`,
         link: `businesses/${this.businessId}/documents/summary`
       }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,12 @@
       attach="#app"
     />
 
+    <DownloadErrorDialog
+      :dialog="downloadErrorDialog"
+      @close="downloadErrorDialog=false"
+      attach="#app"
+    />
+
     <BusinessAuthErrorDialog
       :dialog="businessAuthErrorDialog"
       @exit="onClickExit()"
@@ -73,6 +79,7 @@
         <EntityInfo
           @confirmDissolution="confirmDissolutionDialog = true"
           @notInGoodStanding="nigsMessage = $event; notInGoodStandingDialog = true"
+          @downloadBusinessSummary="downloadBusinessSummary()"
         />
         <router-view />
       </main>
@@ -102,6 +109,7 @@ import {
   BusinessAuthErrorDialog,
   ConfirmDissolution,
   DashboardUnavailableDialog,
+  DownloadErrorDialog,
   NameRequestAuthErrorDialog,
   NameRequestInvalidDialog,
   NotInGoodStandingDialog
@@ -121,7 +129,7 @@ import {
   LegalApiMixin,
   NameRequestMixin
 } from '@/mixins'
-import { ApiFilingIF, ApiTaskIF, BreadcrumbIF, BusinessIF, TaskTodoIF } from '@/interfaces'
+import { ApiFilingIF, ApiTaskIF, BreadcrumbIF, BusinessIF, DocumentIF, TaskTodoIF } from '@/interfaces'
 import {
   CorpTypeCd,
   DissolutionTypes,
@@ -146,6 +154,7 @@ export default {
   data () {
     return {
       confirmDissolutionDialog: false,
+      downloadErrorDialog: false,
       dataLoaded: false,
       dashboardUnavailableDialog: false,
       businessAuthErrorDialog: false,
@@ -178,6 +187,7 @@ export default {
     BreadCrumb,
     ConfirmDissolution,
     DashboardUnavailableDialog,
+    DownloadErrorDialog,
     BusinessAuthErrorDialog,
     NameRequestAuthErrorDialog,
     NameRequestInvalidDialog,
@@ -823,6 +833,23 @@ export default {
         this.nameRequestInvalidDialog = false
         this.fetchData()
       }
+    },
+
+    /** Request and Download Business Summary Document. */
+    async downloadBusinessSummary (): Promise<void> {
+      this.showSpinner = true
+      const summaryDocument: DocumentIF = {
+        title: 'Summary',
+        filename: `${this.businessId} - Summary - ${this.getCurrentDate}.pdf`,
+        link: `businesses/${this.businessId}/documents/summary`
+      }
+
+      await this.fetchDocument(summaryDocument).catch(error => {
+        // eslint-disable-next-line no-console
+        console.log('fetchDocument() error =', error)
+        this.downloadErrorDialog = true
+      })
+      this.showSpinner = false
     }
   },
 

--- a/src/components/Dashboard/FilingHistoryList/PendingFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/PendingFiling.vue
@@ -12,12 +12,6 @@
     <p>If this issue persists, please contact us.</p>
 
     <ContactInfo class="mt-4" />
-
-    <div class="to-dashboard-container text-center mt-6">
-      <v-btn color="primary" @click.native.stop="returnToDashboard()">
-        <span>Return to Dashboard</span>
-      </v-btn>
-    </div>
   </div>
 </template>
 
@@ -41,15 +35,6 @@ export default class PendingFiling extends Mixins(EnumMixin) {
     if (this.isTypeAlteration(this.filing)) return FilingNames.ALTERATION
     if (this.filing.displayName) return this.filing.displayName
     return 'Filing'
-  }
-
-  /** The Manage Businesses URL string. */
-  private get manageBusinessesUrl (): string {
-    return sessionStorage.getItem('AUTH_WEB_URL') + 'business'
-  }
-
-  private returnToDashboard (): void {
-    window.location.assign(this.manageBusinessesUrl) // assume URL is always reachable
   }
 }
 </script>

--- a/src/components/EntityInfo.vue
+++ b/src/components/EntityInfo.vue
@@ -31,7 +31,7 @@
               <v-chip class="primary mt-n1 ml-4 pointer-events-none" small label text-color="white">
                 <strong>HISTORICAL</strong>
               </v-chip>
-              <span class="font-14 ml-3 mr-3">{{reasonText || 'Unknown Reason'}}</span>
+              <span class="font-14 mx-3">{{reasonText || 'Unknown Reason'}}</span>
             </span>
 
             <template v-else>

--- a/src/components/EntityInfo.vue
+++ b/src/components/EntityInfo.vue
@@ -31,7 +31,7 @@
               <v-chip class="primary mt-n1 ml-4 pointer-events-none" small label text-color="white">
                 <strong>HISTORICAL</strong>
               </v-chip>
-              <span class="font-14 ml-3">{{reasonText || 'Unknown Reason'}}</span>
+              <span class="font-14 ml-3 mr-3">{{reasonText || 'Unknown Reason'}}</span>
             </span>
 
             <template v-else>
@@ -83,9 +83,10 @@
                   </v-tooltip>
                 </v-btn>
               </span>
+            </template>
 
-              <!-- Download Business Summary -->
-              <span v-if="isAllowed(AllowableActions.DOWNLOAD_BUSINESS_SUMMARY)">
+            <!-- Download Business Summary -->
+            <span v-if="isAllowed(AllowableActions.DOWNLOAD_BUSINESS_SUMMARY)">
                 <v-tooltip top content-class="top-tooltip">
                   <template v-slot:activator="{ on }">
                     <v-btn
@@ -101,8 +102,7 @@
                   View and download a summary of information about the {{ entityTitle }}, including office addresses
                   and directors.
                 </v-tooltip>
-              </span>
-            </template>
+            </span>
           </menu>
         </v-col>
 
@@ -176,8 +176,7 @@
 import { Component, Emit, Mixins } from 'vue-property-decorator'
 import { State, Getter } from 'vuex-class'
 import { AllowableActionsMixin, CommonMixin, DateMixin, EnumMixin } from '@/mixins'
-import { AllowableActions, CorpTypeCd, Routes, FilingNames, NigsMessage } from '@/enums'
-import { BreadcrumbIF } from '@/interfaces'
+import { AllowableActions, CorpTypeCd, FilingNames, NigsMessage } from '@/enums'
 import { StaffComments } from '@bcrs-shared-components/staff-comments'
 import axios from '@/axios-auth'
 
@@ -286,10 +285,9 @@ export default class EntityInfo extends Mixins(AllowableActionsMixin, CommonMixi
     window.location.assign(this.businessProfileUrl) // assume URL is always reachable
   }
 
-  /** Downloads business summary PDF. */
-  private downloadBusinessSummary (): void {
-    // FUTURE
-  }
+  // Pass prompt downloads business summary event to parent. */
+  @Emit('downloadBusinessSummary')
+  private downloadBusinessSummary (): void {}
 
   // Pass confirm dissolution event to parent.
   @Emit('confirmDissolution')

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -416,3 +416,43 @@ describe('EntityInfo - Click Tests - Dissolutions', () => {
     expect(wrapper.emitted().notInGoodStanding).toEqual([['dissolve']])
   })
 })
+
+describe('EntityInfo - Click Tests - Business Summary', () => {
+  // mock the mixin to always return True
+  const AllowableActionsMixin: any = {
+    methods: {
+      isAllowed: () => true
+    }
+  }
+
+  it('displays the Business Summary button', async () => {
+    // mount the component and wait for everything to stabilize
+    const wrapper = mount(EntityInfo, {
+      store,
+      vuetify,
+      mixins: [AllowableActionsMixin]
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.find('#download-summary-button').exists()).toBe(true)
+  })
+
+  it('emits the download business summary event', async () => {
+    const router = mockRouter.mock()
+
+    // mount the component and wait for everything to stabilize
+    const wrapper: any = mount(EntityInfo, {
+      store,
+      vuetify,
+      router,
+      mixins: [AllowableActionsMixin]
+    })
+    await Vue.nextTick()
+
+    wrapper.find('#download-summary-button').trigger('click')
+    await Vue.nextTick()
+
+    // verify emit event
+    expect(wrapper.emitted().downloadBusinessSummary).toEqual([[]])
+  })
+})

--- a/tests/unit/PendingFiling.spec.ts
+++ b/tests/unit/PendingFiling.spec.ts
@@ -33,7 +33,6 @@ describe('Pending Filing', () => {
     expect(paragraphs.at(0).text()).toContain('This Filing is paid')
     expect(paragraphs.at(1).text()).toContain('If this issue persists')
     expect(wrapper.find(ContactInfo).exists()).toBe(true)
-    expect(wrapper.find('.to-dashboard-container').exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -59,7 +58,6 @@ describe('Pending Filing', () => {
     expect(paragraphs.at(2).text()).toContain('Pursuant to a Plan of Arrangement')
     expect(paragraphs.at(3).text()).toContain('If this issue persists')
     expect(wrapper.find(ContactInfo).exists()).toBe(true)
-    expect(wrapper.find('.to-dashboard-container').exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -81,7 +79,6 @@ describe('Pending Filing', () => {
     expect(paragraphs.at(0).text()).toContain('This Incorporation Application is paid')
     expect(paragraphs.at(1).text()).toContain('If this issue persists')
     expect(wrapper.find(ContactInfo).exists()).toBe(true)
-    expect(wrapper.find('.to-dashboard-container').exists()).toBe(true)
 
     wrapper.destroy()
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10619 & /bcgov/entity#10150

*Description of changes:*
* Connects Download business summary btn to request for document
* Adds unit tests for btn
* Relocate summary btn to present for all business states (other than Temp Reg), ie active & historical
* Remove the 'Goto Dashboard' Btn and functionality from the pending filing in the filing history list

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
