### PR TITLE
11886 FILINGS UI - Start Record Conversion (Add filing to list of staff filings)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.0.4",
+      "version": "5.0.3",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.4",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.0.2",
+      "version": "5.0.4",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.4",
+  "version": "5.0.3",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FirmsAddressList.vue
+++ b/src/components/Dashboard/FirmsAddressList.vue
@@ -54,12 +54,12 @@
                     </li>
                   </ul>
                   <ul class="address-subtitle pre-line" v-else>
-                    <li class="delivery-address-not-entered">Not Entered</li>
+                    <li class="delivery-address-not-entered">(Not Entered)</li>
                   </ul>
                 </v-list-item-subtitle>
                 <v-list-item-subtitle v-else>
                   <ul class="address-subtitle pre-line">
-                    <li class="delivery-address-not-entered">Not Entered</li>
+                    <li class="delivery-address-not-entered">(Not Entered)</li>
                   </ul>
                 </v-list-item-subtitle>
               </v-list-item-content>
@@ -92,12 +92,12 @@
                     </ul>
                   </div>
                   <div class="mailing-address-not-entered" v-else>
-                    <span>Not Entered</span>
+                    <span>(Not Entered)</span>
                   </div>
                 </v-list-item-subtitle>
                 <v-list-item-subtitle v-else>
                   <div class="mailing-address-not-entered">
-                    <span>Not Entered</span>
+                    <span>(Not Entered)</span>
                   </div>
                 </v-list-item-subtitle>
               </v-list-item-content>

--- a/src/components/Dashboard/ProprietorPartnersListSm.vue
+++ b/src/components/Dashboard/ProprietorPartnersListSm.vue
@@ -6,7 +6,7 @@
 
     <v-expansion-panels v-else accordion multiple>
       <v-expansion-panel class="align-items-top address-panel" v-if="proprietorPartners.length===0">
-        <span class="complete-filing">Not Entered</span>
+        <span class="complete-filing">(Not Entered)</span>
       </v-expansion-panel>
       <!-- when grayed out, disable expansion -->
       <v-expansion-panel class="align-items-top address-panel"
@@ -27,7 +27,7 @@
               <v-list-item-content>
                 <v-list-item-title class="mb-2 address-title">Email Address</v-list-item-title>
                 <v-list-item-subtitle class="email-address-text">
-                  {{ party.officer.email || 'Not Entered'}}
+                  {{ party.officer.email || '(Not Entered)'}}
                 </v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
@@ -45,7 +45,7 @@
                     <li class="address-line4">{{ getCountryName(party.deliveryAddress.addressCountry) }}</li>
                   </ul>
                   <ul class="address-subtitle pre-line" v-else>
-                    <li class="delivery-address-not-entered">Not Entered</li>
+                    <li class="delivery-address-not-entered">(Not Entered)</li>
                   </ul>
                 </v-list-item-subtitle>
               </v-list-item-content>
@@ -70,7 +70,7 @@
                     </ul>
                   </div>
                   <div class="mailing-address-not-entered" v-else>
-                    <span>Not Entered</span>
+                    <span>(Not Entered)</span>
                   </div>
                 </v-list-item-subtitle>
               </v-list-item-content>

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -30,7 +30,7 @@
       @close="hideRecordConversionDialog($event)"
       attach="#staff-notation"
       displayName="Firm Record Conversion"
-      name="recordConversion"
+      name="conversion"
     />
 
     <div class="filing-item__actions">
@@ -74,7 +74,7 @@
                 <span class="app-blue">Add Court Order</span>
               </v-list-item-title>
             </v-list-item>
-            <v-list-item @click="onAddressChangeClick()" :disabled="disabled">
+            <v-list-item @click="showRecordConversionDialog()" :disabled="disabled">
               <v-list-item-title>
                 <span class="app-blue">Add Firm Record Conversion</span>
               </v-list-item-title>
