### PR TITLE
9014 HTML tags show up in the warning popup window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/dialogs/PaymentErrorDialog.vue
+++ b/src/components/dialogs/PaymentErrorDialog.vue
@@ -29,8 +29,8 @@
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <ul>
-            <li v-for="(error, index) in errors" :key="index">
-              {{error.message}}
+            <li v-for="(error, index) in errors[0].message.split('<br/>')" :key="index">
+              {{ error }}
             </li>
           </ul>
         </div>

--- a/src/components/dialogs/PaymentErrorDialog.vue
+++ b/src/components/dialogs/PaymentErrorDialog.vue
@@ -29,8 +29,8 @@
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <div v-for="(error, index) in errors" :key="index" class="d-flex">
-            <span id="error-bullet" class="flex-shrink-0">
-              <v-icon id="error-circle">mdi-circle-medium</v-icon>
+            <span class="flex-shrink-0 error-bullet">
+              <v-icon class="error-circle">mdi-circle-medium</v-icon>
             </span>
             <span class="flex-grow-1" v-html="error.message" />
           </div>
@@ -106,12 +106,12 @@ export default class PaymentErrorDialog extends Vue {
 </script>
 
 <style scoped>
-  #error-bullet {
+  .error-bullet {
     padding-left: 1.4px;
     padding-right: 5px;
   }
 
-  #error-circle {
+  .error-circle {
     font-size: 18px;
   }
 </style>

--- a/src/components/dialogs/PaymentErrorDialog.vue
+++ b/src/components/dialogs/PaymentErrorDialog.vue
@@ -39,11 +39,12 @@
         <!-- display warnings-->
         <div class="font-15 mb-4" v-if="numWarnings > 0">
           <p>Please note the following warnings:</p>
-          <ul>
-            <li v-for="(warning, index) in warnings" :key="index">
-              {{warning.message}}
-            </li>
-          </ul>
+          <div v-for="(warning, index) in warnings" :key="index" class="d-flex">
+            <span class="flex-shrink-0 error-bullet">
+              <v-icon class="error-circle">mdi-circle-medium</v-icon>
+            </span>
+            <span class="flex-grow-1" v-html="warning.message" />
+          </div>
         </div>
 
         <template v-if="!isRoleStaff">

--- a/src/components/dialogs/PaymentErrorDialog.vue
+++ b/src/components/dialogs/PaymentErrorDialog.vue
@@ -29,9 +29,7 @@
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <div v-for="(error, index) in errors" :key="index" class="d-flex">
-            <span class="flex-shrink-0 error-bullet">
-              <v-icon class="error-circle">mdi-circle-medium</v-icon>
-            </span>
+            <span class="flex-shrink-0"><v-icon>mdi-circle-medium</v-icon></span>
             <span class="flex-grow-1" v-html="error.message" />
           </div>
         </div>
@@ -40,9 +38,7 @@
         <div class="font-15 mb-4" v-if="numWarnings > 0">
           <p>Please note the following warnings:</p>
           <div v-for="(warning, index) in warnings" :key="index" class="d-flex">
-            <span class="flex-shrink-0 error-bullet">
-              <v-icon class="error-circle">mdi-circle-medium</v-icon>
-            </span>
+            <span class="flex-shrink-0"><v-icon>mdi-circle-medium</v-icon></span>
             <span class="flex-grow-1" v-html="warning.message" />
           </div>
         </div>
@@ -105,14 +101,3 @@ export default class PaymentErrorDialog extends Vue {
   }
 }
 </script>
-
-<style scoped>
-  .error-bullet {
-    padding-left: 1.4px;
-    padding-right: 5px;
-  }
-
-  .error-circle {
-    font-size: 18px;
-  }
-</style>

--- a/src/components/dialogs/PaymentErrorDialog.vue
+++ b/src/components/dialogs/PaymentErrorDialog.vue
@@ -28,11 +28,12 @@
         <!-- display errors -->
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
-          <ul>
-            <li v-for="(error, index) in errors[0].message.split('<br/>')" :key="index">
-              {{ error }}
-            </li>
-          </ul>
+          <div v-for="(error, index) in errors" :key="index" class="d-flex">
+            <span id="error-bullet" class="flex-shrink-0">
+              <v-icon id="error-circle">mdi-circle-medium</v-icon>
+            </span>
+            <span class="flex-grow-1" v-html="error.message" />
+          </div>
         </div>
 
         <!-- display warnings-->
@@ -103,3 +104,14 @@ export default class PaymentErrorDialog extends Vue {
   }
 }
 </script>
+
+<style scoped>
+  #error-bullet {
+    padding-left: 1.4px;
+    padding-right: 5px;
+  }
+
+  #error-circle {
+    font-size: 18px;
+  }
+</style>

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -138,4 +138,80 @@ describe('Payment Error Dialog', () => {
 
     wrapper.destroy()
   })
