### PR TITLE
Hide Show Documents Button in the Filing History for filing with no documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.3.11",
+  "version": "4.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.3.11",
+  "version": "4.3.12",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -172,6 +172,7 @@
                   outlined
                   :ripple=false
                   @click.stop="togglePanel(index, filing)"
+                  v-show="displayAction(filing)"
                 >
                   <span v-if="filing.availableOnPaperOnly" class="app-blue">
                     {{(panel === index) ? "Close" : "Request a Copy"}}
@@ -416,6 +417,11 @@ export default class FilingHistoryList extends Mixins(
   /** The Business ID string. */
   private get businessId (): string {
     return sessionStorage.getItem('BUSINESS_ID')
+  }
+
+  /** Returns whether the action button is visible or not. */
+  private displayAction (filing): string {
+    return filing.availableOnPaperOnly || filing.isTypeStaff || filing.documentsLink
   }
 
   private loadData (): void {

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -179,7 +179,7 @@
                   <span v-else-if="filing.isTypeStaff" class="app-blue">
                     {{(panel === index) ? "Hide" : "View"}}
                   </span>
-                  <span v-else class="app-blue">
+                  <span v-else-if="filing.documentsLink" class="app-blue">
                     {{(panel === index) ? "Hide Documents" : "View Documents"}}
                   </span>
                 </v-btn>

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -1338,6 +1338,7 @@ describe('Filing History List - paper only and other filings', () => {
         status: 'PAID',
         submittedDate: '2020-03-24 19:20:05 GMT',
         submitter: 'Cameron',
+        documentsLink: 'http://test',
         data: {
           alteration: {
             fromLegalType: 'BC',
@@ -1365,6 +1366,8 @@ describe('Filing History List - paper only and other filings', () => {
     expect(spans.at(2).text()).toContain('EFFECTIVE as of Dec 31, 2099')
     expect(vm.panel).toBeNull() // no row is expanded
     expect(wrapper.find('.no-results').exists()).toBe(false)
+
+    jest.spyOn(vm, 'loadDocuments').mockImplementation(() => Promise.resolve([]))
 
     // verify View Documents button and toggle panel
     const detailsBtn = wrapper.find('.expand-btn')
@@ -1401,6 +1404,7 @@ describe('Filing History List - paper only and other filings', () => {
         status: 'PAID',
         submittedDate: '2020-03-24 19:20:05 GMT',
         submitter: 'Cameron',
+        documentsLink: 'http://test',
         data: {
           alteration: {
             fromLegalType: 'BC',
@@ -1429,6 +1433,7 @@ describe('Filing History List - paper only and other filings', () => {
     expect(vm.panel).toBeNull() // no row is expanded
     expect(wrapper.find('.no-results').exists()).toBe(false)
 
+    jest.spyOn(vm, 'loadDocuments').mockImplementation(() => Promise.resolve([]))
     // verify View Documents button and toggle panel
     const detailsBtn = wrapper.find('.expand-btn')
     expect(detailsBtn.text()).toContain('View Documents')
@@ -1464,7 +1469,7 @@ describe('Filing History List - paper only and other filings', () => {
         status: 'COMPLETED',
         submittedDate: '2020-03-24 19:20:05 GMT',
         submitter: 'Cameron',
-        'documentsLink': 'abc',
+        'documentsLink': 'http://test',
         data: {
           alteration: {
             fromLegalType: 'BC',
@@ -1491,6 +1496,8 @@ describe('Filing History List - paper only and other filings', () => {
     expect(spans.at(0).text()).toContain('EFFECTIVE as of Mar 24, 2020')
     expect(vm.panel).toBeNull() // no row is expanded
     expect(wrapper.find('.no-results').exists()).toBe(false)
+
+    jest.spyOn(vm, 'loadDocuments').mockImplementation(() => Promise.resolve([]))
 
     // verify View Documents button and toggle panel
     const detailsBtn = wrapper.find('.expand-btn')
@@ -1963,6 +1970,35 @@ describe('Filing History List - detail comments', () => {
     expect(wrapper.findAll('.details-list .detail-body').length).toBe(2)
 
     sinon.restore()
+    wrapper.destroy()
+  })
+})
+
+describe('Filing History List - documents', () => {
+  const FILING_WITH_DOCUMENTS_LINK = {
+    availableOnPaperOnly: false,
+    businessIdentifier: 'CP0001191',
+    commentsCounts: 0,
+    displayName: 'Involuntary Dissolution',
+    effectiveDate: '2019-12-13 00:00:00 GMT',
+    filingId: 111,
+    isFutureEffective: false,
+    name: 'Involuntary Dissolution',
+    status: 'COMPLETED',
+    submittedDate: '2019-04-06 19:22:59.00 GMT',
+    submitter: 'Cameron'
+  }
+
+  it('does not display the view documents button when no documents are present on a filing', async () => {
+    // init store
+    store.state.filings = [FILING_WITH_DOCUMENTS_LINK]
+
+    const wrapper = mount(FilingHistoryList, { store, vuetify })
+    await Vue.nextTick()
+    console.log(wrapper.find('.expand-btn').html())
+    // verify that View Documents Button is not rendered
+    const button = wrapper.find('.expand-btn')
+    expect(button.text()).toEqual('')
     wrapper.destroy()
   })
 })

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -1975,7 +1975,7 @@ describe('Filing History List - detail comments', () => {
 })
 
 describe('Filing History List - documents', () => {
-  const FILING_WITH_DOCUMENTS_LINK = {
+  const FILING_WITHOUT_DOCUMENTS_LINK = {
     availableOnPaperOnly: false,
     businessIdentifier: 'CP0001191',
     commentsCounts: 0,
@@ -1991,7 +1991,7 @@ describe('Filing History List - documents', () => {
 
   it('does not display the view documents button when no documents are present on a filing', async () => {
     // init store
-    store.state.filings = [FILING_WITH_DOCUMENTS_LINK]
+    store.state.filings = [FILING_WITHOUT_DOCUMENTS_LINK]
 
     const wrapper = mount(FilingHistoryList, { store, vuetify })
     await Vue.nextTick()

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -259,12 +259,16 @@ describe('Filing History List - misc functionality', () => {
         name: 'annualReport',
         status: 'COMPLETED',
         submittedDate: '2019-06-02',
-        submitter: 'Cameron'
+        submitter: 'Cameron',
+        documentsLink: 'http://test'
       }
     ]
 
     const wrapper = mount(FilingHistoryList, { store, vuetify })
     const vm = wrapper.vm as any
+    jest.spyOn(vm, 'loadDocuments').mockImplementation(() => (
+      Promise.resolve([])
+    ))
     await Vue.nextTick()
 
     // verify no row is expanded
@@ -1140,7 +1144,8 @@ describe('Filing History List - incorporation applications', () => {
         name: 'incorporationApplication',
         status: 'COMPLETED',
         submittedDate: '2020-04-28 19:14:45 GMT',
-        submitter: 'Cameron'
+        submitter: 'Cameron',
+        documentsLink: 'http://test'
       }
     ]
 
@@ -1168,6 +1173,7 @@ describe('Filing History List - incorporation applications', () => {
     // verify View Documents button
     const button = wrapper.find('.expand-btn')
     expect(button.text()).toContain('View Documents')
+    jest.spyOn(vm, 'loadDocuments').mockImplementation(() => Promise.resolve([]))
 
     // expand details
     button.trigger('click')
@@ -1271,6 +1277,7 @@ describe('Filing History List - paper only and other filings', () => {
         status: 'COMPLETED',
         submittedDate: '2020-03-24 19:20:05 GMT',
         submitter: 'Cameron',
+        documentsLink: 'http://test',
         data: {
           order: {}
         }
@@ -1293,6 +1300,8 @@ describe('Filing History List - paper only and other filings', () => {
     expect(spans.at(0).text()).toContain('EFFECTIVE as of Mar 24, 2020')
     expect(vm.panel).toBeNull() // no row is expanded
     expect(wrapper.find('.no-results').exists()).toBe(false)
+
+    jest.spyOn(vm, 'loadDocuments').mockImplementation(() => Promise.resolve([]))
 
     // verify View Documents button and toggle panel
     const detailsBtn = wrapper.find('.expand-btn')
@@ -1455,6 +1464,7 @@ describe('Filing History List - paper only and other filings', () => {
         status: 'COMPLETED',
         submittedDate: '2020-03-24 19:20:05 GMT',
         submitter: 'Cameron',
+        'documentsLink': 'abc',
         data: {
           alteration: {
             fromLegalType: 'BC',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10934

*Description of changes:*

- Updated the filing history list component to show the view documents button only if documentsLink exists and has a non null value
- Updated tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
