### PR TITLE
11374 Filings UI: get account id from CURRENT_ACCOUNT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.1.6",
+      "version": "5.1.7",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/CompletedDissolution.vue
+++ b/src/components/Dashboard/FilingHistoryList/CompletedDissolution.vue
@@ -45,7 +45,7 @@ export default class CompletedDissolution extends Mixins(DateMixin) {
 
   /** The entity title to display. */
   get entityTitle (): string {
-    return this.getDissolutionConfirmationResource.entityTitle
+    return this.getDissolutionConfirmationResource?.entityTitle || 'Unknown Entity'
   }
 
   /** The dissolution date-time to display. */

--- a/src/resources/BreadcrumbResources.ts
+++ b/src/resources/BreadcrumbResources.ts
@@ -2,7 +2,7 @@ import { BreadcrumbIF } from '@/interfaces'
 
 /** Returns URL param string with Account ID if present, else empty string. */
 function getParams (): string {
-  const accountId = sessionStorage.getItem('ACCOUNT_ID')
+  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT')).id
   return accountId ? `?accountid=${accountId}` : ''
 }
 

--- a/src/resources/BreadcrumbResources.ts
+++ b/src/resources/BreadcrumbResources.ts
@@ -2,7 +2,7 @@ import { BreadcrumbIF } from '@/interfaces'
 
 /** Returns URL param string with Account ID if present, else empty string. */
 function getParams (): string {
-  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT')).id
+  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
   return accountId ? `?accountid=${accountId}` : ''
 }
 

--- a/src/utils/fetch-config.ts
+++ b/src/utils/fetch-config.ts
@@ -18,7 +18,8 @@ export async function fetchConfig (): Promise<void> {
   }
 
   // get and store account id, if present
-  const accountId = new URLSearchParams(windowLocationSearch).get('accountid')
+  // const accountId = new URLSearchParams(windowLocationSearch).get('accountid')
+  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT')).id
   if (accountId) {
     sessionStorage.setItem('ACCOUNT_ID', accountId)
     console.log('Set Account ID to: ' + accountId)

--- a/src/utils/fetch-config.ts
+++ b/src/utils/fetch-config.ts
@@ -11,18 +11,9 @@ export async function fetchConfig (): Promise<void> {
   const processEnvBaseUrl: string = process.env.BASE_URL // eg, /business/
   const windowLocationPathname = window.location.pathname // eg, /business/CP1234567/...
   const windowLocationOrigin = window.location.origin // eg, http://localhost:8080
-  const windowLocationSearch = window.location.search // eg, ?accountid=2288
 
   if (!processEnvBaseUrl || !windowLocationPathname || !windowLocationOrigin) {
     return Promise.reject(new Error('Missing environment variables'))
-  }
-
-  // get and store account id, if present
-  // const accountId = new URLSearchParams(windowLocationSearch).get('accountid')
-  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT')).id
-  if (accountId) {
-    sessionStorage.setItem('ACCOUNT_ID', accountId)
-    console.log('Set Account ID to: ' + accountId)
   }
 
   // fetch config from API

--- a/src/utils/navigate.ts
+++ b/src/utils/navigate.ts
@@ -5,7 +5,7 @@
 export function navigate (url: string): boolean {
   try {
     // get account id and set in params
-    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT')).id
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     if (accountId) {
       if (url.includes('?')) {
         url += `&accountid=${accountId}`

--- a/src/utils/navigate.ts
+++ b/src/utils/navigate.ts
@@ -5,7 +5,7 @@
 export function navigate (url: string): boolean {
   try {
     // get account id and set in params
-    const accountId = sessionStorage.getItem('ACCOUNT_ID')
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT')).id
     if (accountId) {
       if (url.includes('?')) {
         url += `&accountid=${accountId}`

--- a/tests/unit/AnnualReport.spec.ts
+++ b/tests/unit/AnnualReport.spec.ts
@@ -861,7 +861,7 @@ describe('Annual Report - Part 3 - Submitting', () => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)
@@ -920,8 +920,9 @@ describe('Annual Report - Part 3 - Submitting', () => {
     await flushPromises()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/321/' + encodeURIComponent('https://base.url/?filing_id=123')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -1070,7 +1071,7 @@ describe('Annual Report - Part 3B - Submitting (BCOMP)', () => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
 
     // create local Vue and mock router
     const localVue = createLocalVue()
@@ -1122,8 +1123,9 @@ describe('Annual Report - Part 3B - Submitting (BCOMP)', () => {
     await flushPromises()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/321/' + encodeURIComponent('https://base.url/?filing_id=123')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })

--- a/tests/unit/AnnualReport.spec.ts
+++ b/tests/unit/AnnualReport.spec.ts
@@ -861,6 +861,7 @@ describe('Annual Report - Part 3 - Submitting', () => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)
@@ -1069,6 +1070,7 @@ describe('Annual Report - Part 3B - Submitting (BCOMP)', () => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
 
     // create local Vue and mock router
     const localVue = createLocalVue()

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -317,6 +317,7 @@ describe('App as a COOP', () => {
     sessionStorage.clear()
     sessionStorage.setItem('KEYCLOAK_TOKEN', KEYCLOAK_TOKEN_STAFF)
     sessionStorage.setItem('BUSINESS_ID', 'CP0001191')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
   })
 
   beforeEach(async () => {

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -317,7 +317,7 @@ describe('App as a COOP', () => {
     sessionStorage.clear()
     sessionStorage.setItem('KEYCLOAK_TOKEN', KEYCLOAK_TOKEN_STAFF)
     sessionStorage.setItem('BUSINESS_ID', 'CP0001191')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
   })
 
   beforeEach(async () => {

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -336,7 +336,7 @@ describe('EntityInfo - Click Tests - Alterations', () => {
     sessionStorage.clear()
     sessionStorage.setItem('EDIT_URL', 'https://edit.url/')
     sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
     store.state.identifier = 'BC1234567'
     store.state.goodStanding = true
     store.state.entityType = 'BEN'
@@ -350,8 +350,9 @@ describe('EntityInfo - Click Tests - Alterations', () => {
     await Vue.nextTick()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const editUrl = 'https://edit.url/BC1234567/alteration'
-    expect(window.location.assign).toHaveBeenCalledWith(editUrl)
+    expect(window.location.assign).toHaveBeenCalledWith(editUrl + '?accountid=' + accountId)
 
     wrapper.destroy()
   })

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -336,6 +336,7 @@ describe('EntityInfo - Click Tests - Alterations', () => {
     sessionStorage.clear()
     sessionStorage.setItem('EDIT_URL', 'https://edit.url/')
     sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
     store.state.identifier = 'BC1234567'
     store.state.goodStanding = true
     store.state.entityType = 'BEN'

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -659,6 +659,7 @@ describe('Filing History List - redirections', () => {
     // init data
     sessionStorage.setItem('EDIT_URL', 'https://edit.url/')
     sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
     store.state.keycloakRoles = ['staff']
     store.state.identifier = 'BC1234567'
     store.state.filings = [

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -659,7 +659,7 @@ describe('Filing History List - redirections', () => {
     // init data
     sessionStorage.setItem('EDIT_URL', 'https://edit.url/')
     sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
     store.state.keycloakRoles = ['staff']
     store.state.identifier = 'BC1234567'
     store.state.filings = [
@@ -699,8 +699,9 @@ describe('Filing History List - redirections', () => {
     await flushPromises()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const createUrl = 'https://edit.url/BC1234567/correction/?correction-id=110514'
-    expect(window.location.assign).toHaveBeenCalledWith(createUrl)
+    expect(window.location.assign).toHaveBeenCalledWith(createUrl + '&accountid=' + accountId)
 
     sessionStorage.removeItem('BUSINESS_ID')
     wrapper.destroy()

--- a/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -674,6 +674,7 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
 
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = mount(StandaloneDirectorsFiling, {
@@ -744,6 +745,7 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
 
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = mount(StandaloneDirectorsFiling, {

--- a/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -674,7 +674,7 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
 
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = mount(StandaloneDirectorsFiling, {
@@ -731,8 +731,9 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     // expect(tooltipText).toContain('There is no opportunity to change information beyond this point.')
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/321/' + encodeURIComponent('https://base.url/?filing_id=123')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -745,7 +746,7 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
 
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = mount(StandaloneDirectorsFiling, {
@@ -801,8 +802,9 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     // expect(tooltipText).toContain('There is no opportunity to change information beyond this point.')
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/321/' + encodeURIComponent('https://base.url/?filing_id=123')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })

--- a/tests/unit/StandaloneOfficeAddressFiling.spec.ts
+++ b/tests/unit/StandaloneOfficeAddressFiling.spec.ts
@@ -672,7 +672,7 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)
@@ -719,8 +719,9 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
     await flushPromises()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/321/' + encodeURIComponent('https://base.url/?filing_id=123')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -953,7 +954,7 @@ describe('Standalone Office Address Filing - Part 3B - Submitting (BCOMP)', () =
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)
@@ -1000,8 +1001,9 @@ describe('Standalone Office Address Filing - Part 3B - Submitting (BCOMP)', () =
     await flushPromises()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/321/' + encodeURIComponent('https://base.url/?filing_id=123')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })

--- a/tests/unit/StandaloneOfficeAddressFiling.spec.ts
+++ b/tests/unit/StandaloneOfficeAddressFiling.spec.ts
@@ -672,6 +672,7 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)
@@ -952,6 +953,7 @@ describe('Standalone Office Address Filing - Part 3B - Submitting (BCOMP)', () =
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', 'https://base.url/')
     sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)

--- a/tests/unit/TodoList.spec.ts
+++ b/tests/unit/TodoList.spec.ts
@@ -1596,6 +1596,7 @@ describe('TodoList - Click Tests', () => {
     // init store
     sessionStorage.clear()
     sessionStorage.setItem('BUSINESS_ID', 'CP0001191')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
     store.state.identifier = 'CP0001191'
     store.state.entityType = 'CP'
 
@@ -1933,6 +1934,7 @@ describe('TodoList - Click Tests - BCOMPs', () => {
     sessionStorage.clear()
     sessionStorage.setItem('BUSINESS_ID', 'BC0007291')
     store.state.identifier = 'BC0007291'
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
 
     // mock the window.location.assign function
     delete window.location
@@ -2175,6 +2177,7 @@ describe('TodoList - Click Tests - NRs and Incorp Apps', () => {
     sessionStorage.clear()
     sessionStorage.setItem('CREATE_URL', 'https://create.url/')
     sessionStorage.setItem('TEMP_REG_NUMBER', 'T123456789')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
     store.state.entityName = 'My Business Inc'
     store.state.entityType = 'BEN'
 
@@ -2301,6 +2304,7 @@ describe('TodoList - Click Tests - IA Corrections', () => {
     sessionStorage.clear()
     sessionStorage.setItem('EDIT_URL', 'https://edit.url/')
     sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
     store.state.identifier = 'BC1234567'
     // init draft Correction filing task
     store.state.tasks = [
@@ -2360,6 +2364,7 @@ describe('TodoList - Click Tests - Alterations', () => {
     sessionStorage.clear()
     sessionStorage.setItem('EDIT_URL', 'https://edit.url/')
     sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
     store.state.identifier = 'BC1234567'
     store.state.goodStanding = true
     store.state.entityType = 'BEN'

--- a/tests/unit/TodoList.spec.ts
+++ b/tests/unit/TodoList.spec.ts
@@ -1596,7 +1596,7 @@ describe('TodoList - Click Tests', () => {
     // init store
     sessionStorage.clear()
     sessionStorage.setItem('BUSINESS_ID', 'CP0001191')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
     store.state.identifier = 'CP0001191'
     store.state.entityType = 'CP'
 
@@ -1756,8 +1756,9 @@ describe('TodoList - Click Tests', () => {
     await button.click()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/654/' + encodeURIComponent('https://base.url/?filing_id=456')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -1805,8 +1806,9 @@ describe('TodoList - Click Tests', () => {
     await button.click()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/987/' + encodeURIComponent('https://base.url/?filing_id=789')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -1855,8 +1857,9 @@ describe('TodoList - Click Tests', () => {
     await button.click()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/987/' + encodeURIComponent('https://base.url/?filing_id=789')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -1934,7 +1937,7 @@ describe('TodoList - Click Tests - BCOMPs', () => {
     sessionStorage.clear()
     sessionStorage.setItem('BUSINESS_ID', 'BC0007291')
     store.state.identifier = 'BC0007291'
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
 
     // mock the window.location.assign function
     delete window.location
@@ -2113,8 +2116,9 @@ describe('TodoList - Click Tests - BCOMPs', () => {
     await button.click()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/654/' + encodeURIComponent('https://base.url/?filing_id=456')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -2162,8 +2166,9 @@ describe('TodoList - Click Tests - BCOMPs', () => {
     await button.click()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const payURL = 'https://auth.web.url/makepayment/987/' + encodeURIComponent('https://base.url/?filing_id=789')
-    expect(window.location.assign).toHaveBeenCalledWith(payURL)
+    expect(window.location.assign).toHaveBeenCalledWith(payURL + '?accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -2177,7 +2182,7 @@ describe('TodoList - Click Tests - NRs and Incorp Apps', () => {
     sessionStorage.clear()
     sessionStorage.setItem('CREATE_URL', 'https://create.url/')
     sessionStorage.setItem('TEMP_REG_NUMBER', 'T123456789')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
     store.state.entityName = 'My Business Inc'
     store.state.entityType = 'BEN'
 
@@ -2234,8 +2239,9 @@ describe('TodoList - Click Tests - NRs and Incorp Apps', () => {
     await flushPromises()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const createUrl = 'https://create.url/?id=T123456789'
-    expect(window.location.assign).toHaveBeenCalledWith(createUrl)
+    expect(window.location.assign).toHaveBeenCalledWith(createUrl + '&accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -2279,8 +2285,9 @@ describe('TodoList - Click Tests - NRs and Incorp Apps', () => {
     await flushPromises()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const createUrl = 'https://create.url/?id=T123456789'
-    expect(window.location.assign).toHaveBeenCalledWith(createUrl)
+    expect(window.location.assign).toHaveBeenCalledWith(createUrl + '&accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -2304,7 +2311,7 @@ describe('TodoList - Click Tests - IA Corrections', () => {
     sessionStorage.clear()
     sessionStorage.setItem('EDIT_URL', 'https://edit.url/')
     sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
     store.state.identifier = 'BC1234567'
     // init draft Correction filing task
     store.state.tasks = [
@@ -2339,8 +2346,9 @@ describe('TodoList - Click Tests - IA Corrections', () => {
     await Vue.nextTick()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const editUrl = 'https://edit.url/BC1234567/correction/?correction-id=123'
-    expect(window.location.assign).toHaveBeenCalledWith(editUrl)
+    expect(window.location.assign).toHaveBeenCalledWith(editUrl + '&accountid=' + accountId)
 
     wrapper.destroy()
   })
@@ -2364,7 +2372,7 @@ describe('TodoList - Click Tests - Alterations', () => {
     sessionStorage.clear()
     sessionStorage.setItem('EDIT_URL', 'https://edit.url/')
     sessionStorage.setItem('BUSINESS_ID', 'BC1234567')
-    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "" }')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
     store.state.identifier = 'BC1234567'
     store.state.goodStanding = true
     store.state.entityType = 'BEN'
@@ -2399,8 +2407,9 @@ describe('TodoList - Click Tests - Alterations', () => {
     await Vue.nextTick()
 
     // verify redirection
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const editUrl = 'https://edit.url/BC1234567/alteration/?alteration-id=123'
-    expect(window.location.assign).toHaveBeenCalledWith(editUrl)
+    expect(window.location.assign).toHaveBeenCalledWith(editUrl + '&accountid=' + accountId)
 
     wrapper.destroy()
   })

--- a/tests/unit/allowable-actions-mixin.spec.ts
+++ b/tests/unit/allowable-actions-mixin.spec.ts
@@ -259,6 +259,7 @@ describe('Allowable Actions Mixin', () => {
       // all conditions:
       { entityState: 'ACTIVE', hasBlocker: false, businessId: 'CP1234567', roles: ['staff'], expected: true },
       // For SP/GP conditions:
+      // eslint-disable-next-line max-len
       { entityState: 'ACTIVE', hasBlockerExceptStaffApproval: false, businessId: 'SP1234567', roles: ['staff'], expected: true }
     ]
 

--- a/tests/unit/fetch-config.spec.ts
+++ b/tests/unit/fetch-config.spec.ts
@@ -43,7 +43,6 @@ xdescribe('Fetch Config', () => {
     await fetchConfig()
 
     // verify data
-    expect(sessionStorage.getItem('ACCOUNT_ID')).toBe('2288')
     expect(sessionStorage.getItem('AUTH_WEB_URL')).toBe('auth web url')
     expect(sessionStorage.getItem('BUSINESSES_URL')).toBe('businesses url')
     expect(sessionStorage.getItem('BUSINESS_CREATE_URL')).toBe('business create url')

--- a/tests/unit/fetch-config.spec.ts
+++ b/tests/unit/fetch-config.spec.ts
@@ -36,7 +36,7 @@ xdescribe('Fetch Config', () => {
         ADDRESS_COMPLETE_KEY: 'address complete key',
         BUSINESS_FILING_LD_CLIENT_ID: 'business filing ld client id',
         SENTRY_ENABLE: 'sentry enable',
-        SENTRY_DSN: 'sentry dsn'
+        CURRENT_ACCOUNT: '{"id": "2288"}'
       }))
 
     // call method
@@ -60,5 +60,6 @@ xdescribe('Fetch Config', () => {
     expect(sessionStorage.getItem('BUSINESS_ID')).toBe('CP1234567')
     expect(sessionStorage.getItem('VUE_ROUTER_BASE')).toBe('/business/CP1234567/')
     expect(sessionStorage.getItem('BASE_URL')).toBe('http://localhost:8080/business/CP1234567/')
+    expect(sessionStorage.getItem('CURRENT_ACCOUNT')).toBe('{"id": "2288"}')
   })
 })


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#11374](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/11374)

*Description of changes:*
- removed `accountId` in file: fetch-config.ts 
- updated `accountId` in file: navigate.ts
- updated app version in file: package.json
- updated many unit test files to accommodate `CURRENT_ACCOUNT`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