+
+  it('renders PAD error messages correctly when they are present', () => {
+    store.state.keycloakRoles = []
+
+    const wrapper = shallowMount(PaymentErrorDialog,
+      {
+        propsData: {
+          dialog: true,
+          errors: [{ message: 'error msg' }]
+        },
+        store,
+        vuetify
+      })
+    const vm: any = wrapper.vm
+
+    expect(vm.numErrors).toBe(1)
+    expect(wrapper.find('#dialog-title').text()).toBe('Unable to Process Payment')
+    expect(wrapper.find('#dialog-text').text()).toContain('This Filing has been')
+    expect(wrapper.find('#dialog-text').text())
+      .toContain('We were unable to process your payment due to the following errors:')
+    expect(wrapper.find('#dialog-text').text()).toContain('error msg')
+    expect(wrapper.find('#dialog-ok-button')).toBeDefined()
+    
+    expect(wrapper.isVisible()).toBe(true)
+
+    expect(wrapper.findAll('p').length).toBe(3)
+    expect(wrapper.findAll('p').at(0).text()).toContain('We are unable to process your payment')
+    expect(wrapper.findAll('p').at(1).text()).toContain(
+      'We were unable to process your payment due to the following errors:'
+    )
+    expect(wrapper.findAll('p').at(2).text()).toContain('If this error persists')
+    expect(wrapper.findAll('li').length).toBe(0)
+    expect(wrapper.findAll('span').length).toBe(2)
+    expect(wrapper.findAll('span').at(1).text()).toContain('error msg')
+
+    // expect(wrapper.findComponent(ErrorContact).exists()).toBe(true)
+    expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('renders PAD warning messages correctly when they are present', () => {
+    store.state.keycloakRoles = []
+
+    const wrapper = shallowMount(PaymentErrorDialog,
+      {
+        propsData: {
+          dialog: true,
+          warnings: [
+            { message: 'Test Warning 1' },
+            { message: 'Test Warning 2' }
+        ]
+      },
+        store,
+        vuetify
+      })
+    const vm: any = wrapper.vm
+
+    expect(vm.numWarnings).toBe(2)
+
+    expect(wrapper.isVisible()).toBe(true)
+    expect(wrapper.find('#dialog-title').text()).toBe('Unable to Process Payment')
+    expect(wrapper.findAll('p').length).toBe(3)
+    expect(wrapper.findAll('p').at(0).text()).toContain('We are unable to process your payment')
+    expect(wrapper.findAll('p').at(1).text()).toContain('Please note the following warnings')
+    expect(wrapper.findAll('li').length).toBe(2)
+    expect(wrapper.findAll('li').at(0).text()).toBe('Test Warning 1')
+    expect(wrapper.findAll('li').at(1).text()).toBe('Test Warning 2')
+    expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
+    expect(wrapper.find('#dialog-okay-button').exists()).toBe(false)
+
+    // expect(wrapper.findComponent(ErrorContact).exists()).toBe(true)
+    expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
+
+    wrapper.destroy()
+  })
 })

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -203,9 +203,10 @@ describe('Payment Error Dialog', () => {
     expect(wrapper.findAll('p').length).toBe(3)
     expect(wrapper.findAll('p').at(0).text()).toContain('We are unable to process your payment')
     expect(wrapper.findAll('p').at(1).text()).toContain('Please note the following warnings')
-    expect(wrapper.findAll('li').length).toBe(2)
-    expect(wrapper.findAll('li').at(0).text()).toBe('Test Warning 1')
-    expect(wrapper.findAll('li').at(1).text()).toBe('Test Warning 2')
+    expect(wrapper.findAll('li').length).toBe(0)
+    expect(wrapper.findAll('span').length).toBe(4)
+    expect(wrapper.findAll('span').at(1).text()).toContain('Test Warning 1')
+    expect(wrapper.findAll('span').at(3).text()).toContain('Test Warning 2')
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
     expect(wrapper.find('#dialog-okay-button').exists()).toBe(false)
 

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -139,7 +139,7 @@ describe('Payment Error Dialog', () => {
     wrapper.destroy()
   })
 
-  it('renders PAD error messages correctly when they are present', () => {
+  it('renders error messages correctly when they are present', () => {
     store.state.keycloakRoles = []
 
     const wrapper = shallowMount(PaymentErrorDialog,
@@ -173,13 +173,12 @@ describe('Payment Error Dialog', () => {
     expect(wrapper.findAll('span').length).toBe(2)
     expect(wrapper.findAll('span').at(1).text()).toContain('error msg')
 
-    // expect(wrapper.findComponent(ErrorContact).exists()).toBe(true)
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
 
     wrapper.destroy()
   })
 
-  it('renders PAD warning messages correctly when they are present', () => {
+  it('renders warning messages correctly when they are present', () => {
     store.state.keycloakRoles = []
 
     const wrapper = shallowMount(PaymentErrorDialog,
@@ -210,7 +209,6 @@ describe('Payment Error Dialog', () => {
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
     expect(wrapper.find('#dialog-okay-button').exists()).toBe(false)
 
-    // expect(wrapper.findComponent(ErrorContact).exists()).toBe(true)
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
 
     wrapper.destroy()


### PR DESCRIPTION
Issue #: [/bcgov/entity#9014](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/9014)

Description of changes:
When a payment error occurred, a popup window for "Unable to process payment" show up.
tags are included in the text in the popup window, and they need to be removed.

- [x] Filings UI


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
