### PR TITLE
14159 Allow corrections to correction and conversion filings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.14",
+  "version": "5.7.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.7.14",
+      "version": "5.7.15",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.14",
+  "version": "5.7.15",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1367,20 +1367,25 @@ export default class TodoList extends Vue {
         break
 
       case FilingTypes.CORRECTION:
-        if (
-          (item.correctedFilingType === FilingNames.INCORPORATION_APPLICATION) ||
-          (item.correctedFilingType === FilingNames.CHANGE_OF_REGISTRATION) ||
-          (item.correctedFilingType === FilingNames.REGISTRATION)
-        ) {
-          // navigate to Edit UI to resume this correction
-          const correctionUrl = `${this.editUrl}${this.getIdentifier}/correction/?correction-id=${item.filingId}`
-          navigate(correctionUrl)
-        } else {
-          // resume this Correction locally
-          this.setCurrentFilingStatus(FilingStatus.DRAFT)
-          this.$router.push({ name: Routes.CORRECTION,
-            params: { filingId: item.filingId.toString(), correctedFilingId: item.correctedFilingId.toString() }
-          })
+        switch (item.correctedFilingType) {
+          case FilingNames.INCORPORATION_APPLICATION:
+          case FilingNames.CHANGE_OF_REGISTRATION:
+          case FilingNames.CONVERSION:
+          case FilingNames.CORRECTION:
+          case FilingNames.REGISTRATION:
+            // resume correction via Edit UI
+            const correctionUrl = `${this.editUrl}${this.getIdentifier}/correction/?correction-id=${item.filingId}`
+            navigate(correctionUrl)
+            break
+
+          default:
+            // resume local correction for all other filings
+            this.setCurrentFilingStatus(FilingStatus.DRAFT)
+            this.$router.push({
+              name: Routes.CORRECTION,
+              params: { filingId: item.filingId.toString(), correctedFilingId: item.correctedFilingId.toString() }
+            })
+            break
         }
         break
 

--- a/tests/unit/FilingHistoryList1.spec.ts
+++ b/tests/unit/FilingHistoryList1.spec.ts
@@ -377,9 +377,6 @@ describe('Filing History List - misc functionality', () => {
     // corrected filing:
     expect(vm.disableCorrection({ ...item, status: 'CORRECTED' })).toBe(false)
 
-    // correction filing:
-    expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(false)
-
     // IA as a BEN:
     store.state.entityType = 'BEN'
     expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(false)
@@ -388,39 +385,59 @@ describe('Filing History List - misc functionality', () => {
     store.state.entityType = 'SP'
     expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(false)
 
+    // Conversion as a firm:
+    store.state.entityType = 'SP'
+    expect(vm.disableCorrection({ ...item, name: 'conversion' })).toBe(false)
+
+    // Correction as a firm:
+    store.state.entityType = 'SP'
+    expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(false)
+
+    // Correction as a BEN:
+    store.state.entityType = 'BEN'
+    expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(false)
+
     // Registration as a firm:
     store.state.entityType = 'SP'
     expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(false)
 
-    // only first condition:
+    // only conditions[0]:
     jest.spyOn(vm, 'isAllowed').mockReturnValue(false)
     expect(vm.disableCorrection({ ...item })).toBe(true)
     jest.spyOn(vm, 'isAllowed').mockReturnValue(true)
 
-    // only second condition:
+    // only conditions[1]:
     expect(vm.disableCorrection({ ...item, availableOnPaperOnly: true })).toBe(true)
 
-    // only third condition:
+    // only conditions[2]:
     expect(vm.disableCorrection({ ...item, isTypeStaff: true })).toBe(true)
 
-    // only fourth condition:
+    // only conditions[3]:
     expect(vm.disableCorrection({ ...item, isFutureEffective: true })).toBe(true)
 
-    // only fifth condition:
+    // only conditions[4]:
     expect(vm.disableCorrection({ ...item, name: 'alteration' })).toBe(true)
 
-    // only sixth condition:
+    // only conditions[5]:
     expect(vm.disableCorrection({ ...item, name: 'transition' })).toBe(true)
 
-    // only seventh condition (as not a BEN):
+    // only conditions[6] (as not a BEN):
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(true)
 
-    // only eighth condition (as not a firm):
+    // only conditions[7] (as not a firm):
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(true)
 
-    // only ninth condition (as not a firm):
+    // only conditions[8] (as not a firm):
+    store.state.entityType = 'CP'
+    expect(vm.disableCorrection({ ...item, name: 'conversion' })).toBe(true)
+
+    // only conditions[9] (as not a firm):
+    store.state.entityType = 'CP'
+    expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(true)
+
+    // only conditions[10] (as not a firm):
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(true)
   })


### PR DESCRIPTION
*Issue #:* bcgov/entity#14159

*Description of changes:*
- updated correctThisFiling() to handle other filing types
- updated disableCorrection() to handle other filing types
- updated doResumeFiling() to handle other filing types
- refactored disableCorrection() to better line up with unit test
- updated unit test
- app version = 5.7.15

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).