### PR TITLE
12024 Filings UI - Display "Not Entered" for missing data on address and prop/part components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FirmsAddressList.vue
+++ b/src/components/Dashboard/FirmsAddressList.vue
@@ -34,14 +34,14 @@
         <div v-else class="pt-4 pb-4">
           <v-list class="pt-0 pb-0" v-if="businessAddress">
             <!-- Delivery Address -->
-            <v-list-item class="delivery-address-list-item" v-if="businessAddress.deliveryAddress">
+            <v-list-item class="delivery-address-list-item">
               <v-list-item-icon class="address-icon mr-0">
                 <v-icon color="primary">mdi-truck</v-icon>
               </v-list-item-icon>
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Delivery Address</v-list-item-title>
                 <v-list-item-subtitle>
-                  <ul class="address-subtitle pre-line">
+                  <ul class="address-subtitle pre-line" v-if="businessAddress.deliveryAddress">
                     <li class="address-line1">{{ businessAddress.deliveryAddress.streetAddress }}</li>
                     <li class="address-line2">{{ businessAddress.deliveryAddress.streetAddressAdditional }}</li>
                     <li class="address-line3">
@@ -53,35 +53,41 @@
                       <span>{{ getCountryName(businessAddress.deliveryAddress.addressCountry) }}</span>
                     </li>
                   </ul>
+                  <ul class="address-subtitle pre-line" v-else>
+                    <li class="address-line1">Not Entered</li>
+                  </ul>
                 </v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
 
             <!-- Mailing Address -->
-            <v-list-item class="mailing-address-list-item" v-if="businessAddress.mailingAddress">
+            <v-list-item class="mailing-address-list-item">
               <v-list-item-icon class="address-icon mr-0">
                 <v-icon color="primary">mdi-email-outline</v-icon>
               </v-list-item-icon>
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Mailing Address</v-list-item-title>
                 <v-list-item-subtitle>
-                  <div
-                    class="same-as-above"
-                    v-if="isSame(businessAddress.deliveryAddress, businessAddress.mailingAddress, ['id'])">
-                    <span>Same as above</span>
+                  <div class="same-as-above" v-if="businessAddress.mailingAddress">
+                    <span v-if="isSame(businessAddress.deliveryAddress, businessAddress.mailingAddress, ['id'])">
+                      Same as above
+                    </span>
+                    <ul v-else class="address-subtitle pre-line">
+                      <li class="address-line1">{{ businessAddress.mailingAddress.streetAddress }}</li>
+                      <li class="address-line2">{{ businessAddress.mailingAddress.streetAddressAdditional }}</li>
+                      <li class="address-line3">
+                        {{ businessAddress.mailingAddress.addressCity }}
+                        {{ businessAddress.mailingAddress.addressRegion }}
+                        {{ businessAddress.mailingAddress.postalCode }}
+                      </li>
+                      <li class="address-line4">
+                        <span>{{ getCountryName(businessAddress.mailingAddress.addressCountry) }}</span>
+                      </li>
+                    </ul>
                   </div>
-                  <ul v-else class="address-subtitle pre-line">
-                    <li class="address-line1">{{ businessAddress.mailingAddress.streetAddress }}</li>
-                    <li class="address-line2">{{ businessAddress.mailingAddress.streetAddressAdditional }}</li>
-                    <li class="address-line3">
-                      {{ businessAddress.mailingAddress.addressCity }}
-                      {{ businessAddress.mailingAddress.addressRegion }}
-                      {{ businessAddress.mailingAddress.postalCode }}
-                    </li>
-                    <li class="address-line4">
-                      <span>{{ getCountryName(businessAddress.mailingAddress.addressCountry) }}</span>
-                    </li>
-                  </ul>
+                  <div class="same-as-above" v-else>
+                    <span>Not Entered</span>
+                  </div>
                 </v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>

