### PR TITLE
12392 Correction Filing Dialog for Firm Corrections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.2.18",
+  "version": "5.2.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.2.18",
+      "version": "5.2.19",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.2.18",
+  "version": "5.2.19",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -416,7 +416,6 @@ export default class FilingHistoryList extends Mixins(
   private currentFiling: HistoryItemIF = null
   private loadingOneIndex = -1
   private isBusy = false
-  private correctionFiling: HistoryItemIF = null
 
   // enum for template
   readonly AllowableActions = AllowableActions
@@ -647,12 +646,12 @@ export default class FilingHistoryList extends Mixins(
   }
 
   private startCorrectionDialog (item: HistoryItemIF): void {
-    this.correctionFiling = item
+    this.currentFiling = item
     this.fileCorrectionDialog = true
   }
 
   private async redirectThisFiling (correctionType: CorrectionTypes): Promise<void> {
-    const item = this.correctionFiling
+    const item = this.currentFiling
 
     try {
       // show spinner since the network calls below can take a few seconds
@@ -739,10 +738,7 @@ export default class FilingHistoryList extends Mixins(
         // FUTURE: allow a correction to a correction?
         // this.$router.push({ name: Routes.CORRECTION,
         //   params: { correctedFilingId } })
-        this.$router.push({
-          name: Routes.CORRECTION,
-          params: { correctedFilingId }
-        })
+        alert('At this time, you cannot correct a correction. Please contact Ops if needed.')
         break
 
       case FilingTypes.ALTERATION:

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1296,8 +1296,6 @@ export default class TodoList extends Mixins(
 
   /** Resumes a draft filing. */
   protected doResumeFiling (item: TodoItemIF): void {
-    console.info('item.name: ', item.name)
-    console.info('item: ', item)
     switch (item.name) {
       case FilingTypes.ANNUAL_REPORT:
         // resume this Annual Report locally
@@ -1322,7 +1320,6 @@ export default class TodoList extends Mixins(
         break
 
       case FilingTypes.CORRECTION:
-        console.info('item.correctedFilingType: ', item.correctedFilingType === FilingNames.CHANGE_OF_REGISTRATION)
         if (
           (item.correctedFilingType === FilingNames.INCORPORATION_APPLICATION) ||
           (item.correctedFilingType === FilingNames.CHANGE_OF_REGISTRATION) ||

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -595,7 +595,6 @@ export default class TodoList extends Mixins(
 
   @Prop({ default: null }) readonly highlightId: number
 
-  @Getter isCoop!: boolean
   @Getter getCurrentYear!: number
   @Getter getTasks!: Array<ApiTaskIF>
   @Getter isGoodStanding!: boolean
@@ -1075,7 +1074,6 @@ export default class TodoList extends Mixins(
         correctedFilingId: correction.correctedFilingId,
         // this is only used for external corrections (IA):
         correctedFilingType: this.filingTypeToName(correction.correctedFilingType as FilingTypes),
-        type: correction.type,
         title: (this.priorityCorrectionTitle(header.priority) + ' - ' +
           this.filingTypeToName(correction.correctedFilingType as FilingTypes)),
         draftTitle: this.filingTypeToName(FilingTypes.CORRECTION),
@@ -1298,6 +1296,8 @@ export default class TodoList extends Mixins(
 
   /** Resumes a draft filing. */
   protected doResumeFiling (item: TodoItemIF): void {
+    console.info('item.name: ', item.name)
+    console.info('item: ', item)
     switch (item.name) {
       case FilingTypes.ANNUAL_REPORT:
         // resume this Annual Report locally
@@ -1322,6 +1322,7 @@ export default class TodoList extends Mixins(
         break
 
       case FilingTypes.CORRECTION:
+        console.info('item.correctedFilingType: ', item.correctedFilingType === FilingNames.CHANGE_OF_REGISTRATION)
         if (
           (item.correctedFilingType === FilingNames.INCORPORATION_APPLICATION) ||
           (item.correctedFilingType === FilingNames.CHANGE_OF_REGISTRATION) ||

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -146,7 +146,7 @@
                     :ripple=false
                     @click.stop="togglePanel(index)"
                   >
-                    <v-icon left>mdi-information-outline</v-icon>
+                    <v-icon>mdi-information-outline</v-icon>
                     <span>{{ (panel === index) ? "Hide Details" : "View Details" }}</span>
                   </v-btn>
                 </div>
@@ -1075,6 +1075,7 @@ export default class TodoList extends Mixins(
         correctedFilingId: correction.correctedFilingId,
         // this is only used for external corrections (IA):
         correctedFilingType: this.filingTypeToName(correction.correctedFilingType as FilingTypes),
+        type: correction.type,
         title: (this.priorityCorrectionTitle(header.priority) + ' - ' +
           this.filingTypeToName(correction.correctedFilingType as FilingTypes)),
         draftTitle: this.filingTypeToName(FilingTypes.CORRECTION),

--- a/src/components/dialogs/FileCorrectionDialog.vue
+++ b/src/components/dialogs/FileCorrectionDialog.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-dialog v-model="dialog" width="45rem" persistent :attach="attach">
+  <v-dialog v-model="dialog" width="45rem" persistent :attach="attach" content-class="file-correction-dialog">
     <v-card>
       <v-card-title class="pt-8">Correction Filing</v-card-title>
 
       <v-card-text class="font-15">
         <p>Select who caused the correction. If client, completing party information and certification
           will be required. If staff, completing party information and certification will not be required.</p>
-        <v-radio-group v-model="correctionOption">
-          <v-radio id="fas-radio" class="mb-0 pt-2" label="Client Error" :value="correctionOptions.CLIENT" />
-          <v-radio id="bcol-radio" class="mb-0 pt-2" label="Staff Error" :value="correctionOptions.STAFF" />
+        <v-radio-group v-model="correctionType">
+          <v-radio id="correct-client-radio" class="mb-0 pt-2" label="Client Error" :value="CorrectionTypes.CLIENT" />
+          <v-radio id="correct-staff-radio" class="mb-0 pt-2" label="Staff Error" :value="CorrectionTypes.STAFF" />
         </v-radio-group>
         <template v-if="!hasChosenCorrection">
           <p class="font-15 option-error">Choose one option to proceed</p>
@@ -34,28 +34,19 @@
 
 <script lang="ts">
 import { Component, Vue, Prop, Emit, Watch } from 'vue-property-decorator'
-import { mapGetters } from 'vuex'
 import { ContactInfo } from '@/components/common'
+import { CorrectionTypes } from '@/enums'
 
 @Component({
-  computed: {
-    // Property definition for runtime environment.
-    ...mapGetters(['isRoleStaff'])
-  },
   components: { ContactInfo }
 })
 export default class FileCorrectionDialog extends Vue {
-  // Initialize hasChosenCorrection.
+  // enums for template
+  readonly CorrectionTypes = CorrectionTypes
+
+  // local variables
   private hasChosenCorrection = true
-
-  /** Radio group model property. */
-  private correctionOptions = {
-    NONE: 0,
-    CLIENT: 1,
-    STAFF: 2
-  }
-
-  private correctionOption = this.correctionOptions.NONE
+  protected correctionType = null as CorrectionTypes
 
   // Prop to display the dialog.
   @Prop() readonly dialog: boolean
@@ -63,31 +54,25 @@ export default class FileCorrectionDialog extends Vue {
   // Prop to provide attachment selector.
   @Prop() readonly attach: string
 
-  // Pass click event to parent.
-  @Emit() private exit () {
-    this.hasChosenCorrection = true
-    this.correctionOption = this.correctionOptions.NONE
-  }
-
   private checkToStart () {
-    if (this.correctionOption === this.correctionOptions.NONE) {
+    if (this.correctionType === null) {
       this.hasChosenCorrection = false
     } else {
       this.hasChosenCorrection = true
-      this.emitStart(true)
+      this.emitRedirect(this.correctionType)
     }
   }
 
   /** Called when payment option (radio group item) has changed. */
-  @Watch('correctionOption')
-  private onCorrectionOptionChanged (val: number): void {
+  @Watch('correctionType')
+  private onCorrectionTypeChanged (val: string): void {
     switch (val) {
-      case this.correctionOptions.CLIENT:
-        this.correctionOption = this.correctionOptions.CLIENT
+      case CorrectionTypes.CLIENT:
+        this.correctionType = CorrectionTypes.CLIENT
         this.hasChosenCorrection = true
         break
-      case this.correctionOptions.STAFF:
-        this.correctionOption = this.correctionOptions.STAFF
+      case CorrectionTypes.STAFF:
+        this.correctionType = CorrectionTypes.STAFF
         this.hasChosenCorrection = true
         break
       default:
@@ -95,12 +80,18 @@ export default class FileCorrectionDialog extends Vue {
     }
   }
 
+  // Pass click event to parent.
+  @Emit() private exit () {
+    this.hasChosenCorrection = true
+    this.correctionType = null
+  }
+
   /**
    * Emits event to Edit UI for correction.
-   * @param startCorrection Whether to redirect to start correction.
+   * Redirect to start correction.
    */
-  @Emit('start')
-  private emitStart (startCorrection: boolean): void { }
+  @Emit('redirect')
+  private emitRedirect (correctionType: CorrectionTypes): void { }
 }
 </script>
 

--- a/src/components/dialogs/FileCorrectionDialog.vue
+++ b/src/components/dialogs/FileCorrectionDialog.vue
@@ -1,0 +1,125 @@
+<template>
+  <v-dialog v-model="dialog" width="45rem" persistent :attach="attach">
+    <v-card>
+      <v-card-title class="pt-8">Correction Filing</v-card-title>
+
+      <v-card-text class="font-15">
+        <p>Select who caused the correction. If client, completing party information and certification
+          will be required. If staff, completing party information and certification will not be required.</p>
+        <v-radio-group v-model="correctionOption">
+          <v-radio id="fas-radio" class="mb-0 pt-2" label="Client Error" :value="correctionOptions.CLIENT" />
+          <v-radio id="bcol-radio" class="mb-0 pt-2" label="Staff Error" :value="correctionOptions.STAFF" />
+        </v-radio-group>
+        <template v-if="!hasChosenCorrection">
+          <p class="font-15 option-error">Choose one option to proceed</p>
+        </template>
+      </v-card-text>
+
+      <v-card-actions class="py-10">
+        <v-btn outlined large
+          class="mr-2"
+          color="primary"
+          id="dialog-exit-button"
+          @click="exit()"
+        > Cancel </v-btn>
+        <v-btn depressed large
+          color="primary"
+          id="dialog-start-button"
+          @click="checkToStart()"
+        >Start Correction</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop, Emit, Watch } from 'vue-property-decorator'
+import { mapGetters } from 'vuex'
+import { ContactInfo } from '@/components/common'
+
+@Component({
+  computed: {
+    // Property definition for runtime environment.
+    ...mapGetters(['isRoleStaff'])
+  },
+  components: { ContactInfo }
+})
+export default class FileCorrectionDialog extends Vue {
+  // Initialize hasChosenCorrection.
+  private hasChosenCorrection = true
+
+  /** Radio group model property. */
+  private correctionOptions = {
+    NONE: 0,
+    CLIENT: 1,
+    STAFF: 2
+  }
+
+  private correctionOption = this.correctionOptions.NONE
+
+  // Prop to display the dialog.
+  @Prop() readonly dialog: boolean
+
+  // Prop to provide attachment selector.
+  @Prop() readonly attach: string
+
+  // Pass click event to parent.
+  @Emit() private exit () {
+    this.hasChosenCorrection = true
+    this.correctionOption = this.correctionOptions.NONE
+  }
+
+  private checkToStart () {
+    if (this.correctionOption === this.correctionOptions.NONE) {
+      this.hasChosenCorrection = false
+    } else {
+      this.hasChosenCorrection = true
+      this.emitStart(true)
+    }
+  }
+
+  /** Called when payment option (radio group item) has changed. */
+  @Watch('correctionOption')
+  private onCorrectionOptionChanged (val: number): void {
+    switch (val) {
+      case this.correctionOptions.CLIENT:
+        this.correctionOption = this.correctionOptions.CLIENT
+        this.hasChosenCorrection = true
+        break
+      case this.correctionOptions.STAFF:
+        this.correctionOption = this.correctionOptions.STAFF
+        this.hasChosenCorrection = true
+        break
+      default:
+        break
+    }
+  }
+
+  /**
+   * Emits event to Edit UI for correction.
+   * @param startCorrection Whether to redirect to start correction.
+   */
+  @Emit('start')
+  private emitStart (startCorrection: boolean): void { }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@/assets/styles/theme.scss";
+
+::v-deep .v-dialog {
+  .v-card {
+    .v-card__title {
+      color: black;
+      background: #ffff;
+      font-weight: bold;
+    }
+    .v-card__actions {
+      justify-content: center;
+    }
+    .option-error {
+      color: $app-red;
+    }
+  }
+}
+</style>

--- a/src/components/dialogs/FileCorrectionDialog.vue
+++ b/src/components/dialogs/FileCorrectionDialog.vue
@@ -21,7 +21,7 @@
           color="primary"
           id="dialog-exit-button"
           @click="exit()"
-        > Cancel </v-btn>
+          >Cancel</v-btn>
         <v-btn depressed large
           color="primary"
           id="dialog-start-button"
@@ -34,12 +34,9 @@
 
 <script lang="ts">
 import { Component, Vue, Prop, Emit, Watch } from 'vue-property-decorator'
-import { ContactInfo } from '@/components/common'
 import { CorrectionTypes } from '@/enums'
 
-@Component({
-  components: { ContactInfo }
-})
+@Component({})
 export default class FileCorrectionDialog extends Vue {
   // enums for template
   readonly CorrectionTypes = CorrectionTypes
@@ -54,7 +51,8 @@ export default class FileCorrectionDialog extends Vue {
   // Prop to provide attachment selector.
   @Prop() readonly attach: string
 
-  private checkToStart () {
+  /** Check off buttons to confirm correction type */
+  protected checkToStart () {
     if (this.correctionType === null) {
       this.hasChosenCorrection = false
     } else {
@@ -81,7 +79,7 @@ export default class FileCorrectionDialog extends Vue {
   }
 
   // Pass click event to parent.
-  @Emit() private exit () {
+  @Emit() protected exit () {
     this.hasChosenCorrection = true
     this.correctionType = null
   }
@@ -102,7 +100,7 @@ export default class FileCorrectionDialog extends Vue {
   .v-card {
     .v-card__title {
       color: black;
-      background: #ffff;
+      background: white;
       font-weight: bold;
     }
     .v-card__actions {

--- a/src/components/dialogs/index.ts
+++ b/src/components/dialogs/index.ts
@@ -9,6 +9,7 @@ import DashboardUnavailableDialog from './DashboardUnavailableDialog.vue'
 import DeleteErrorDialog from './DeleteErrorDialog.vue'
 import DownloadErrorDialog from './DownloadErrorDialog.vue'
 import FetchErrorDialog from './FetchErrorDialog.vue'
+import FileCorrectionDialog from './FileCorrectionDialog.vue'
 import LoadCorrectionDialog from './LoadCorrectionDialog.vue'
 import NameRequestAuthErrorDialog from './NameRequestAuthErrorDialog.vue'
 import NameRequestInvalidDialog from './NameRequestInvalidDialog.vue'
@@ -31,6 +32,7 @@ export {
   DeleteErrorDialog,
   DownloadErrorDialog,
   FetchErrorDialog,
+  FileCorrectionDialog,
   LoadCorrectionDialog,
   NameRequestAuthErrorDialog,
   NameRequestInvalidDialog,

--- a/src/enums/correctionTypes.ts
+++ b/src/enums/correctionTypes.ts
@@ -1,0 +1,4 @@
+export enum CorrectionTypes {
+    CLIENT = 'CLIENT',
+    STAFF = 'STAFF'
+}

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -1,5 +1,6 @@
 export * from './actions'
 export * from './allowableActions'
+export * from './correctionTypes'
 export * from './dissolutionTypesNames'
 export * from './effectOfOrderTypes'
 export * from './entityState'

--- a/src/interfaces/correction-filing-interface.ts
+++ b/src/interfaces/correction-filing-interface.ts
@@ -1,3 +1,4 @@
+import { CorrectionTypes } from '@/enums'
 /** Incorporation Application filing loaded from / saved to the Legal API. */
 export interface CorrectionFilingIF {
   header: {
@@ -21,6 +22,7 @@ export interface CorrectionFilingIF {
     correctedFilingId: string
     correctedFilingType: string
     correctedFilingDate: string
+    type?: CorrectionTypes
     comment: string
   },
   incorporationApplication?: {},

--- a/src/interfaces/todo-item-interface.ts
+++ b/src/interfaces/todo-item-interface.ts
@@ -1,4 +1,4 @@
-import { FilingTypes, PaymentMethod, CorrectionTypes } from '@/enums'
+import { FilingTypes, PaymentMethod } from '@/enums'
 import { PaymentErrorIF } from '@/interfaces'
 
 /**

--- a/src/interfaces/todo-item-interface.ts
+++ b/src/interfaces/todo-item-interface.ts
@@ -1,4 +1,4 @@
-import { FilingTypes, PaymentMethod } from '@/enums'
+import { FilingTypes, PaymentMethod, CorrectionTypes } from '@/enums'
 import { PaymentErrorIF } from '@/interfaces'
 
 /**
@@ -40,6 +40,7 @@ export interface TodoItemIF {
   // corrections only
   correctedFilingId?: number
   correctedFilingType?: string
+  type?: CorrectionTypes
 
   // IAs only
   isEmptyFiling?: boolean

--- a/src/interfaces/todo-item-interface.ts
+++ b/src/interfaces/todo-item-interface.ts
@@ -40,7 +40,6 @@ export interface TodoItemIF {
   // corrections only
   correctedFilingId?: number
   correctedFilingType?: string
-  type?: CorrectionTypes
 
   // IAs only
   isEmptyFiling?: boolean

--- a/src/mixins/enum-mixin.ts
+++ b/src/mixins/enum-mixin.ts
@@ -221,6 +221,7 @@ export default class EnumMixin extends Vue {
       case FilingTypes.CHANGE_OF_ADDRESS: return FilingNames.CHANGE_OF_ADDRESS
       case FilingTypes.CHANGE_OF_DIRECTORS: return FilingNames.CHANGE_OF_DIRECTORS
       case FilingTypes.CHANGE_OF_NAME: return FilingNames.CHANGE_OF_NAME
+      case FilingTypes.CHANGE_OF_REGISTRATION: return FilingNames.CHANGE_OF_REGISTRATION
       case FilingTypes.CONVERSION: return FilingNames.CONVERSION
       case FilingTypes.CORRECTION: return FilingNames.CORRECTION
       case FilingTypes.COURT_ORDER: return FilingNames.COURT_ORDER

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -139,6 +139,7 @@ export default class FilingMixin extends Mixins(DateMixin) {
         correctedFilingId: correctedFiling.header.filingId,
         correctedFilingType: correctedFiling.header.name,
         correctedFilingDate: correctedFiling.header.date,
+        type: correctedFiling.correction.type,
         comment: ''
         // type: ... // *** FUTURE: implement this
       }

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -2,7 +2,7 @@ import { Component, Mixins } from 'vue-property-decorator'
 import { DateMixin } from '@/mixins'
 import { Action, State, Getter } from 'vuex-class'
 import { CommentIF, CorrectionFilingIF, DissolutionFilingIF, FilingDataIF, OfficeAddressIF } from '@/interfaces'
-import { CorpTypeCd, DissolutionTypes, FilingCodes, FilingTypes } from '@/enums'
+import { CorpTypeCd, CorrectionTypes, DissolutionTypes, FilingCodes, FilingTypes } from '@/enums'
 
 /**
  * Mixin that provides some useful filing utilities.
@@ -95,7 +95,7 @@ export default class FilingMixin extends Mixins(DateMixin) {
    * @param correctedFiling the IA filing to correct
    * @returns the IA Correction filing body
    */
-  buildIaCorrectionFiling (correctedFiling: any): CorrectionFilingIF {
+  buildIaCorrectionFiling (correctedFiling: any, correctionType: CorrectionTypes): CorrectionFilingIF {
     const correctionFiling: CorrectionFilingIF = {
       header: {
         name: FilingTypes.CORRECTION,
@@ -110,7 +110,8 @@ export default class FilingMixin extends Mixins(DateMixin) {
         correctedFilingId: correctedFiling.header.filingId,
         correctedFilingType: FilingTypes.INCORPORATION_APPLICATION,
         correctedFilingDate: correctedFiling.header.date,
-        comment: ''
+        comment: '',
+        type: correctionType
       },
       incorporationApplication: correctedFiling.incorporationApplication
     }
@@ -124,7 +125,7 @@ export default class FilingMixin extends Mixins(DateMixin) {
    * @param correctedFiling the Change of Registration or Registration filing to correct
    * @returns the Firm Correction filing body
    */
-  buildFmCorrectionFiling (correctedFiling: any): CorrectionFilingIF {
+  buildFmCorrectionFiling (correctedFiling: any, correctionType: CorrectionTypes): CorrectionFilingIF {
     const correctionFiling: CorrectionFilingIF = {
       header: {
         name: FilingTypes.CORRECTION,
@@ -139,9 +140,8 @@ export default class FilingMixin extends Mixins(DateMixin) {
         correctedFilingId: correctedFiling.header.filingId,
         correctedFilingType: correctedFiling.header.name,
         correctedFilingDate: correctedFiling.header.date,
-        type: correctedFiling.correction.type,
-        comment: ''
-        // type: ... // *** FUTURE: implement this
+        comment: '',
+        type: correctionType
       }
     }
 

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -191,7 +191,7 @@ import { ConfirmDialog, LoadCorrectionDialog, PaymentErrorDialog, ResumeErrorDia
 
 // Mixins, enums and interfaces
 import { CommonMixin, DateMixin, EnumMixin, FilingMixin, LegalApiMixin, ResourceLookupMixin } from '@/mixins'
-import { CorpTypeCd, FilingCodes, FilingStatus, FilingTypes, Routes, SaveErrorReasons,
+import { CorpTypeCd, CorrectionTypes, FilingCodes, FilingStatus, FilingTypes, Routes, SaveErrorReasons,
   StaffPaymentOptions } from '@/enums'
 import { ActionBindingIF, ConfirmDialogType, FilingDataIF, StaffPaymentIF } from '@/interfaces'
 
@@ -263,6 +263,7 @@ export default class Correction extends Mixins(
   private haveChanges = false
   private saveErrors = []
   private saveWarnings = []
+  private correctionType: CorrectionTypes
 
   /** True if loading container should be shown, else False. */
   get showLoadingContainer (): boolean {
@@ -363,6 +364,8 @@ export default class Correction extends Mixins(
     // this is the id of the original filing to correct
     this.correctedFilingId = +this.$route.params.correctedFilingId // number (may be NaN)
 
+    // this is the correction type of either client or staff
+    // this.correctionType = this.$route.params.correctionUserType
     // if required data isn't set, go back to dashboard
     if (!this.getIdentifier || isNaN(this.correctedFilingId)) {
       this.$router.push({ name: Routes.DASHBOARD })
@@ -692,14 +695,14 @@ export default class Correction extends Mixins(
         correctedFilingId: this.correctedFilingId,
         correctedFilingType: this.origFiling.header.name,
         correctedFilingDate: this.dateToYyyyMmDd(this.apiToDate(this.origFiling.header.date)),
-        comment: `${this.defaultComment}\n${this.detailComment}`
+        comment: `${this.defaultComment}\n${this.detailComment}`,
+        type: this.correctionType
       }
     }
 
     // build filing data
     // NB: a correction to a correction is applied to the original data
     const data = Object.assign({}, header, business, correction)
-
     try {
       let ret
       if (this.filingId > 0) {

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -191,7 +191,7 @@ import { ConfirmDialog, LoadCorrectionDialog, PaymentErrorDialog, ResumeErrorDia
 
 // Mixins, enums and interfaces
 import { CommonMixin, DateMixin, EnumMixin, FilingMixin, LegalApiMixin, ResourceLookupMixin } from '@/mixins'
-import { CorpTypeCd, CorrectionTypes, FilingCodes, FilingStatus, FilingTypes, Routes, SaveErrorReasons,
+import { CorpTypeCd, FilingCodes, FilingStatus, FilingTypes, Routes, SaveErrorReasons,
   StaffPaymentOptions } from '@/enums'
 import { ActionBindingIF, ConfirmDialogType, FilingDataIF, StaffPaymentIF } from '@/interfaces'
 
@@ -263,7 +263,6 @@ export default class Correction extends Mixins(
   private haveChanges = false
   private saveErrors = []
   private saveWarnings = []
-  private correctionType: CorrectionTypes
 
   /** True if loading container should be shown, else False. */
   get showLoadingContainer (): boolean {
@@ -695,8 +694,7 @@ export default class Correction extends Mixins(
         correctedFilingId: this.correctedFilingId,
         correctedFilingType: this.origFiling.header.name,
         correctedFilingDate: this.dateToYyyyMmDd(this.apiToDate(this.origFiling.header.date)),
-        comment: `${this.defaultComment}\n${this.detailComment}`,
-        type: this.correctionType
+        comment: `${this.defaultComment}\n${this.detailComment}`
       }
     }
 

--- a/tests/unit/Correction.spec.ts
+++ b/tests/unit/Correction.spec.ts
@@ -239,12 +239,13 @@ describe('Correction - UI', () => {
       ))
 
     // mock $route
-    const $route = { params: { filingId: '0', correctedFilingId: '123' } }
+    const $route = { params: { filingId: '0', correctedFilingId: '123', correctionType: 'CLIENT' } }
 
     // create local Vue and mock router
     createLocalVue().use(VueRouter)
     const router = mockRouter.mock()
-    router.push({ name: 'correction', params: { filingId: '0', correctedFilingId: '123' } })
+    router.push({ name: 'correction',
+      params: { filingId: '0', correctedFilingId: '123', correctionType: 'CLIENT' } })
 
     const wrapper = mount(Correction, {
       store,

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -711,6 +711,7 @@ describe('Filing History List - redirections', () => {
     const staffRadioBtn = wrapper.find('#correct-staff-radio')
     expect(staffRadioBtn).toBeDefined()
     staffRadioBtn.trigger('click')
+    await flushPromises()
 
     // verify redirection
     const startCorrectionBtn = wrapper.find('#dialog-start-button')

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -699,7 +699,26 @@ describe('Filing History List - redirections', () => {
     fileCorrectionItem.trigger('click')
     await flushPromises()
 
+    // verify to display the correction dialog modal
+    const fileCorrectionDialog = wrapper.find('#correction-filing-dialog')
+    expect(fileCorrectionDialog).toBeDefined()
+
+    // verify radio buttons for client and staff
+    const clientRadioBtn = wrapper.find('#correct-client-radio')
+    expect(clientRadioBtn).toBeDefined()
+
+    // click the staff radio button
+    const staffRadioBtn = wrapper.find('#correct-staff-radio')
+    expect(staffRadioBtn).toBeDefined()
+    staffRadioBtn.trigger('click')
+    await flushPromises()
+
     // verify redirection
+    const startCorrectionBtn = wrapper.find('#dialog-start-button')
+    expect(startCorrectionBtn).toBeDefined()
+    startCorrectionBtn.trigger('click')
+    await flushPromises()
+
     const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const createUrl = 'https://edit.url/BC1234567/correction/?correction-id=110514'
     expect(window.location.assign).toHaveBeenCalledWith(createUrl + '&accountid=' + accountId)

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -711,7 +711,6 @@ describe('Filing History List - redirections', () => {
     const staffRadioBtn = wrapper.find('#correct-staff-radio')
     expect(staffRadioBtn).toBeDefined()
     staffRadioBtn.trigger('click')
-    await flushPromises()
 
     // verify redirection
     const startCorrectionBtn = wrapper.find('#dialog-start-button')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12392

*Description of changes:*
- [x] created `FileCorrectionDialog.vue` for correction dialog modal
- [x] updated the logic to enable correction for corrected filings
- [x] updated redirect url for firm corrections
- [x] updated correction interfaces to fit the [new schema](https://github.com/bcgov/business-schemas/blob/main/src/registry_schemas/schemas/correction.json)
- [x] Allow correction of firm filing types (but retain other "can't correct" conditions).
- [x] Implement STAFF/CLIENT modal for firm corrections.
- [x] unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
