### PR TITLE
12671 Add missing gavel to Court order filings in list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.6.2",
+      "version": "5.6.3",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -29,7 +29,7 @@
     <!-- Display for if a court order(s) have been filed -->
     <v-card v-if="hasCourtOrders" class="my-6 pa-6" elevation="0">
       <v-icon>mdi-gavel</v-icon>
-      <span>Court order(s) have been filed on this company. Review the filing history for impacts to business
+      <span> Court order(s) have been filed on this company. Review the filing history for impacts to business
         information.</span>
     </v-card>
 
@@ -54,8 +54,10 @@
             <div class="item-header d-flex">
               <!-- the filing label (left side) -->
               <div class="item-header__label">
-                <h3 class="item-header__title"><v-icon v-if="filing.displayName==FilingNames.COURT_ORDER">mdi-gavel
-                </v-icon>{{filing.displayName}}</h3>
+                <h3 class="item-header__title">
+                  <v-icon v-if="filing.displayName==FilingNames.COURT_ORDER" class="pr-1">mdi-gavel</v-icon>
+                  <span>{{filing.displayName}}</span>
+                  </h3>
 
                 <!-- NB: blocks below are mutually exclusive, and order is important -->
 
@@ -919,7 +921,6 @@ export default class FilingHistoryList extends Mixins(
 
 .v-icon.mdi-gavel {
   color: $gray9;
-  padding-right: 4px;
 }
 
 .scrollable-container {

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -29,7 +29,7 @@
     <!-- Display for if a court order(s) have been filed -->
     <v-card v-if="hasCourtOrders" class="my-6 pa-6" elevation="0">
       <v-icon>mdi-gavel</v-icon>
-      <span> Court order(s) have been filed on this company. Review the filing history for impacts to business
+      <span>Court order(s) have been filed on this company. Review the filing history for impacts to business
         information.</span>
     </v-card>
 
@@ -54,7 +54,8 @@
             <div class="item-header d-flex">
               <!-- the filing label (left side) -->
               <div class="item-header__label">
-                <h3 class="item-header__title">{{filing.displayName}}</h3>
+                <h3 class="item-header__title"><v-icon v-if="filing.displayName==FilingNames.COURT_ORDER">mdi-gavel
+                </v-icon>{{filing.displayName}}</h3>
 
                 <!-- NB: blocks below are mutually exclusive, and order is important -->
 
@@ -371,7 +372,7 @@ import StaffFiling from './FilingHistoryList/StaffFiling.vue'
 import { AddCommentDialog, DownloadErrorDialog, FileCorrectionDialog, LoadCorrectionDialog } from '@/components/dialogs'
 
 // Enums, interfaces and mixins
-import { AllowableActions, FilingTypes, Routes, CorrectionTypes } from '@/enums'
+import { AllowableActions, FilingTypes, Routes, CorrectionTypes, FilingNames } from '@/enums'
 import { ActionBindingIF, ApiFilingIF, CorrectionFilingIF, DocumentIF, HistoryItemIF, LegalFilingIF }
   from '@/interfaces'
 import { AllowableActionsMixin, DateMixin, EnumMixin, FilingMixin, LegalApiMixin } from '@/mixins'
@@ -425,6 +426,7 @@ export default class FilingHistoryList extends Mixins(
 
   // enum for template
   readonly AllowableActions = AllowableActions
+  readonly FilingNames = FilingNames
 
   /** The Edit URL string. */
   get editUrl (): string {
@@ -917,6 +919,7 @@ export default class FilingHistoryList extends Mixins(
 
 .v-icon.mdi-gavel {
   color: $gray9;
+  padding-right: 4px;
 }
 
 .scrollable-container {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12671

*Description of changes:*
 - add gavel icon for court order title in the filing list
 - Requested UI change on this PR bcgov/business-filings-ui/pull/393


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