--- a/src/components/Dashboard/FirmsAddressList.vue
+++ b/src/components/Dashboard/FirmsAddressList.vue
@@ -54,7 +54,7 @@
                     </li>
                   </ul>
                   <ul class="address-subtitle pre-line" v-else>
-                    <li class="address-line1">Not Entered</li>
+                    <li class="delivery-address-not-entered">Not Entered</li>
                   </ul>
                 </v-list-item-subtitle>
               </v-list-item-content>
@@ -68,8 +68,9 @@
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Mailing Address</v-list-item-title>
                 <v-list-item-subtitle>
-                  <div class="same-as-above" v-if="businessAddress.mailingAddress">
-                    <span v-if="isSame(businessAddress.deliveryAddress, businessAddress.mailingAddress, ['id'])">
+                  <div v-if="businessAddress.mailingAddress">
+                    <span class="same-as-above"
+                      v-if="isSame(businessAddress.deliveryAddress, businessAddress.mailingAddress, ['id'])">
                       Same as above
                     </span>
                     <ul v-else class="address-subtitle pre-line">
@@ -85,7 +86,7 @@
                       </li>
                     </ul>
                   </div>
-                  <div class="same-as-above" v-else>
+                  <div class="mailing-address-not-entered" v-else>
                     <span>Not Entered</span>
                   </div>
                 </v-list-item-subtitle>

--- a/src/components/Dashboard/FirmsAddressList.vue
+++ b/src/components/Dashboard/FirmsAddressList.vue
@@ -32,7 +32,7 @@
         </div>
 
         <div v-else class="pt-4 pb-4">
-          <v-list class="pt-0 pb-0" v-if="businessAddress">
+          <v-list class="pt-0 pb-0">
             <!-- Delivery Address -->
             <v-list-item class="delivery-address-list-item">
               <v-list-item-icon class="address-icon mr-0">
@@ -40,7 +40,7 @@
               </v-list-item-icon>
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Delivery Address</v-list-item-title>
-                <v-list-item-subtitle>
+                <v-list-item-subtitle v-if="businessAddress">
                   <ul class="address-subtitle pre-line" v-if="businessAddress.deliveryAddress">
                     <li class="address-line1">{{ businessAddress.deliveryAddress.streetAddress }}</li>
                     <li class="address-line2">{{ businessAddress.deliveryAddress.streetAddressAdditional }}</li>
@@ -57,6 +57,11 @@
                     <li class="delivery-address-not-entered">Not Entered</li>
                   </ul>
                 </v-list-item-subtitle>
+                <v-list-item-subtitle v-else>
+                  <ul class="address-subtitle pre-line">
+                    <li class="delivery-address-not-entered">Not Entered</li>
+                  </ul>
+                </v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
 
@@ -67,7 +72,7 @@
               </v-list-item-icon>
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Mailing Address</v-list-item-title>
-                <v-list-item-subtitle>
+                <v-list-item-subtitle v-if="businessAddress">
                   <div v-if="businessAddress.mailingAddress">
                     <span class="same-as-above"
                       v-if="isSame(businessAddress.deliveryAddress, businessAddress.mailingAddress, ['id'])">
@@ -87,6 +92,11 @@
                     </ul>
                   </div>
                   <div class="mailing-address-not-entered" v-else>
+                    <span>Not Entered</span>
+                  </div>
+                </v-list-item-subtitle>
+                <v-list-item-subtitle v-else>
+                  <div class="mailing-address-not-entered">
                     <span>Not Entered</span>
                   </div>
                 </v-list-item-subtitle>

--- a/src/components/Dashboard/ProprietorPartnersListSm.vue
+++ b/src/components/Dashboard/ProprietorPartnersListSm.vue
@@ -5,8 +5,11 @@
     </div>
 
     <v-expansion-panels v-else accordion multiple>
+      <v-expansion-panel class="align-items-top address-panel" v-if="proprietorPartners.length===0">
+        <span class="complete-filing">Complete your filing to display</span>
+      </v-expansion-panel>
       <!-- when grayed out, disable expansion -->
