### PR TITLE
13953 Conditionally hide alert phone numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.10",
+  "version": "5.7.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.7.10",
+      "version": "5.7.11",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.10",
+  "version": "5.7.11",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/Alerts/MissingInformation.vue
+++ b/src/components/Dashboard/Alerts/MissingInformation.vue
@@ -24,7 +24,11 @@
         <p class="mb-0 pt-5">
           If further action is required, please contact BC Registries staff:
         </p>
-        <ContactInfo class="pt-5" />
+        <ContactInfo
+          class="pt-5"
+          :hidePhoneTollFree="hidePhoneNumbers"
+          :hidePhoneVictoria="hidePhoneNumbers"
+        />
       </v-expansion-panel-content>
     </v-expansion-panel>
   </v-expansion-panels>
@@ -33,16 +37,25 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
+import { Getter } from 'vuex-class'
 import { ContactInfo } from '@/components/common'
+import { getFeatureFlag } from '@/utils'
 
 @Component({
   components: { ContactInfo }
 })
 export default class MissingInformation extends Vue {
-  protected panel = 1
+  @Getter isFirm!: boolean
 
-  protected togglePanel (): void {
+  private panel = 1
+
+  private togglePanel (): void {
     this.panel = (this.panel === 1 ? 0 : 1)
+  }
+
+  get hidePhoneNumbers (): boolean {
+    // hide for firms without FF
+    return (this.isFirm && !getFeatureFlag('show-alert-phone-numbers-firm'))
   }
 }
 </script>

--- a/src/components/common/ContactInfo.vue
+++ b/src/components/common/ContactInfo.vue
@@ -1,16 +1,16 @@
 <template>
   <ul class="contact-info pl-0">
-    <li class="contact-container">
+    <li class="contact-container" v-if="!hidePhoneTollFree">
       <v-icon class="contact-icon" size="18px">mdi-phone</v-icon>
       <span class="px-2">Canada and U.S. Toll Free:</span>
       <a href="tel:+1-877-526-1526" class="contact-value">1-877-526-1526</a>
     </li>
-    <li class="contact-container">
+    <li class="contact-container" v-if="!hidePhoneVictoria">
       <v-icon class="contact-icon" size="18px">mdi-phone</v-icon>
       <span class="px-2">Victoria Office:</span>
       <a href="tel:+1-250-387-7848" class="contact-value">250-387-7848</a>
     </li>
-    <li class="contact-container">
+    <li class="contact-container" v-if="!hideEmail">
       <v-icon class="contact-icon" size="18px">mdi-email</v-icon>
       <span class="px-2">Email:</span>
       <a href="mailto:BCRegistries@gov.bc.ca" class="contact-value">BCRegistries@gov.bc.ca</a>
@@ -20,10 +20,19 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { Component } from 'vue-property-decorator'
+import { Component, Prop } from 'vue-property-decorator'
 
 @Component({})
-export default class ContactInfo extends Vue {}
+export default class ContactInfo extends Vue {
+  /** Whether to hide the toll free phone number. */
+  @Prop({ default: false }) readonly hidePhoneTollFree!: boolean
+
+  /** Whether to hide the Victoria phone number. */
+  @Prop({ default: false }) readonly hidePhoneVictoria!: boolean
+
+  /** Whether to hide the email address. */
+  @Prop({ default: false }) readonly hideEmail!: boolean
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -10,7 +10,8 @@ declare const window: any
 const defaultFlagSet: LDFlagSet = {
   'supported-dissolution-entities': [],
   'supported-business-summary-entities': [],
-  'enable-digital-credentials': false
+  'enable-digital-credentials': false,
+  'show-alert-phone-numbers-firm': false
 }
 
 /**

--- a/tests/unit/MissingInformation.spec.ts
+++ b/tests/unit/MissingInformation.spec.ts
@@ -1,16 +1,18 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import { mount } from '@vue/test-utils'
+import { getVuexStore } from '@/store'
 import MissingInformation from '@/components/Dashboard/Alerts/MissingInformation.vue'
 import { ContactInfo } from '@/components/common'
 
 Vue.use(Vuetify)
 
 const vuetify = new Vuetify({})
+const store = getVuexStore() as any // remove typings for unit tests
 
 describe('Missing Information component', () => {
   it('Displays expansion panel closed', () => {
-    const wrapper = mount(MissingInformation, { vuetify })
+    const wrapper = mount(MissingInformation, { store, vuetify })
 
     // verify content
     expect(wrapper.find('h3').text()).toBe('Missing information')
@@ -21,7 +23,7 @@ describe('Missing Information component', () => {
   })
 
   it('Displays expansion panel open', async () => {
-    const wrapper = mount(MissingInformation, { vuetify })
+    const wrapper = mount(MissingInformation, { store, vuetify })
 
     // click the button
     wrapper.find('.details-btn').trigger('click')


### PR DESCRIPTION
*Issue #:* bcgov/entity#13953

*Description of changes:*
- added ability to hide Contact Info phone numbers
- added logic to hide phone numbers in Missing Information alert
- added feature flag to enable logic
- app version = 5.7.11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).