### PR TITLE
Filing UI not displaying FED alteration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.3.14",
+  "version": "4.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.3.14",
+  "version": "4.3.15",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -556,6 +556,7 @@ export default class FilingHistoryList extends Mixins(
           this.isEffectiveDatePast(effectiveDate)
         )
 
+        // data is available only for a completed filing
         if (item.isCompletedAlteration) {
           item.courtOrderNumber = filing.data.order?.fileNumber || ''
           item.isArrangement = this.isEffectOfOrderPlanOfArrangement(filing.data.order?.effectOfOrder)

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -556,10 +556,12 @@ export default class FilingHistoryList extends Mixins(
           this.isEffectiveDatePast(effectiveDate)
         )
 
-        item.courtOrderNumber = filing.data.order?.fileNumber || ''
-        item.isArrangement = this.isEffectOfOrderPlanOfArrangement(filing.data.order?.effectOfOrder)
-        item.toLegalType = filing.data.alteration?.toLegalType || null
-        item.fromLegalType = filing.data.alteration?.fromLegalType || null
+        if (item.isCompletedAlteration) {
+          item.courtOrderNumber = filing.data.order?.fileNumber || ''
+          item.isArrangement = this.isEffectOfOrderPlanOfArrangement(filing.data.order?.effectOfOrder)
+          item.toLegalType = filing.data.alteration?.toLegalType || null
+          item.fromLegalType = filing.data.alteration?.fromLegalType || null
+        }
       }
 
       // add properties for Dissolutions


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11202

*Description of changes:*
The data section is available in the filings json only for a completed filing. Added a check for that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
