### PR TITLE
12024 Fix Filings UI - Display "Not Entered" for missing data on address and prop/part components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -372,7 +372,7 @@ export default {
       if (this.businessId) {
         try {
           await this.fetchBusinessData() // throws on error
-          await this.fetchAddressData() // business address
+          await this.fetchStoreAddressData() // business address
           this.dataLoaded = true
         } catch (error) {
           console.log(error) // eslint-disable-line no-console
@@ -415,7 +415,7 @@ export default {
       this.storeParties(data[4])
     },
 
-    async fetchAddressData ():Promise<void> {
+    async fetchStoreAddressData ():Promise<void> {
       let hasBAError = false
       const data = await Promise.resolve(
         this.fetchAddresses(this.businessId)
@@ -425,10 +425,13 @@ export default {
           error.response.data.message.includes('address not found')) hasBAError = true
       })
 
-      let badAddress = { data: { businessOffice: null } }
-      if (!data && hasBAError) this.storeAddresses(badAddress) // if 404 and business address not found
-      if (!data && !hasBAError) throw new Error('Incomplete business data')
-      if (data) this.storeAddresses(data)
+      if (data) {
+        this.storeAddresses(data)
+      } else if (hasBAError) { // if 404 and business address not found
+        this.storeAddresses({ data: { businessOffice: null } })
+      } else {
+        throw new Error('Incomplete business data')
+      }
     },
 
     /** Fetches and stores the draft application data. */

--- a/src/components/Dashboard/FirmsAddressList.vue
+++ b/src/components/Dashboard/FirmsAddressList.vue
@@ -133,7 +133,10 @@ export default class FirmsAddressList extends Mixins(CommonMixin, CountriesProvi
   @Getter getBusinessAddress!: OfficeAddressIF
 
   // Business
-  get businessAddress (): OfficeAddressIF {
+  get businessAddress (): OfficeAddressIF|null {
+    if (this.getBusinessAddress && this.getBusinessAddress.deliveryAddress &&
+        Object.values(this.getBusinessAddress.deliveryAddress).length === 0) return null
+    if (this.getBusinessAddress && this.getBusinessAddress.deliveryAddress === null) return null
     return this.getBusinessAddress
   }
 

--- a/src/components/Dashboard/FirmsAddressList.vue
+++ b/src/components/Dashboard/FirmsAddressList.vue
@@ -113,6 +113,7 @@
 // Libraries
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
+import { isEmpty } from 'lodash'
 
 // Mixins
 import { CommonMixin, CountriesProvincesMixin } from '@/mixins'
@@ -134,10 +135,7 @@ export default class FirmsAddressList extends Mixins(CommonMixin, CountriesProvi
 
   // Business
   get businessAddress (): OfficeAddressIF|null {
-    let deliveryAddress = this.getBusinessAddress?.deliveryAddress
-    if (this.getBusinessAddress === null) return null
-    if (deliveryAddress === null) return null
-    if (Object.values(deliveryAddress).length === 0) return null
+    if (isEmpty(this.getBusinessAddress?.deliveryAddress)) return null
     return this.getBusinessAddress
   }
 

--- a/src/components/Dashboard/FirmsAddressList.vue
+++ b/src/components/Dashboard/FirmsAddressList.vue
@@ -134,9 +134,10 @@ export default class FirmsAddressList extends Mixins(CommonMixin, CountriesProvi
 
   // Business
   get businessAddress (): OfficeAddressIF|null {
-    if (this.getBusinessAddress && this.getBusinessAddress.deliveryAddress &&
-        Object.values(this.getBusinessAddress.deliveryAddress).length === 0) return null
-    if (this.getBusinessAddress && this.getBusinessAddress.deliveryAddress === null) return null
+    let deliveryAddress = this.getBusinessAddress?.deliveryAddress
+    if (this.getBusinessAddress === null) return null
+    if (deliveryAddress === null) return null
+    if (Object.values(deliveryAddress).length === 0) return null
     return this.getBusinessAddress
   }
 

--- a/src/components/Dashboard/ProprietorPartnersListSm.vue
+++ b/src/components/Dashboard/ProprietorPartnersListSm.vue
@@ -107,6 +107,7 @@ export default class ProprietorPartnersListSm extends Mixins(CommonMixin, Countr
   get proprietorPartners (): PartyIF[] {
     if (this.isSoleProp) {
       // return array with the proprietor
+      if (this.getParties.length === 0) return []
       return [ this.getParties.find(party => party.roles.some(role => role.roleType === Roles.PROPRIETOR)) ]
     }
     if (this.isPartnership) {

--- a/tests/unit/FirmsAddressList.spec.ts
+++ b/tests/unit/FirmsAddressList.spec.ts
@@ -189,9 +189,9 @@ describe('FirmsAddressList', () => {
     wrapper.destroy()
   })
 
-  it('displays "(Not Entered)" for invalid getBusinessAddress', async () => {
+  it('displays "(Not Entered)" for getter getBusinessAddress', async () => {
     // init store
-    store.state.getBusinessAddress = {
+    store.state.businessAddress = {
       deliveryAddress: {},
       mailingAddress: {}
     }

--- a/tests/unit/FirmsAddressList.spec.ts
+++ b/tests/unit/FirmsAddressList.spec.ts
@@ -163,12 +163,34 @@ describe('FirmsAddressList', () => {
     wrapper.destroy()
   })
 
-  it('displays "(Not Entered)" for null address', async () => {
+  it('displays "(Not Entered)" for invalid businessAddress', async () => {
     // init store
     store.state.businessAddress = {
       deliveryAddress: null,
       mailingAddress: null
     }
+
+    const wrapper = mount(FirmsAddressList, {
+      store,
+      vuetify,
+      propsData: {
+        showCompleteYourFilingMessage: false,
+        showGrayedOut: false
+      }
+    })
+    await Vue.nextTick()
+
+    // Verify (Not Entered) for delivery/mailing address
+    expect(wrapper.find('.delivery-address-list-item .delivery-address-not-entered').text())
+      .toBe('(Not Entered)')
+    expect(wrapper.find('.mailing-address-list-item .mailing-address-not-entered').text())
+      .toBe('(Not Entered)')
+
+    wrapper.destroy()
+  })
+
+  it('displays "(Not Entered)" for invalid getBusinessAddress', async () => {
+    // init store
     store.state.getBusinessAddress = {
       deliveryAddress: {},
       mailingAddress: {}

--- a/tests/unit/FirmsAddressList.spec.ts
+++ b/tests/unit/FirmsAddressList.spec.ts
@@ -163,11 +163,15 @@ describe('FirmsAddressList', () => {
     wrapper.destroy()
   })
 
-  it('displays "Not Enter" for null address', async () => {
+  it('displays "(Not Entered)" for null address', async () => {
     // init store
     store.state.businessAddress = {
       deliveryAddress: null,
       mailingAddress: null
+    }
+    store.state.getBusinessAddress = {
+      deliveryAddress: {},
+      mailingAddress: {}
     }
 
     const wrapper = mount(FirmsAddressList, {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12024

*Description of changes:*

**Completed UXA Observations:**

- [x] FM0614924 is an SP missing the Proprietor. The Proprietor section on the dashboard is empty. The placeholder text "Not Entered" should be displayed inside a box. (This works fine for a GP missing partners)
- [x] FM0614946 is an SP (DBA) missing the Proprietor. The Proprietor section on the dashboard is empty. The placeholder text "Not Entered" should be displayed inside a box.
- [x] Changed "Not Entered" to "(Not Entered)" with parentheses. 

**404 Handler**
- [x] Filing UI can load FM0272480 FM0272488 with 404 handler.

**New Ticket**
- [x] Edit UI can't load FM0614924/FM0613561/FM0272480/FM0272488: new ticket created [12206](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12206)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