@@ -109,6 +109,9 @@ export default class StaffNotation extends Vue {
   /** Prop for disabling the menu items. */
   @Prop({ default: false }) readonly disabled: boolean
 
+  @Getter isFirm!: boolean
+  @Getter getIdentifier: string
+
   showRegistrarsNotationDialog (): void {
     this.isAddingRegistrarsNotation = true
   }
@@ -136,8 +139,10 @@ export default class StaffNotation extends Vue {
     this.close(needReload)
   }
 
+  /** If entity is a Firm then navigate to Edit UI,
+    * Else display message that this is not a firm. */
   showRecordConversionDialog (): void {
-    this.isAddingRecordConversion = true
+    this.isFirm ? this.goToChangeFiling() : this.isAddingRecordConversion = true
   }
 
   hideRecordConversionDialog (needReload: boolean): void {
@@ -150,14 +155,6 @@ export default class StaffNotation extends Vue {
     // Intentionally empty
   }
 
-  /**
-   * If entity is a Firm then navigate to Edit UI.
-   * Else display message that this is not a firm.
-   */
-  @Getter isFirm!: boolean
-  @Getter getIdentifier: string
-  @Getter isBComp: boolean
-
   /** The Edit URL string. */
   get editUrl (): string {
     return sessionStorage.getItem('EDIT_URL')
@@ -166,10 +163,6 @@ export default class StaffNotation extends Vue {
   goToChangeFiling ():void {
     const url = `${this.editUrl}${this.getIdentifier}/change`
     navigate(url)
-  }
-
-  onAddressChangeClick () {
-    this.isFirm ? this.goToChangeFiling() : this.showRecordConversionDialog()
   }
 }
 </script>

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -29,7 +29,7 @@
       :dialog="isAddingRecordConversion"
       @close="hideRecordConversionDialog($event)"
       attach="#staff-notation"
-      displayName="Firm Record Conversion"
+      displayName="Record Conversion"
       name="conversion"
     />
 
@@ -76,7 +76,7 @@
             </v-list-item>
             <v-list-item @click="showRecordConversionDialog()" :disabled="disabled">
               <v-list-item-title>
-                <span class="app-blue">Add Firm Record Conversion</span>
+                <span class="app-blue">Record Conversion</span>
               </v-list-item-title>
             </v-list-item>
           </v-list-item-group>
@@ -142,7 +142,7 @@ export default class StaffNotation extends Vue {
   /** If entity is a Firm then navigate to Edit UI,
     * Else display message that this is not a firm. */
   showRecordConversionDialog (): void {
-    this.isFirm ? this.goToChangeFiling() : this.isAddingRecordConversion = true
+    this.isFirm ? this.goToConversionFiling() : this.isAddingRecordConversion = true
   }
 
   hideRecordConversionDialog (needReload: boolean): void {
@@ -160,8 +160,8 @@ export default class StaffNotation extends Vue {
     return sessionStorage.getItem('EDIT_URL')
   }
 
-  goToChangeFiling ():void {
-    const url = `${this.editUrl}${this.getIdentifier}/change`
+  goToConversionFiling ():void {
+    const url = `${this.editUrl}${this.getIdentifier}/conversion`
     navigate(url)
   }
 }

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -66,7 +66,7 @@
                 <span class="app-blue">Add Court Order</span>
               </v-list-item-title>
             </v-list-item>
-            <v-list-item @click="goToConversionFiling()" :disabled="!isFirm">
+            <v-list-item @click="goToConversionFiling()" :disabled="disabled || !isFirm">
               <v-list-item-title>
                 <span class="app-blue">Record Conversion</span>
               </v-list-item-title>

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -25,6 +25,14 @@
       courtOrderNumberRequired="true"
     />
 
+    <AddStaffNotationDialog
+      :dialog="isAddingRecordConversion"
+      @close="hideRecordConversionDialog($event)"
+      attach="#staff-notation"
+      displayName="Firm Record Conversion"
+      name="recordConversion"
+    />
+
     <div class="filing-item__actions">
       <v-menu offset-y left transition="slide-y-transition" v-model="expand">
         <template v-slot:activator="{ on }">
@@ -66,6 +74,11 @@
                 <span class="app-blue">Add Court Order</span>
               </v-list-item-title>
             </v-list-item>
+            <v-list-item @click="onAddressChangeClick()" :disabled="disabled">
+              <v-list-item-title>
+                <span class="app-blue">Add Firm Record Conversion</span>
+              </v-list-item-title>
+            </v-list-item>
           </v-list-item-group>
         </v-list>
       </v-menu>
@@ -75,7 +88,8 @@
 
 <script lang="ts">
 import { Component, Prop, Emit, Vue } from 'vue-property-decorator'
-
+import { Getter } from 'vuex-class'
+import { navigate } from '@/utils'
 // Dialog
 import { AddStaffNotationDialog } from '@/components/dialogs'
 
@@ -86,6 +100,7 @@ export default class StaffNotation extends Vue {
   private isAddingRegistrarsNotation = false
   private isAddingRegistrarsOrder = false
   private isAddingCourtOrder = false
+  private isAddingRecordConversion = false
   private expand = false
 
   /** Prop for the scrollbar offset to be added. */
@@ -121,9 +136,40 @@ export default class StaffNotation extends Vue {
     this.close(needReload)
   }
 
+  showRecordConversionDialog (): void {
+    this.isAddingRecordConversion = true
+  }
+
+  hideRecordConversionDialog (needReload: boolean): void {
+    this.isAddingRecordConversion = false
+    this.close(needReload)
+  }
+
   @Emit('close')
   private close (needReload: boolean): void {
     // Intentionally empty
+  }
+
+  /**
+   * If entity is a Firm then navigate to Edit UI.
+   * Else display message that this is not a firm.
+   */
+  @Getter isFirm!: boolean
+  @Getter getIdentifier: string
+  @Getter isBComp: boolean
+
+  /** The Edit URL string. */
+  get editUrl (): string {
+    return sessionStorage.getItem('EDIT_URL')
+  }
+
+  goToChangeFiling ():void {
+    const url = `${this.editUrl}${this.getIdentifier}/change`
+    navigate(url)
+  }
+
+  onAddressChangeClick () {
+    this.isFirm ? this.goToChangeFiling() : this.showRecordConversionDialog()
   }
 }
 </script>

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -25,14 +25,6 @@
       courtOrderNumberRequired="true"
     />
 
-    <AddStaffNotationDialog
-      :dialog="isAddingRecordConversion"
-      @close="hideRecordConversionDialog($event)"
-      attach="#staff-notation"
-      displayName="Record Conversion"
-      name="conversion"
-    />
-
     <div class="filing-item__actions">
       <v-menu offset-y left transition="slide-y-transition" v-model="expand">
         <template v-slot:activator="{ on }">
@@ -74,7 +66,7 @@
                 <span class="app-blue">Add Court Order</span>
               </v-list-item-title>
             </v-list-item>
-            <v-list-item @click="showRecordConversionDialog()" :disabled="disabled">
+            <v-list-item @click="goToConversionFiling()" :disabled="!isFirm">
               <v-list-item-title>
                 <span class="app-blue">Record Conversion</span>
               </v-list-item-title>
@@ -100,7 +92,6 @@ export default class StaffNotation extends Vue {
   private isAddingRegistrarsNotation = false
   private isAddingRegistrarsOrder = false
   private isAddingCourtOrder = false
-  private isAddingRecordConversion = false
   private expand = false
 
   /** Prop for the scrollbar offset to be added. */
@@ -111,6 +102,11 @@ export default class StaffNotation extends Vue {
 
   @Getter isFirm!: boolean
   @Getter getIdentifier: string
+
+  /** The Edit URL string. */
+  get editUrl (): string {
+    return sessionStorage.getItem('EDIT_URL')
+  }
 
   showRegistrarsNotationDialog (): void {
     this.isAddingRegistrarsNotation = true
@@ -139,25 +135,9 @@ export default class StaffNotation extends Vue {
     this.close(needReload)
   }
 
-  /** If entity is a Firm then navigate to Edit UI,
-    * Else display message that this is not a firm. */
-  showRecordConversionDialog (): void {
-    this.isFirm ? this.goToConversionFiling() : this.isAddingRecordConversion = true
-  }
-
-  hideRecordConversionDialog (needReload: boolean): void {
-    this.isAddingRecordConversion = false
-    this.close(needReload)
-  }
-
   @Emit('close')
   private close (needReload: boolean): void {
     // Intentionally empty
-  }
-
-  /** The Edit URL string. */
-  get editUrl (): string {
-    return sessionStorage.getItem('EDIT_URL')
   }
 
   goToConversionFiling ():void {

--- a/src/components/dialogs/AddStaffNotationDialog.vue
+++ b/src/components/dialogs/AddStaffNotationDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <v-dialog v-model="dialog" width="45rem" persistent :attach="attach" content-class="add-notation-dialog">
-    <v-card v-if="displayName==='Firm Record Conversion'">
-      <v-card-title id="conversion-title">Add a {{displayName}}</v-card-title>
+    <v-card v-if="name==='conversion'">
+      <v-card-title id="conversion-title">{{displayName}}</v-card-title>
       <v-card-text>
         <div id="notation-text" class="mb-4 mt-2" ref="notationFormRef">
-          Firm record conversion is only applicable for sole proprietorship, "Doing Business As" name (DBA),
+          Record conversion is only applicable for sole proprietorship, "Doing Business As" name (DBA),
           or general partnership business types.
         </div>
       </v-card-text>

--- a/src/components/dialogs/AddStaffNotationDialog.vue
+++ b/src/components/dialogs/AddStaffNotationDialog.vue
@@ -1,25 +1,6 @@
 <template>
   <v-dialog v-model="dialog" width="45rem" persistent :attach="attach" content-class="add-notation-dialog">
-    <v-card v-if="name==='conversion'">
-      <v-card-title id="conversion-title">{{displayName}}</v-card-title>
-      <v-card-text>
-        <div id="notation-text" class="mb-4 mt-2" ref="notationFormRef">
-          Record conversion is only applicable for sole proprietorship, "Doing Business As" name (DBA),
-          or general partnership business types.
-        </div>
-      </v-card-text>
-      <v-divider class="mb-4"></v-divider>
-      <v-card-actions class="pt-0">
-        <v-spacer></v-spacer>
-        <div class="form__btns">
-          <v-btn text color="primary"
-            id="dialog-cancel-button"
-            @click.native="emitClose(false)"
-          >Cancel</v-btn>
-        </div>
-      </v-card-actions>
-    </v-card>
-    <v-card v-else>
+    <v-card>
       <v-card-title id="dialog-title">Add a {{displayName}}</v-card-title>
       <v-card-text>
         <div id="notation-text" class="mb-4 mt-2">
@@ -156,7 +137,7 @@ export default class AddStaffNotationDialog extends Mixins(DateMixin) {
   @Watch('dialog')
   private async onDialogChanged (val: boolean): Promise<void> {
     // when dialog is shown, reset notation and validation
-    if (val && this.name !== 'conversion') {
+    if (val) {
       this.notation = ''
       await Vue.nextTick()
       this.$refs.notationFormRef.resetValidation()

--- a/src/components/dialogs/AddStaffNotationDialog.vue
+++ b/src/components/dialogs/AddStaffNotationDialog.vue
@@ -1,9 +1,9 @@
 <template>
   <v-dialog v-model="dialog" width="45rem" persistent :attach="attach" content-class="add-notation-dialog">
     <v-card v-if="displayName==='Firm Record Conversion'">
-      <v-card-title id="dialog-title">Add a {{displayName}}</v-card-title>
+      <v-card-title id="conversion-title">Add a {{displayName}}</v-card-title>
       <v-card-text>
-        <div id="notation-text" class="mb-4 mt-2">
+        <div id="notation-text" class="mb-4 mt-2" ref="notationFormRef">
           Firm record conversion is only applicable for sole proprietorship, "Doing Business As" name (DBA),
           or general partnership business types.
         </div>
@@ -14,7 +14,6 @@
         <div class="form__btns">
           <v-btn text color="primary"
             id="dialog-cancel-button"
-            :disabled="saving"
             @click.native="emitClose(false)"
           >Cancel</v-btn>
         </div>
@@ -157,7 +156,7 @@ export default class AddStaffNotationDialog extends Mixins(DateMixin) {
   @Watch('dialog')
   private async onDialogChanged (val: boolean): Promise<void> {
     // when dialog is shown, reset notation and validation
-    if (val) {
+    if (val && this.name !== 'conversion') {
       this.notation = ''
       await Vue.nextTick()
       this.$refs.notationFormRef.resetValidation()

--- a/src/components/dialogs/AddStaffNotationDialog.vue
+++ b/src/components/dialogs/AddStaffNotationDialog.vue
@@ -1,6 +1,26 @@
 <template>
   <v-dialog v-model="dialog" width="45rem" persistent :attach="attach" content-class="add-notation-dialog">
-    <v-card>
+    <v-card v-if="displayName==='Firm Record Conversion'">
+      <v-card-title id="dialog-title">Add a {{displayName}}</v-card-title>
+      <v-card-text>
+        <div id="notation-text" class="mb-4 mt-2">
+          Firm record conversion is only applicable for sole proprietorship, "Doing Business As" name (DBA),
+          or general partnership business types.
+        </div>
+      </v-card-text>
+      <v-divider class="mb-4"></v-divider>
+      <v-card-actions class="pt-0">
+        <v-spacer></v-spacer>
+        <div class="form__btns">
+          <v-btn text color="primary"
+            id="dialog-cancel-button"
+            :disabled="saving"
+            @click.native="emitClose(false)"
+          >Cancel</v-btn>
+        </div>
+      </v-card-actions>
+    </v-card>
+    <v-card v-else>
       <v-card-title id="dialog-title">Add a {{displayName}}</v-card-title>
       <v-card-text>
         <div id="notation-text" class="mb-4 mt-2">

--- a/tests/unit/AddressListSm.spec.ts
+++ b/tests/unit/AddressListSm.spec.ts
@@ -467,7 +467,7 @@ describe('AddressListSm', () => {
     wrapper.destroy()
   })
 
-  it('displays "not entered" message for firm registration', async () => {
+  it('displays "(Not Entered)" message for firm registration', async () => {
     // init store
     store.state.entityType = 'SP'
     store.state.businessAddress = {
@@ -479,15 +479,15 @@ describe('AddressListSm', () => {
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
-    // Verify delivery address 'Not Entered'
+    // Verify delivery address '(Not Entered)'
     expect(vm.$el.querySelector('#business-address-panel .delivery-address-list-item .delivery-address-not-entered')
-      .textContent).toContain('Not Entered')
+      .textContent).toContain('(Not Entered)')
     expect(vm.$el.querySelector('#business-address-panel .delivery-address-list-item .address-line1'))
       .toBeNull()
 
-    // verify mailing address 'Not Entered'
+    // verify mailing address '(Not Entered)'
     expect(vm.$el.querySelector('#business-address-panel .mailing-address-list-item .mailing-address-not-entered')
-      .textContent).toContain('Not Entered')
+      .textContent).toContain('(Not Entered)')
     expect(vm.$el.querySelector('#business-address-panel .mailing-address-list-item .same-as-above'))
       .toBeNull()
     expect(vm.$el.querySelector('#business-address-panel .mailing-address-list-item .address-subtitle .address-line1'))

--- a/tests/unit/FirmsAddressList.spec.ts
+++ b/tests/unit/FirmsAddressList.spec.ts
@@ -51,7 +51,7 @@ describe('FirmsAddressList', () => {
     })
     await Vue.nextTick()
 
-    // Verify Not Entered Texts
+    // Verify (Not Entered) Texts
     expect(wrapper.find('.delivery-address-list-item .complete-filing').text())
       .toBe('Complete your filing to display')
     expect(wrapper.find('.mailing-address-list-item .complete-filing').text())
@@ -60,7 +60,7 @@ describe('FirmsAddressList', () => {
     wrapper.destroy()
   })
 
-  it('displays "Not Entered" for delivery/mailing address', async () => {
+  it('displays "(Not Entered)" for delivery/mailing address', async () => {
     // init store
     store.state.businessAddress = null
 
@@ -74,9 +74,9 @@ describe('FirmsAddressList', () => {
     })
     await Vue.nextTick()
 
-    // Verify Not Entered Texts
-    expect(wrapper.find('.delivery-address-not-entered').text()).toBe('Not Entered')
-    expect(wrapper.find('.mailing-address-not-entered').text()).toBe('Not Entered')
+    // Verify (Not Entered) Texts
+    expect(wrapper.find('.delivery-address-not-entered').text()).toBe('(Not Entered)')
+    expect(wrapper.find('.mailing-address-not-entered').text()).toBe('(Not Entered)')
 
     wrapper.destroy()
   })
@@ -180,11 +180,11 @@ describe('FirmsAddressList', () => {
     })
     await Vue.nextTick()
 
-    // Verify Not Entered for delivery/mailing address
+    // Verify (Not Entered) for delivery/mailing address
     expect(wrapper.find('.delivery-address-list-item .delivery-address-not-entered').text())
-      .toBe('Not Entered')
+      .toBe('(Not Entered)')
     expect(wrapper.find('.mailing-address-list-item .mailing-address-not-entered').text())
-      .toBe('Not Entered')
+      .toBe('(Not Entered)')
 
     wrapper.destroy()
   })

--- a/tests/unit/ProprietorPartnersListSm.spec.ts
+++ b/tests/unit/ProprietorPartnersListSm.spec.ts
@@ -173,7 +173,7 @@ describe('ProprietorPartnersListSm', () => {
     wrapper.destroy()
   })
 
-  it('displays "not entered" message for firm registration', async () => {
+  it('displays "(Not Entered)" message for firm registration', async () => {
     // init store
     store.state.entityType = 'GP'
     store.state.parties = [
@@ -233,17 +233,17 @@ describe('ProprietorPartnersListSm', () => {
     await buttons[0].click()
     await buttons[1].click()
 
-    // Verify delivery addresses 'Not Entered'
-    expect(wrapper.findAll('.email-address-text').at(0).text()).toBe('Not Entered')
-    expect(wrapper.findAll('.email-address-text').at(1).text()).toBe('Not Entered')
+    // Verify delivery addresses '(Not Entered)'
+    expect(wrapper.findAll('.email-address-text').at(0).text()).toBe('(Not Entered)')
+    expect(wrapper.findAll('.email-address-text').at(1).text()).toBe('(Not Entered)')
 
-    // Verify mailing addresses 'Not Entered'
-    expect(wrapper.findAll('.delivery-address-not-entered').at(0).text()).toBe('Not Entered')
-    expect(wrapper.findAll('.delivery-address-not-entered').at(1).text()).toBe('Not Entered')
+    // Verify mailing addresses '(Not Entered)'
+    expect(wrapper.findAll('.delivery-address-not-entered').at(0).text()).toBe('(Not Entered)')
+    expect(wrapper.findAll('.delivery-address-not-entered').at(1).text()).toBe('(Not Entered)')
 
-    // // Verify mailing addresses 'Not Entered'
-    expect(wrapper.findAll('.mailing-address-not-entered').at(0).text()).toBe('Not Entered')
-    expect(wrapper.findAll('.mailing-address-not-entered').at(1).text()).toBe('Not Entered')
+    // // Verify mailing addresses '(Not Entered)'
+    expect(wrapper.findAll('.mailing-address-not-entered').at(0).text()).toBe('(Not Entered)')
+    expect(wrapper.findAll('.mailing-address-not-entered').at(1).text()).toBe('(Not Entered)')
     wrapper.destroy()
   })
 
@@ -267,7 +267,7 @@ describe('ProprietorPartnersListSm', () => {
     // Verify to organization names
     expect(vm.getParties.length).toEqual(0)
     expect(vm.proprietorPartners.length).toEqual(0)
-    expect(wrapper.find('.align-items-top.address-panel .complete-filing').text()).toBe('Not Entered')
+    expect(wrapper.find('.align-items-top.address-panel .complete-filing').text()).toBe('(Not Entered)')
 
     wrapper.destroy()
   })

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -28,7 +28,7 @@ describe('StaffNotation', () => {
   // Boilerplate to prevent the complaint "[Vuetify] Unable to locate target [data-app]"
   document.body.setAttribute('data-app', 'true')
   document.body.setAttribute('id', 'staff-notation')
-  store.state.isFirm = true
+  store.state.entityType = 'SP'
   it('renders the page contents correctly', () => {
     const wrapper = mount(StaffNotation, { store })
 

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -10,13 +10,27 @@ Vue.use(Vuetify)
 const vuetify = new Vuetify({})
 const store = getVuexStore() as any // remove typings for unit tests
 
+const staffFilingTypes = [
+  {
+    name: 'Registrar\'s Notation',
+    type: 'registrarsNotation'
+  },
+  {
+    name: 'Registrar\'s Order',
+    type: 'registrarsOrder'
+  },
+  {
+    name: 'Court Order',
+    type: 'courtOrder'
+  }
+]
 describe('StaffNotation', () => {
   // Boilerplate to prevent the complaint "[Vuetify] Unable to locate target [data-app]"
   document.body.setAttribute('data-app', 'true')
   document.body.setAttribute('id', 'staff-notation')
-
+  store.state.isFirm = true
   it('renders the page contents correctly', () => {
-    const wrapper = mount(StaffNotation, {})
+    const wrapper = mount(StaffNotation, {store})
 
     expect(wrapper.vm.$data.expand).toBe(false)
     expect(wrapper.find('#add-staff-filing-label').text()).toBe('Add Staff Filing')
@@ -26,7 +40,8 @@ describe('StaffNotation', () => {
   it('renders the menu correctly', async () => {
     const wrapper = mount(StaffNotation, {
       vuetify,
-      sync: false
+      sync: false,
+      store
     })
 
     // Open menu
@@ -45,64 +60,6 @@ describe('StaffNotation', () => {
   it('emits close', async () => {
     const wrapper = mount(StaffNotation, {
       vuetify,
-      sync: false
-    })
-
-    // Open menu
-    wrapper.find('.menu-btn').trigger('click')
-    expect(wrapper.vm.$data.expand).toBe(true)
-    await Vue.nextTick()
-
-    // Click on first item
-    wrapper.find('.v-list .v-item-group .v-list-item').trigger('click')
-    await flushPromises()
-    expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeTruthy()
-
-    // click the Cancel button
-    wrapper.find('#dialog-cancel-button').trigger('click')
-    await Vue.nextTick()
-    expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeFalsy()
-
-    // verify Close event
-    expect(wrapper.emitted('close').pop()).toEqual([false])
-    wrapper.destroy()
-  })
-
-  it('renders the modal correctly for Registrar\'s Notation', async () => {
-    const wrapper = mount(StaffNotation, {
-      vuetify,
-      sync: false
-    })
-
-    // Open menu
-    wrapper.find('.menu-btn').trigger('click')
-    expect(wrapper.vm.$data.expand).toBe(true)
-    await Vue.nextTick()
-
-    // Click on first item
-    wrapper.find('.v-list .v-item-group .v-list-item').trigger('click')
-    await flushPromises()
-    expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeTruthy()
-
-    // Verify the modal title
-    expect(wrapper.find('#dialog-title').text()).toContain('Add a Registrar\'s Notation')
-    expect(wrapper.find('#notation-form .text-input-field .v-label').text()).toContain('Registrar\'s Notation')
-
-    // click the Cancel button
-    wrapper.find('#dialog-cancel-button').trigger('click')
-    await Vue.nextTick()
-    expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeFalsy()
-
-    // verify Close event
-    expect(wrapper.emitted('close').pop()).toEqual([false])
-    wrapper.destroy()
-  })
-
-  it('renders the modal correctly for Record Conversion', async () => {
-    store.state.isFirm = false
-    store.state.getIdentifier = ''
-    const wrapper = mount(StaffNotation, {
-      vuetify,
       sync: false,
       store
     })
@@ -112,23 +69,65 @@ describe('StaffNotation', () => {
     expect(wrapper.vm.$data.expand).toBe(true)
     await Vue.nextTick()
 
-    // Click on last item
-    wrapper.findAll('.v-list .v-item-group .v-list-item').at(3).trigger('click')
+    // Click on first item
+    wrapper.find('.v-list .v-item-group .v-list-item').trigger('click')
     await flushPromises()
-    expect(wrapper.vm.$data.isAddingRecordConversion).toBeTruthy()
-
-    // Verify the modal title
-    expect(wrapper.find('#conversion-title').text()).toContain('Record Conversion')
-    expect(wrapper.find('#notation-text').text()).toContain('sole proprietorship')
+    expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeTruthy()
 
     // click the Cancel button
     wrapper.find('#dialog-cancel-button').trigger('click')
     await Vue.nextTick()
     expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeFalsy()
 
-    // // verify Close event
+    // verify Close event
     expect(wrapper.emitted('close').pop()).toEqual([false])
-
     wrapper.destroy()
   })
+
+  for (const test of staffFilingTypes) {
+    
+    it(`renders the modal correctly for ${test.name}`, async () => {
+      const wrapper = mount(StaffNotation, {
+        vuetify,
+        sync: false,
+        store
+      })
+
+      // Open menu
+      wrapper.find('.menu-btn').trigger('click')
+      expect(wrapper.vm.$data.expand).toBe(true)
+      await Vue.nextTick()
+
+      // Click on first item
+      let index = staffFilingTypes.indexOf(test)
+      wrapper.findAll('.v-list .v-item-group .v-list-item').at(index).trigger('click')
+      await flushPromises()
+      switch (test.type) {
+        case 'registrarsNotation':
+          expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeTruthy()
+          break;
+        case 'registrarsOrder':
+          expect(wrapper.vm.$data.isAddingRegistrarsOrder).toBeTruthy()
+          break;
+        case 'courtOrder':
+          expect(wrapper.vm.$data.isAddingCourtOrder).toBeTruthy()
+          break;
+        default:
+          break;
+      }
+
+      // Verify the modal title
+      expect(wrapper.find('#dialog-title').text()).toContain(`Add a ${test.name}`)
+      expect(wrapper.find('#notation-form .text-input-field .v-label').text()).toContain(test.name)
+
+      // click the Cancel button
+      wrapper.find('#dialog-cancel-button').trigger('click')
+      await Vue.nextTick()
+      expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeFalsy()
+
+      // verify Close event
+      expect(wrapper.emitted('close').pop()).toEqual([false])
+      wrapper.destroy()
+    })
+  }
 })

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -36,7 +36,8 @@ describe('StaffNotation', () => {
     await Vue.nextTick()
     expect(wrapper.find('.v-list').text()).toContain('Add Registrar\'s Notation')
     expect(wrapper.find('.v-list').text()).toContain('Add Registrar\'s Order')
-    expect(wrapper.find('.v-list .v-item-group').text()).toContain('Add Court Order')
+    expect(wrapper.find('.v-list').text()).toContain('Add Court Order')
+    expect(wrapper.find('.v-list').text()).toContain('Add Firm Record Conversion')
 
     wrapper.destroy()
   })
@@ -64,6 +65,70 @@ describe('StaffNotation', () => {
 
     // verify Close event
     expect(wrapper.emitted('close').pop()).toEqual([false])
+    wrapper.destroy()
+  })
+
+  it('renders the modal correctly for Registrar\'s Notation', async () => {
+    const wrapper = mount(StaffNotation, {
+      vuetify,
+      sync: false
+    })
+
+    // Open menu
+    wrapper.find('.menu-btn').trigger('click')
+    expect(wrapper.vm.$data.expand).toBe(true)
+    await Vue.nextTick()
+
+    // Click on first item
+    wrapper.find('.v-list .v-item-group .v-list-item').trigger('click')
+    await flushPromises()
+    expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeTruthy()
+
+    // Verify the modal title
+    expect(wrapper.find('#dialog-title').text()).toContain('Add a Registrar\'s Notation')
+    expect(wrapper.find('#notation-form .text-input-field .v-label').text()).toContain('Registrar\'s Notation')
+
+    // click the Cancel button
+    wrapper.find('#dialog-cancel-button').trigger('click')
+    await Vue.nextTick()
+    expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeFalsy()
+
+    // verify Close event
+    expect(wrapper.emitted('close').pop()).toEqual([false])
+    wrapper.destroy()
+  })
+
+  it('renders the modal correctly for Record Conversion', async () => {
+    store.state.isFirm = false
+    store.state.getIdentifier = ''
+    const wrapper = mount(StaffNotation, {
+      vuetify,
+      sync: false,
+      store
+    })
+
+    // Open menu
+    wrapper.find('.menu-btn').trigger('click')
+    expect(wrapper.vm.$data.expand).toBe(true)
+    await Vue.nextTick()
+
+    // Click on last item
+    wrapper.findAll('.v-list .v-item-group .v-list-item').at(3).trigger('click')
+    await flushPromises()
+    expect(wrapper.vm.$data.isAddingRecordConversion).toBeTruthy()
+
+    // Verify the modal title
+    expect(wrapper.find('#conversion-title').text()).toContain('Add a Firm Record Conversion')
+    expect(wrapper.find('#notation-text').text()).toContain('sole proprietorship')
+
+    // click the Cancel button
+    wrapper.find('#dialog-cancel-button').trigger('click')
+    await Vue.nextTick()
+    expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeFalsy()
+
+    // // verify Close event
+    expect(wrapper.emitted('close').pop()).toEqual([false])
+
     wrapper.destroy()
   })
 })

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -37,7 +37,7 @@ describe('StaffNotation', () => {
     expect(wrapper.find('.v-list').text()).toContain('Add Registrar\'s Notation')
     expect(wrapper.find('.v-list').text()).toContain('Add Registrar\'s Order')
     expect(wrapper.find('.v-list').text()).toContain('Add Court Order')
-    expect(wrapper.find('.v-list').text()).toContain('Add Firm Record Conversion')
+    expect(wrapper.find('.v-list').text()).toContain('Record Conversion')
 
     wrapper.destroy()
   })
@@ -118,7 +118,7 @@ describe('StaffNotation', () => {
     expect(wrapper.vm.$data.isAddingRecordConversion).toBeTruthy()
 
     // Verify the modal title
-    expect(wrapper.find('#conversion-title').text()).toContain('Add a Firm Record Conversion')
+    expect(wrapper.find('#conversion-title').text()).toContain('Record Conversion')
     expect(wrapper.find('#notation-text').text()).toContain('sole proprietorship')
 
     // click the Cancel button

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -30,7 +30,7 @@ describe('StaffNotation', () => {
   document.body.setAttribute('id', 'staff-notation')
   store.state.isFirm = true
   it('renders the page contents correctly', () => {
-    const wrapper = mount(StaffNotation, {store})
+    const wrapper = mount(StaffNotation, { store })
 
     expect(wrapper.vm.$data.expand).toBe(false)
     expect(wrapper.find('#add-staff-filing-label').text()).toBe('Add Staff Filing')
@@ -85,7 +85,6 @@ describe('StaffNotation', () => {
   })
 
   for (const test of staffFilingTypes) {
-    
     it(`renders the modal correctly for ${test.name}`, async () => {
       const wrapper = mount(StaffNotation, {
         vuetify,
@@ -105,15 +104,15 @@ describe('StaffNotation', () => {
       switch (test.type) {
         case 'registrarsNotation':
           expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeTruthy()
-          break;
+          break
         case 'registrarsOrder':
           expect(wrapper.vm.$data.isAddingRegistrarsOrder).toBeTruthy()
-          break;
+          break
         case 'courtOrder':
           expect(wrapper.vm.$data.isAddingCourtOrder).toBeTruthy()
-          break;
+          break
         default:
-          break;
+          break
       }
 
       // Verify the modal title


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#11886](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/11886)

*Description of changes:*

**Completed Tasks:**
- [x] This filing is always available in the dropdown for staff
- [x] Clicking "Firm Record Conversion" will NOT create a draft, and redirect to the edit UI
  - Redirect path related to ticket #111894. 
  - Suggested url is "/conversion". 
- [x] If staff do save a draft for this filing, filings UI needs to display this draft (if it doesn't work nicely as-is, consult Roy and keep working on it in this ticket)
  - Edit UI is related to ticket #111894. 
  - `filing.displayName` must be "Record Conversion Filing" (related ticket #11771?)
- [x] Unit tests

**Additional change:**
- [x] Corrected "Not Entered" to "(Not Entered)" with parentheses 
- [x] If the business type is not SP/GP/DBA, clicking on the "Record Conversion" will display the modal. This is subject to change upon UXA review.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
