### PR TITLE
13347 Stop attaching corrected filing to draft corrections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/correction-filing-interface.ts
+++ b/src/interfaces/correction-filing-interface.ts
@@ -24,8 +24,5 @@ export interface CorrectionFilingIF {
     correctedFilingDate: string
     type?: CorrectionTypes
     comment: string
-  },
-  incorporationApplication?: {},
-  changeOfRegistration?: {},
-  registration?: {}
+  }
 }

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -90,90 +90,49 @@ export default class FilingMixin extends Mixins(DateMixin) {
   }
 
   /**
-   * Builds an Incorporation Application Correction filing body from IA filing.
-   * Used when creating an IA Correction.
-   * @param correctedFiling the IA filing to correct
-   * @returns the IA Correction filing body
+   * Builds a Correction filing body.
+   * @param correctedFiling the filing to correct
+   * @param correctedType the correction type
+   * @returns the filing body
    */
-  buildIaCorrectionFiling (correctedFiling: any, correctionType: CorrectionTypes): CorrectionFilingIF {
+  buildCorrectionFiling (correctedFiling: any, correctionType: CorrectionTypes): CorrectionFilingIF {
     const correctionFiling: CorrectionFilingIF = {
       header: {
-        name: FilingTypes.CORRECTION,
-        date: this.getCurrentDate
+        date: this.getCurrentDate,
+        name: FilingTypes.CORRECTION
       },
       business: {
-        legalType: correctedFiling.business.legalType,
-        identifier: correctedFiling.business.identifier,
-        legalName: correctedFiling.business.legalName
+        identifier: this.getIdentifier,
+        legalName: this.entityName, // may be undefined
+        legalType: this.getEntityType
       },
       correction: {
-        correctedFilingId: correctedFiling.header.filingId,
-        correctedFilingType: FilingTypes.INCORPORATION_APPLICATION,
-        correctedFilingDate: correctedFiling.header.date,
         comment: '',
-        type: correctionType
-      },
-      incorporationApplication: correctedFiling.incorporationApplication
-    }
-
-    return correctionFiling
-  }
-
-  /**
-   * Builds a Firm Correction filing body from a Registration or Change of Registration filing.
-   * Used when creating a Firm Correction.
-   * @param correctedFiling the Change of Registration or Registration filing to correct
-   * @returns the Firm Correction filing body
-   */
-  buildFmCorrectionFiling (correctedFiling: any, correctionType: CorrectionTypes): CorrectionFilingIF {
-    const correctionFiling: CorrectionFilingIF = {
-      header: {
-        name: FilingTypes.CORRECTION,
-        date: this.getCurrentDate
-      },
-      business: {
-        legalType: correctedFiling.business.legalType,
-        identifier: correctedFiling.business.identifier,
-        legalName: correctedFiling.business.legalName
-      },
-      correction: {
-        correctedFilingId: correctedFiling.header.filingId,
-        correctedFilingType: correctedFiling.header.name,
-        correctedFilingDate: correctedFiling.header.date,
-        comment: '',
+        correctedFilingDate: correctedFiling.submittedDate,
+        correctedFilingId: correctedFiling.filingId,
+        correctedFilingType: correctedFiling.name,
         type: correctionType
       }
     }
 
-    // add in original Change of Registration filing
-    if (correctedFiling.changeOfRegistration) {
-      correctionFiling.changeOfRegistration = correctedFiling.changeOfRegistration
-    }
-
-    // add in original Registration filing
-    if (correctedFiling.registration) {
-      correctionFiling.registration = correctedFiling.registration
-    }
-
     return correctionFiling
   }
 
   /**
-   * Builds an Dissolution filing body to intialize a draft.
-   * Used when creating a draft Dissolution filing.
-   * @returns the Dissolution filing body
+   * Builds a Dissolution filing body. Used when creating a draft Dissolution filing.
+   * @returns the filing body
    */
   buildDissolutionFiling (): DissolutionFilingIF {
     const dissolutionFiling: DissolutionFilingIF = {
       header: {
-        name: FilingTypes.DISSOLUTION,
-        date: this.getCurrentDate
+        date: this.getCurrentDate,
+        name: FilingTypes.DISSOLUTION
       },
       business: {
-        legalType: this.getEntityType,
+        foundingDate: this.dateToApi(this.getEntityFoundingDate),
         identifier: this.getIdentifier,
         legalName: this.entityName,
-        foundingDate: this.dateToApi(this.getEntityFoundingDate)
+        legalType: this.getEntityType
       },
       dissolution: {
         custodialOffice: this.getRegisteredOfficeAddress,
@@ -185,9 +144,9 @@ export default class FilingMixin extends Mixins(DateMixin) {
     switch (this.getEntityType) {
       case CorpTypeCd.SOLE_PROP:
       case CorpTypeCd.PARTNERSHIP:
-        dissolutionFiling.dissolution = { ...dissolutionFiling.dissolution,
+        dissolutionFiling.dissolution = {
+          ...dissolutionFiling.dissolution,
           custodialOffice: this.getBusinessAddress || null
-
         }
         break
     }


### PR DESCRIPTION
*Issue #:* bcgov/entity#13347

*Description of changes:*
- no longer fetch corrected filing
- no longer attach corrected filing to correction
- deleted obsolete comments
- updated Correction Filing interface
- combined/updated correction build methods
- app version = 5.3.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).