### PR TITLE
remove court order validation for AD and PutBackOn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.2.6",
+      "version": "5.2.7",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/dialogs/AddStaffNotationDialog.vue
+++ b/src/components/dialogs/AddStaffNotationDialog.vue
@@ -231,11 +231,15 @@ export default class AddStaffNotationDialog extends Mixins(DateMixin, EnumMixin)
         foundingDate: this.getEntityFoundingDate
       }
       data.filing[this.name] = { ...data.filing[this.name],
-        details: this.notation,
-        ...(this.courtOrderNumber && { courtOrder: {
-          effectOfOrder: (this.planOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : ''),
-          fileNumber: (this.courtOrderNumber ? this.courtOrderNumber : '')
-        } })
+        details: this.notation
+      }
+      if (this.courtOrderNumber) {
+        data.filing[this.name] = { ...data.filing[this.name],
+          courtOrder: {
+            effectOfOrder: (this.planOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : ''),
+            fileNumber: (this.courtOrderNumber ? this.courtOrderNumber : '')
+          }
+        }
       }
     } else if (this.administrativeDissolution) {
       data.filing.business = { ...data.filing.business,
@@ -246,12 +250,16 @@ export default class AddStaffNotationDialog extends Mixins(DateMixin, EnumMixin)
       data.filing[this.name] = { ...data.filing[this.name],
         dissolutionType: 'administrative',
         dissolutionDate: this.getCurrentDate,
-        details: this.notation,
-        ...(this.courtOrderNumber && { courtOrder: {
-          effectOfOrder: (this.planOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : ''),
-          fileNumber: (this.courtOrderNumber ? this.courtOrderNumber : ''),
-          orderDetails: this.notation
-        } })
+        details: this.notation
+      }
+      if (this.courtOrderNumber) {
+        data.filing[this.name] = { ...data.filing[this.name],
+          courtOrder: {
+            effectOfOrder: (this.planOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : ''),
+            fileNumber: (this.courtOrderNumber ? this.courtOrderNumber : ''),
+            orderDetails: this.notation
+          }
+        }
       }
     } else {
       data.filing[this.name] = { ...data.filing[this.name],

--- a/src/components/dialogs/AddStaffNotationDialog.vue
+++ b/src/components/dialogs/AddStaffNotationDialog.vue
@@ -110,6 +110,7 @@ export default class AddStaffNotationDialog extends Mixins(DateMixin, EnumMixin)
   @Getter getBusinessNumber!: string
   @Getter getEntityType!: string
   @Getter getEntityFoundingDate!: Date
+  @Getter isFirm!: boolean
 
   /** The notation text. */
   private notation: string = ''
@@ -195,10 +196,19 @@ export default class AddStaffNotationDialog extends Mixins(DateMixin, EnumMixin)
     await this.$nextTick()
     const isNotationFormRefValid = this.$refs.notationFormRef.validate()
     const isCourtOrderPoaFormRefValid = this.$refs.courtOrderPoaRef.validate()
-    if (!isNotationFormRefValid || !isCourtOrderPoaFormRefValid) {
-      this.saving = false
-      return
+
+    if (this.isFirm && (this.putBackOn || this.administrativeDissolution)) {
+      if (!isNotationFormRefValid) {
+        this.saving = false
+        return
+      }
+    } else {
+      if (!isNotationFormRefValid || !isCourtOrderPoaFormRefValid) {
+        this.saving = false
+        return
+      }
     }
+
     const data : any = {
       filing: {
         header: {
@@ -222,10 +232,10 @@ export default class AddStaffNotationDialog extends Mixins(DateMixin, EnumMixin)
       }
       data.filing[this.name] = { ...data.filing[this.name],
         details: this.notation,
-        courtOrder: {
+        ...(this.courtOrderNumber && { courtOrder: {
           effectOfOrder: (this.planOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : ''),
           fileNumber: (this.courtOrderNumber ? this.courtOrderNumber : '')
-        }
+        } })
       }
     } else if (this.administrativeDissolution) {
       data.filing.business = { ...data.filing.business,
@@ -236,10 +246,12 @@ export default class AddStaffNotationDialog extends Mixins(DateMixin, EnumMixin)
       data.filing[this.name] = { ...data.filing[this.name],
         dissolutionType: 'administrative',
         dissolutionDate: this.getCurrentDate,
-        courtOrder: {
+        details: this.notation,
+        ...(this.courtOrderNumber && { courtOrder: {
+          effectOfOrder: (this.planOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : ''),
           fileNumber: (this.courtOrderNumber ? this.courtOrderNumber : ''),
           orderDetails: this.notation
-        }
+        } })
       }
     } else {
       data.filing[this.name] = { ...data.filing[this.name],


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12092

*Description of changes:*
* remove frontend validation for court order number (not a required field)
* update data sent for admin dissolution in court order object


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
