### PR TITLE
13197 Don't save Certified By in a draft correction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.2.17",
+  "version": "5.2.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.2.17",
+      "version": "5.2.18",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.2.17",
+  "version": "5.2.18",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/correction-filing-interface.ts
+++ b/src/interfaces/correction-filing-interface.ts
@@ -2,7 +2,7 @@
 export interface CorrectionFilingIF {
   header: {
     name: string
-    certifiedBy: string
+    certifiedBy?: string
     date: string
     routingSlipNumber?: string
     folioNumber?: string

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -99,7 +99,6 @@ export default class FilingMixin extends Mixins(DateMixin) {
     const correctionFiling: CorrectionFilingIF = {
       header: {
         name: FilingTypes.CORRECTION,
-        certifiedBy: correctedFiling.header.certifiedBy,
         date: this.getCurrentDate
       },
       business: {
@@ -129,7 +128,6 @@ export default class FilingMixin extends Mixins(DateMixin) {
     const correctionFiling: CorrectionFilingIF = {
       header: {
         name: FilingTypes.CORRECTION,
-        certifiedBy: correctedFiling.header.certifiedBy,
         date: this.getCurrentDate
       },
       business: {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13197

*Description of changes:*
- don't save Certified By in BEN or FM draft correction
- app version = 5.2.18

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).