### PR TITLE
13320 Allow correction to a corrected or correction filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.2.21",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.2.21",
+      "version": "5.3.0",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.2.21",
+  "version": "5.3.0",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -909,13 +909,11 @@ export default class FilingHistoryList extends Mixins(
       item.availableOnPaperOnly ||
       item.isTypeStaff ||
       item.isFutureEffective ||
-      this.isStatusCorrected(item) ||
       this.isTypeAlteration(item) ||
       this.isTypeCorrection(item) ||
       this.isTypeTransition(item) ||
-      this.isTypeIncorporationApplication(item) || // *** temporary
       // the following corrections are supported:
-      // (this.isTypeIncorporationApplication(item) && !this.isBComp) || // *** temporary
+      (this.isTypeIncorporationApplication(item) && !this.isBComp) ||
       (this.isTypeChangeOfRegistration(item) && !this.isFirm) ||
       (this.isTypeRegistration(item) && !this.isFirm)
     )

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -910,7 +910,6 @@ export default class FilingHistoryList extends Mixins(
       item.isTypeStaff ||
       item.isFutureEffective ||
       this.isTypeAlteration(item) ||
-      this.isTypeCorrection(item) ||
       this.isTypeTransition(item) ||
       // the following corrections are supported:
       (this.isTypeIncorporationApplication(item) && !this.isBComp) ||

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -373,6 +373,21 @@ describe('Filing History List - misc functionality', () => {
     jest.spyOn(vm, 'isAllowed').mockReturnValue(true)
     expect(vm.disableCorrection({ ...item })).toBe(false)
 
+    // corrected filing:
+    expect(vm.disableCorrection({ ...item, status: 'CORRECTED' })).toBe(false)
+
+    // IA as a BEN
+    store.state.entityType = 'BEN'
+    expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(false)
+
+    // Change of Registration as a firm
+    store.state.entityType = 'SP'
+    expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(false)
+
+    // Registration as a firm
+    store.state.entityType = 'SP'
+    expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(false)
+
     // only first condition:
     jest.spyOn(vm, 'isAllowed').mockReturnValue(false)
     expect(vm.disableCorrection({ ...item })).toBe(true)
@@ -388,24 +403,25 @@ describe('Filing History List - misc functionality', () => {
     expect(vm.disableCorrection({ ...item, isFutureEffective: true })).toBe(true)
 
     // only fifth condition:
-    expect(vm.disableCorrection({ ...item, status: 'CORRECTED' })).toBe(true)
-
-    // only sixth condition:
     expect(vm.disableCorrection({ ...item, name: 'alteration' })).toBe(true)
 
-    // only seventh condition:
+    // only sixth condition:
     expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(true)
 
-    // only eighth condition:
+    // only seventh condition:
     expect(vm.disableCorrection({ ...item, name: 'transition' })).toBe(true)
 
-    // only ninth condition (as a BEN):
-    store.state.entityType = 'BEN'
-    // expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(false) // *** temporary
-
-    // only ninth condition (as a CP):
+    // only eighth condition (as not a BEN):
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(true)
+
+    // only ninth condition (as not a firm):
+    store.state.entityType = 'CP'
+    expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(true)
+
+    // only tenth condition (as not a firm):
+    store.state.entityType = 'CP'
+    expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(true)
   })
 })
 

--- a/tests/unit/FilingHistoryList.spec.ts
+++ b/tests/unit/FilingHistoryList.spec.ts
@@ -376,15 +376,18 @@ describe('Filing History List - misc functionality', () => {
     // corrected filing:
     expect(vm.disableCorrection({ ...item, status: 'CORRECTED' })).toBe(false)
 
-    // IA as a BEN
+    // correction filing:
+    expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(false)
+
+    // IA as a BEN:
     store.state.entityType = 'BEN'
     expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(false)
 
-    // Change of Registration as a firm
+    // Change of Registration as a firm:
     store.state.entityType = 'SP'
     expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(false)
 
-    // Registration as a firm
+    // Registration as a firm:
     store.state.entityType = 'SP'
     expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(false)
 
@@ -406,20 +409,17 @@ describe('Filing History List - misc functionality', () => {
     expect(vm.disableCorrection({ ...item, name: 'alteration' })).toBe(true)
 
     // only sixth condition:
-    expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(true)
-
-    // only seventh condition:
     expect(vm.disableCorrection({ ...item, name: 'transition' })).toBe(true)
 
-    // only eighth condition (as not a BEN):
+    // only seventh condition (as not a BEN):
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(true)
 
-    // only ninth condition (as not a firm):
+    // only eighth condition (as not a firm):
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(true)
 
-    // only tenth condition (as not a firm):
+    // only ninth condition (as not a firm):
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(true)
   })


### PR DESCRIPTION
*Issue #:* bcgov/entity#13320

*Description of changes:*
- allow corrections to corrected filings
- allow corrections to BEN IAs
- allow corrections to corrections
- updated unit tests
- app version = 5.3.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).