-      <v-expansion-panel class="align-items-top address-panel"
+      <v-expansion-panel class="align-items-top address-panel" v-else
         v-for="(party, index) in proprietorPartners"
         :key="index"
         :disabled="disabled"

--- a/src/components/Dashboard/ProprietorPartnersListSm.vue
+++ b/src/components/Dashboard/ProprietorPartnersListSm.vue
@@ -23,7 +23,9 @@
             <v-list-item class="email-address-list-item">
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Email Address</v-list-item-title>
-                <v-list-item-subtitle>{{ party.officer.email || 'Not Entered'}}</v-list-item-subtitle>
+                <v-list-item-subtitle class="email-address-text">
+                  {{ party.officer.email || 'Not Entered'}}
+                </v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
 
@@ -40,7 +42,7 @@
                     <li class="address-line4">{{ getCountryName(party.deliveryAddress.addressCountry) }}</li>
                   </ul>
                   <ul class="address-subtitle pre-line" v-else>
-                    <li class="address-line1">Not Entered</li>
+                    <li class="delivery-address-not-entered">Not Entered</li>
                   </ul>
                 </v-list-item-subtitle>
               </v-list-item-content>
@@ -50,8 +52,9 @@
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Mailing Address</v-list-item-title>
                 <v-list-item-subtitle>
-                  <div class="same-as-above" v-if="party.mailingAddress">
-                    <span v-if="isSame(party.deliveryAddress, party.mailingAddress, 'id')">
+                  <div v-if="party.mailingAddress">
+                    <span class="same-as-above"
+                      v-if="isSame(party.deliveryAddress, party.mailingAddress, 'id')">
                       Same as above
                     </span>
                     <ul v-else class="address-subtitle pre-line">
@@ -63,7 +66,7 @@
                       <li class="address-line4">{{ getCountryName(party.mailingAddress.addressCountry) }}</li>
                     </ul>
                   </div>
-                  <div class="same-as-above" v-else>
+                  <div class="mailing-address-not-entered" v-else>
                     <span>Not Entered</span>
                   </div>
                 </v-list-item-subtitle>

--- a/src/components/Dashboard/ProprietorPartnersListSm.vue
+++ b/src/components/Dashboard/ProprietorPartnersListSm.vue
@@ -6,10 +6,10 @@
 
     <v-expansion-panels v-else accordion multiple>
       <v-expansion-panel class="align-items-top address-panel" v-if="proprietorPartners.length===0">
-        <span class="complete-filing">Complete your filing to display</span>
+        <span class="complete-filing">Not Entered</span>
       </v-expansion-panel>
       <!-- when grayed out, disable expansion -->
-      <v-expansion-panel class="align-items-top address-panel" v-else
+      <v-expansion-panel class="align-items-top address-panel"
         v-for="(party, index) in proprietorPartners"
         :key="index"
         :disabled="disabled"

--- a/src/components/Dashboard/ProprietorPartnersListSm.vue
+++ b/src/components/Dashboard/ProprietorPartnersListSm.vue
@@ -20,18 +20,18 @@
 
         <v-expansion-panel-content>
           <v-list class="pt-0 pb-0">
-            <v-list-item class="email-address-list-item" v-if="party.officer.email">
+            <v-list-item class="email-address-list-item">
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Email Address</v-list-item-title>
-                <v-list-item-subtitle>{{ party.officer.email }}</v-list-item-subtitle>
+                <v-list-item-subtitle>{{ party.officer.email || 'Not Entered'}}</v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
 
-            <v-list-item class="delivery-address-list-item" v-if="party.deliveryAddress">
+            <v-list-item class="delivery-address-list-item">
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Delivery Address</v-list-item-title>
                 <v-list-item-subtitle>
