### PR TITLE
10826 Fix the Annual Report AGM validation message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/AnnualReport/AGMDate.vue
+++ b/src/components/AnnualReport/AGMDate.vue
@@ -33,8 +33,7 @@
             <v-date-picker
               data-test-id="agm-date-picker"
               v-model="datePicker"
-              :min=arMinDate
-              :max=arMaxDate
+              :min=localMaxDate
               no-title
               @input="menu=false"
               @change="onDatePickerChanged($event)"
@@ -147,8 +146,15 @@ export default class AgmDate extends Mixins(DateMixin) {
   @Prop({ default: true })
   readonly allowCod: boolean
 
+  /** last address change date */
+  @Prop({ default: '' })
+  readonly lastACD: string
+
+  /** last director change date */
+  @Prop({ default: '' })
+  readonly lastDCD: string
+
   @State ARFilingYear!: number
-  @State arMinDate!: string
   @State arMaxDate!: string
   @Getter isCoop!: boolean
   @Getter getCurrentDate!: string
@@ -160,6 +166,7 @@ export default class AgmDate extends Mixins(DateMixin) {
   private agmExtension = false // whether checkbox is checked
   private noAgm = false // whether checkbox is checked
   private backupDate = '' // for toggling No AGM
+  private localMaxDate = '' // last date of coa, cod and arMaxDate
 
   /** The array of validations rule(s) for the AGM Date text field. */
   private get agmDateRules (): Array<Function> {
@@ -204,6 +211,8 @@ export default class AgmDate extends Mixins(DateMixin) {
   /** Called when component is mounted. */
   private mounted (): void {
     // set date picker but not text field
+    let lastEffectiveDate = this.latestYyyyMmDd(this.lastACD, this.lastDCD)
+    this.localMaxDate = this.latestYyyyMmDd(this.arMaxDate, lastEffectiveDate)
     this.datePicker = this.newAgmDate || this.arMaxDate
   }
 

--- a/src/components/AnnualReport/AGMDate.vue
+++ b/src/components/AnnualReport/AGMDate.vue
@@ -213,7 +213,7 @@ export default class AgmDate extends Mixins(DateMixin) {
     // set date picker but not text field
     let lastEffectiveDate = this.latestYyyyMmDd(this.lastACD, this.lastDCD)
     this.localMaxDate = this.latestYyyyMmDd(this.arMaxDate, lastEffectiveDate)
-    this.datePicker = this.newAgmDate || this.arMaxDate
+    this.datePicker = this.newAgmDate || this.localMaxDate
   }
 
   /** Called when prop changes (ie, due to resuming a draft). */

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -98,6 +98,8 @@
                   :newNoAgm="newNoAgm"
                   :allowCoa="allowChange('coa')"
                   :allowCod="allowChange('cod')"
+                  :lastACD="lastAddressChangeDate"
+                  :lastDCD="lastDirectorChangeDate"
                   @agmDate="onAgmDateChange($event)"
                   @agmExtension="onAgmExtensionChange($event)"
                   @noAgm="onNoAgmChange($event)"


### PR DESCRIPTION
Issue #: [/bcgov/entity#10826](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/10826)

*Description of changes:*

The AGM date currently looks at last COA, COD and Annual Report Dates. The AGM date should be after all these dates.

However, the validation message is confusing because it gives an impression that you changed address/directors after the selected AGM date.

Suggested fix: We may have to change the wording to also reflect that the AGM date should be after the AGM date of previous AR filings. UX/Business to provide actual wording

Cc: [@lmcclung](https://github.com/lmcclung)

- [ ] Update the warning message (red text under the date picker) that triggers when you enter an AGM date that is before another filing's effective date
- [x] Implementation of validation that ensures the selected date is after any of the effective dates among COA, COD and ARD.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