-                  <ul class="address-subtitle pre-line">
+                  <ul class="address-subtitle pre-line" v-if="party.deliveryAddress">
                     <li class="address-line1">{{ party.deliveryAddress.streetAddress }}</li>
                     <li class="address-line2">{{ party.deliveryAddress.streetAddressAdditional }}</li>
                     <li class="address-line3">{{ party.deliveryAddress.addressCity }}
@@ -39,27 +39,33 @@
                                               {{ party.deliveryAddress.postalCode }}</li>
                     <li class="address-line4">{{ getCountryName(party.deliveryAddress.addressCountry) }}</li>
                   </ul>
+                  <ul class="address-subtitle pre-line" v-else>
+                    <li class="address-line1">Not Entered</li>
+                  </ul>
                 </v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
 
-            <v-list-item class="mailing-address-list-item" v-if="party.mailingAddress">
+            <v-list-item class="mailing-address-list-item">
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Mailing Address</v-list-item-title>
                 <v-list-item-subtitle>
-                  <div class="same-as-above"
-                    v-if="isSame(party.deliveryAddress, party.mailingAddress, 'id')"
-                  >
-                    <span>Same as above</span>
+                  <div class="same-as-above" v-if="party.mailingAddress">
+                    <span v-if="isSame(party.deliveryAddress, party.mailingAddress, 'id')">
+                      Same as above
+                    </span>
+                    <ul v-else class="address-subtitle pre-line">
+                      <li class="address-line1">{{ party.mailingAddress.streetAddress }}</li>
+                      <li class="address-line2">{{ party.mailingAddress.streetAddressAdditional }}</li>
+                      <li class="address-line3">{{ party.mailingAddress.addressCity }}
+                                                {{ party.mailingAddress.addressRegion }}
+                                                {{ party.mailingAddress.postalCode }}</li>
+                      <li class="address-line4">{{ getCountryName(party.mailingAddress.addressCountry) }}</li>
+                    </ul>
                   </div>
-                  <ul v-else class="address-subtitle pre-line">
-                    <li class="address-line1">{{ party.mailingAddress.streetAddress }}</li>
-                    <li class="address-line2">{{ party.mailingAddress.streetAddressAdditional }}</li>
-                    <li class="address-line3">{{ party.mailingAddress.addressCity }}
-                                              {{ party.mailingAddress.addressRegion }}
-                                              {{ party.mailingAddress.postalCode }}</li>
-                    <li class="address-line4">{{ getCountryName(party.mailingAddress.addressCountry) }}</li>
-                  </ul>
+                  <div class="same-as-above" v-else>
+                    <span>Not Entered</span>
+                  </div>
                 </v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>

--- a/tests/unit/AddressListSm.spec.ts
+++ b/tests/unit/AddressListSm.spec.ts
@@ -466,4 +466,33 @@ describe('AddressListSm', () => {
 
     wrapper.destroy()
   })
+
+  it('displays "not entered" message for firm registration', async () => {
+    // init store
+    store.state.entityType = 'SP'
+    store.state.businessAddress = {
+      'deliveryAddress': null,
+      'mailingAddress': null
+    }
+
+    const wrapper = mount(AddressListSm, { store, vuetify })
+    const vm = wrapper.vm as any
+    await Vue.nextTick()
+
+    // Verify delivery address 'Not Entered'
+    expect(vm.$el.querySelector('#business-address-panel .delivery-address-list-item .address-subtitle\
+      .delivery-address-not-entered').textContent).toContain('Not Entered')
+    expect(vm.$el.querySelector('#business-address-panel .delivery-address-list-item .address-line1'))
+      .toBeNull()
+    
+    // verify mailing address 'Not Entered'
+    expect(vm.$el.querySelector('#business-address-panel .mailing-address-list-item .mailing-address-not-entered')
+      .textContent).toContain('Not Entered')
+    expect(vm.$el.querySelector('#business-address-panel .mailing-address-list-item .same-as-above'))
+      .toBeNull()
+    expect(vm.$el.querySelector('#business-address-panel .mailing-address-list-item .address-subtitle .address-line1'))
+      .toBeNull()
+
+    wrapper.destroy()
+  })
 })

--- a/tests/unit/AddressListSm.spec.ts
+++ b/tests/unit/AddressListSm.spec.ts
@@ -480,11 +480,11 @@ describe('AddressListSm', () => {
     await Vue.nextTick()
 
     // Verify delivery address 'Not Entered'
-    expect(vm.$el.querySelector('#business-address-panel .delivery-address-list-item .address-subtitle\
-      .delivery-address-not-entered').textContent).toContain('Not Entered')
+    expect(vm.$el.querySelector('#business-address-panel .delivery-address-list-item .delivery-address-not-entered')
+      .textContent).toContain('Not Entered')
     expect(vm.$el.querySelector('#business-address-panel .delivery-address-list-item .address-line1'))
       .toBeNull()
-    
+
     // verify mailing address 'Not Entered'
     expect(vm.$el.querySelector('#business-address-panel .mailing-address-list-item .mailing-address-not-entered')
       .textContent).toContain('Not Entered')

--- a/tests/unit/FirmsAddressList.spec.ts
+++ b/tests/unit/FirmsAddressList.spec.ts
@@ -1,0 +1,167 @@
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+import Vuelidate from 'vuelidate'
+import { mount } from '@vue/test-utils'
+import { getVuexStore } from '@/store'
+import FirmsAddressList from '@/components/Dashboard/FirmsAddressList.vue'
+
+Vue.use(Vuetify)
+Vue.use(Vuelidate)
+
+const vuetify = new Vuetify({})
+const store = getVuexStore() as any // remove typings for unit tests
+
+describe('FirmsAddressList', () => {
+  
+  it('displays title and icons for delivery/mailing address', async () => {
+    // init store
+    store.state.businessAddress = null
+
+    const wrapper = mount(FirmsAddressList, {
+      store,
+      vuetify,
+      propsData: {
+        showCompleteYourFilingMessage: false,
+        showGrayedOut: false
+      }
+    })
+    await Vue.nextTick()
+
+    // Verify delivery/mailing address title
+    expect(wrapper.findAll('.address-title').at(0).text()).toBe('Delivery Address')
+    expect(wrapper.findAll('.address-title').at(1).text()).toBe('Mailing Address')
+
+    // Veryfi delivery/mailing icons
+    expect(wrapper.find('.address-icon .v-icon.mdi-truck').exists()).toBeTruthy()
+    expect(wrapper.find('.address-icon .v-icon.mdi-email-outline').exists()).toBeTruthy()
+  
+    wrapper.destroy()
+  })
+
+  it('displays "Complete your filing to display" for addresses', async () => {
+    // init store
+    store.state.businessAddress = null
+
+    const wrapper = mount(FirmsAddressList, {
+      store,
+      vuetify,
+      propsData: {
+        showCompleteYourFilingMessage: true,
+        showGrayedOut: false
+      }
+    })
+    await Vue.nextTick()
+
+    // Verify Not Entered Texts
+    expect(wrapper.find('.delivery-address-list-item .complete-filing').text())
+      .toBe('Complete your filing to display')
+    expect(wrapper.find('.mailing-address-list-item .complete-filing').text())
+      .toBe('Complete your filing to display')
+
+    wrapper.destroy()
+  })
+
+  it('displays "Not Entered" for delivery/mailing address', async () => {
+    // init store
+    store.state.businessAddress = null
+
+    const wrapper = mount(FirmsAddressList, {
+      store,
+      vuetify,
+      propsData: {
+        showCompleteYourFilingMessage: false,
+        showGrayedOut: false
+      }
+    })
+    await Vue.nextTick()
+
+    // Verify Not Entered Texts
+    expect(wrapper.find('.delivery-address-not-entered').text()).toBe('Not Entered')
+    expect(wrapper.find('.mailing-address-not-entered').text()).toBe('Not Entered')
+
+    wrapper.destroy()
+  })
+
+  it('displays same address for delivery/mailing address', async () => {
+    let sameAddress = {
+      streetAddress: '333 Cook St',
+      addressCity: 'Castlegar',
+      addressRegion: 'BC',
+      postalCode: 'V3V 3V3',
+      addressCountry: 'CA'
+    }
+    // init store
+    store.state.businessAddress = {
+      deliveryAddress: sameAddress,
+      mailingAddress: sameAddress
+    }
+
+    const wrapper = mount(FirmsAddressList, {
+      store,
+      vuetify,
+      propsData: {
+        showCompleteYourFilingMessage: false,
+        showGrayedOut: false
+      }
+    })
+    await Vue.nextTick()
+
+    // Verify delivery address
+    expect(wrapper.find('.delivery-address-list-item .address-line1').text()).toBe('333 Cook St')
+    expect(wrapper.find('.delivery-address-list-item .address-line2').text()).toBe('')
+    expect(wrapper.find('.delivery-address-list-item .address-line3').text()).toContain('Castlegar')
+    expect(wrapper.find('.delivery-address-list-item .address-line3').text()).toContain('BC')
+    expect(wrapper.find('.delivery-address-list-item .address-line3').text()).toContain('V3V 3V3')
+    expect(wrapper.find('.delivery-address-list-item .address-line4').text()).toBe('Canada')
+
+    // Verify mailing address
+    expect(wrapper.find('.mailing-address-list-item .same-as-above').text()).toBe('Same as above')
+
+    wrapper.destroy()
+  })
+
+  it('displays different address for delivery/mailing address', async () => {
+    let deliveryAddress = {
+      streetAddress: '333 Cook St',
+      addressCity: 'Castlegar',
+      addressRegion: 'BC',
+      postalCode: 'V3V 3V3',
+      addressCountry: 'CA'
+    }
+    let mailingAddress = {...deliveryAddress, streetAddress: '444 Fish Rd'}
+    // init store
+    store.state.businessAddress = {
+      deliveryAddress: deliveryAddress,
+      mailingAddress: mailingAddress
+    }
+
+    const wrapper = mount(FirmsAddressList, {
+      store,
+      vuetify,
+      propsData: {
+        showCompleteYourFilingMessage: false,
+        showGrayedOut: false
+      }
+    })
+    await Vue.nextTick()
+
+    // Verify delivery address
+    expect(wrapper.find('.delivery-address-list-item .address-line1').text()).toBe('333 Cook St')
+    expect(wrapper.find('.delivery-address-list-item .address-line2').text()).toBe('')
+    expect(wrapper.find('.delivery-address-list-item .address-line3').text()).toContain('Castlegar')
+    expect(wrapper.find('.delivery-address-list-item .address-line3').text()).toContain('BC')
+    expect(wrapper.find('.delivery-address-list-item .address-line3').text()).toContain('V3V 3V3')
+    expect(wrapper.find('.delivery-address-list-item .address-line4').text()).toBe('Canada')
+
+    // Verify mailing address
+    expect(wrapper.find('.mailing-address-list-item .address-line1').text()).toBe('444 Fish Rd')
+    expect(wrapper.find('.mailing-address-list-item .address-line2').text()).toBe('')
+    expect(wrapper.find('.mailing-address-list-item .address-line3').text()).toContain('Castlegar')
+    expect(wrapper.find('.mailing-address-list-item .address-line3').text()).toContain('BC')
+    expect(wrapper.find('.mailing-address-list-item .address-line3').text()).toContain('V3V 3V3')
+    expect(wrapper.find('.mailing-address-list-item .address-line4').text()).toBe('Canada')
+
+    wrapper.destroy()
+  })
+
+})

--- a/tests/unit/FirmsAddressList.spec.ts
+++ b/tests/unit/FirmsAddressList.spec.ts
@@ -12,7 +12,6 @@ const vuetify = new Vuetify({})
 const store = getVuexStore() as any // remove typings for unit tests
 
 describe('FirmsAddressList', () => {
-  
   it('displays title and icons for delivery/mailing address', async () => {
     // init store
     store.state.businessAddress = null
@@ -34,7 +33,7 @@ describe('FirmsAddressList', () => {
     // Veryfi delivery/mailing icons
     expect(wrapper.find('.address-icon .v-icon.mdi-truck').exists()).toBeTruthy()
     expect(wrapper.find('.address-icon .v-icon.mdi-email-outline').exists()).toBeTruthy()
-  
+
     wrapper.destroy()
   })
 
@@ -128,7 +127,7 @@ describe('FirmsAddressList', () => {
       postalCode: 'V3V 3V3',
       addressCountry: 'CA'
     }
-    let mailingAddress = {...deliveryAddress, streetAddress: '444 Fish Rd'}
+    let mailingAddress = { ...deliveryAddress, streetAddress: '444 Fish Rd' }
     // init store
     store.state.businessAddress = {
       deliveryAddress: deliveryAddress,
@@ -163,5 +162,4 @@ describe('FirmsAddressList', () => {
 
     wrapper.destroy()
   })
-
 })

--- a/tests/unit/FirmsAddressList.spec.ts
+++ b/tests/unit/FirmsAddressList.spec.ts
@@ -162,4 +162,30 @@ describe('FirmsAddressList', () => {
 
     wrapper.destroy()
   })
+
+  it('displays "Not Enter" for null address', async () => {
+    // init store
+    store.state.businessAddress = {
+      deliveryAddress: null,
+      mailingAddress: null
+    }
+
+    const wrapper = mount(FirmsAddressList, {
+      store,
+      vuetify,
+      propsData: {
+        showCompleteYourFilingMessage: false,
+        showGrayedOut: false
+      }
+    })
+    await Vue.nextTick()
+
+    // Verify Not Entered for delivery/mailing address
+    expect(wrapper.find('.delivery-address-list-item .delivery-address-not-entered').text())
+      .toBe('Not Entered')
+    expect(wrapper.find('.mailing-address-list-item .mailing-address-not-entered').text())
+      .toBe('Not Entered')
+
+    wrapper.destroy()
+  })
 })

--- a/tests/unit/ProprietorPartnersListSm.spec.ts
+++ b/tests/unit/ProprietorPartnersListSm.spec.ts
@@ -191,7 +191,7 @@ describe('ProprietorPartnersListSm', () => {
             roleType: 'Partner'
           }
         ]
-      }, 
+      },
       {
         officer: {
           organizationName: 'Donut House',
@@ -209,7 +209,7 @@ describe('ProprietorPartnersListSm', () => {
       }
     ]
 
-    const wrapper = mount(ProprietorPartnersListSm, 
+    const wrapper = mount(ProprietorPartnersListSm,
       {
         store,
         vuetify,

--- a/tests/unit/ProprietorPartnersListSm.spec.ts
+++ b/tests/unit/ProprietorPartnersListSm.spec.ts
@@ -267,8 +267,7 @@ describe('ProprietorPartnersListSm', () => {
     // Verify to organization names
     expect(vm.getParties.length).toEqual(0)
     expect(vm.proprietorPartners.length).toEqual(0)
-    expect(wrapper.find('.align-items-top.address-panel .complete-filing').text())
-      .toBe('Complete your filing to display')
+    expect(wrapper.find('.align-items-top.address-panel .complete-filing').text()).toBe('Not Entered')
 
     wrapper.destroy()
   })

--- a/tests/unit/ProprietorPartnersListSm.spec.ts
+++ b/tests/unit/ProprietorPartnersListSm.spec.ts
@@ -172,4 +172,78 @@ describe('ProprietorPartnersListSm', () => {
 
     wrapper.destroy()
   })
+
+  it('displays "not entered" message for firm registration', async () => {
+    // init store
+    store.state.entityType = 'GP'
+    store.state.parties = [
+      {
+        officer: {
+          organizationName: 'Bacon House',
+          taxId: '222222222',
+          email: null
+        },
+        deliveryAddress: null,
+        mailingAddress: null,
+        roles: [
+          {
+            appointmentDate: '2022-04-01',
+            roleType: 'Partner'
+          }
+        ]
+      }, 
+      {
+        officer: {
+          organizationName: 'Donut House',
+          taxId: '444444444',
+          email: null
+        },
+        deliveryAddress: null,
+        mailingAddress: null,
+        roles: [
+          {
+            appointmentDate: '2022-04-01',
+            roleType: 'Partner'
+          }
+        ]
+      }
+    ]
+
+    const wrapper = mount(ProprietorPartnersListSm, 
+      {
+        store,
+        vuetify,
+        propsData: {
+          showCompleteYourFilingMessage: false
+        }
+      }
+    )
+    const vm = wrapper.vm as any
+    await Vue.nextTick()
+
+    // Verify to organization names
+    expect(vm.getParties.length).toEqual(2)
+    expect(vm.proprietorPartners.length).toEqual(2)
+    expect(wrapper.findAll('.list-item__title').at(0).text()).toBe('Bacon House')
+    expect(wrapper.findAll('.list-item__title').at(1).text()).toBe('Donut House')
+
+    // const item = vm.$el.querySelector('.v-expansion-panel-header.address-panel-toggle')
+    // const items = vm.$el.querySelector('.align-items-top address-panel')
+    const buttons = vm.$el.querySelectorAll('.v-expansion-panel-header.address-panel-toggle')
+    await buttons[0].click()
+    await buttons[1].click()
+
+    // Verify delivery addresses 'Not Entered'
+    expect(wrapper.findAll('.email-address-text').at(0).text()).toBe('Not Entered')
+    expect(wrapper.findAll('.email-address-text').at(1).text()).toBe('Not Entered')
+
+    // Verify mailing addresses 'Not Entered'
+    expect(wrapper.findAll('.delivery-address-not-entered').at(0).text()).toBe('Not Entered')
+    expect(wrapper.findAll('.delivery-address-not-entered').at(1).text()).toBe('Not Entered')
+
+    // // Verify mailing addresses 'Not Entered'
+    expect(wrapper.findAll('.mailing-address-not-entered').at(0).text()).toBe('Not Entered')
+    expect(wrapper.findAll('.mailing-address-not-entered').at(1).text()).toBe('Not Entered')
+    wrapper.destroy()
+  })
 })

--- a/tests/unit/ProprietorPartnersListSm.spec.ts
+++ b/tests/unit/ProprietorPartnersListSm.spec.ts
@@ -246,4 +246,30 @@ describe('ProprietorPartnersListSm', () => {
     expect(wrapper.findAll('.mailing-address-not-entered').at(1).text()).toBe('Not Entered')
     wrapper.destroy()
   })
+
+  it('displays "Complete your filing..." for no parties', async () => {
+    // init store
+    store.state.entityType = 'GP'
+    store.state.parties = []
+
+    const wrapper = mount(ProprietorPartnersListSm,
+      {
+        store,
+        vuetify,
+        propsData: {
+          showCompleteYourFilingMessage: false
+        }
+      }
+    )
+    const vm = wrapper.vm as any
+    await Vue.nextTick()
+
+    // Verify to organization names
+    expect(vm.getParties.length).toEqual(0)
+    expect(vm.proprietorPartners.length).toEqual(0)
+    expect(wrapper.find('.align-items-top.address-panel .complete-filing').text())
+      .toBe('Complete your filing to display')
+
+    wrapper.destroy()
+  })
 })


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#12024](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12024)

*Description of changes:*

When a user opens their entity dashboard for an SP/GP, if data is missing we need to:

- [x] Still display the appropriate headers
- [x] Show "Not Entered" if data fields are empty
  - When the field would normally not be empty for this entity type
  - This applies to firms only (so only those components need this change)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
