### PR TITLE
14159 Disabled conversion corrections + cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.15",
+  "version": "5.7.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.7.15",
+      "version": "5.7.16",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.15",
+  "version": "5.7.16",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -715,8 +715,10 @@ export default class FilingHistoryList extends Vue {
         break
 
       case FilingTypes.ANNUAL_REPORT:
+      case FilingTypes.ALTERATION:
       case FilingTypes.CHANGE_OF_ADDRESS:
       case FilingTypes.CHANGE_OF_DIRECTORS:
+      case FilingTypes.CONVERSION:
       default:
         // local correction for all other filings
         this.$router.push({
@@ -881,12 +883,10 @@ export default class FilingHistoryList extends Vue {
     conditions[1] = () => item.availableOnPaperOnly
     conditions[2] = () => item.isTypeStaff
     conditions[3] = () => item.isFutureEffective
-    conditions[4] = () => this.isTypeAlteration(item)
-    conditions[5] = () => this.isTypeConversion(item)
-    conditions[6] = () => (this.isTypeIncorporationApplication(item) && !this.isBComp)
-    conditions[7] = () => (this.isTypeChangeOfRegistration(item) && !this.isFirm)
-    conditions[8] = () => (this.isTypeCorrection(item) && !this.isFirm && !this.isBComp)
-    conditions[9] = () => (this.isTypeRegistration(item) && !this.isFirm)
+    conditions[4] = () => (this.isTypeIncorporationApplication(item) && !this.isBComp)
+    conditions[5] = () => (this.isTypeChangeOfRegistration(item) && !this.isFirm)
+    conditions[6] = () => (this.isTypeCorrection(item) && !this.isFirm && !this.isBComp)
+    conditions[7] = () => (this.isTypeRegistration(item) && !this.isFirm)
 
     return conditions.some(condition => condition())
   }

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -703,10 +703,10 @@ export default class FilingHistoryList extends Vue {
 
   /** Called by File a Correction button to correct the subject filing. */
   protected async correctThisFiling (item: HistoryItemIF): Promise<void> {
+    // see also TodoList.vue:doResumeFiling()
     switch (item?.name) {
       case FilingTypes.INCORPORATION_APPLICATION:
       case FilingTypes.CHANGE_OF_REGISTRATION:
-      case FilingTypes.CONVERSION:
       case FilingTypes.CORRECTION:
       case FilingTypes.REGISTRATION:
         // correction via Edit UI
@@ -714,6 +714,9 @@ export default class FilingHistoryList extends Vue {
         this.fileCorrectionDialog = true
         break
 
+      case FilingTypes.ANNUAL_REPORT:
+      case FilingTypes.CHANGE_OF_ADDRESS:
+      case FilingTypes.CHANGE_OF_DIRECTORS:
       default:
         // local correction for all other filings
         this.$router.push({
@@ -872,18 +875,18 @@ export default class FilingHistoryList extends Vue {
   protected disableCorrection (item: HistoryItemIF): boolean {
     const conditions: Array<() => boolean> = []
 
-    // any cases not listed below are allowed (enabled)
+    // list of cases to disable correction
+    // (any case not listed below is ALLOWED)
     conditions[0] = () => !this.isAllowed(AllowableActions.FILE_CORRECTION)
     conditions[1] = () => item.availableOnPaperOnly
     conditions[2] = () => item.isTypeStaff
     conditions[3] = () => item.isFutureEffective
     conditions[4] = () => this.isTypeAlteration(item)
-    conditions[5] = () => this.isTypeTransition(item)
+    conditions[5] = () => this.isTypeConversion(item)
     conditions[6] = () => (this.isTypeIncorporationApplication(item) && !this.isBComp)
     conditions[7] = () => (this.isTypeChangeOfRegistration(item) && !this.isFirm)
-    conditions[8] = () => (this.isTypeConversion(item) && !this.isFirm)
-    conditions[9] = () => (this.isTypeCorrection(item) && !this.isFirm && !this.isBComp)
-    conditions[10] = () => (this.isTypeRegistration(item) && !this.isFirm)
+    conditions[8] = () => (this.isTypeCorrection(item) && !this.isFirm && !this.isBComp)
+    conditions[9] = () => (this.isTypeRegistration(item) && !this.isFirm)
 
     return conditions.some(condition => condition())
   }

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1379,8 +1379,10 @@ export default class TodoList extends Vue {
             break
 
           case FilingTypes.ANNUAL_REPORT:
+          case FilingTypes.ALTERATION:
           case FilingTypes.CHANGE_OF_ADDRESS:
           case FilingTypes.CHANGE_OF_DIRECTORS:
+          case FilingTypes.CONVERSION:
           default:
             // resume local correction for all other filings
             this.setCurrentFilingStatus(FilingStatus.DRAFT)

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1367,10 +1367,10 @@ export default class TodoList extends Vue {
         break
 
       case FilingTypes.CORRECTION:
+        // see also FilingHistoryList.vue:correctThisFiling()
         switch (item.correctedFilingType) {
           case FilingNames.INCORPORATION_APPLICATION:
           case FilingNames.CHANGE_OF_REGISTRATION:
-          case FilingNames.CONVERSION:
           case FilingNames.CORRECTION:
           case FilingNames.REGISTRATION:
             // resume correction via Edit UI
@@ -1378,6 +1378,9 @@ export default class TodoList extends Vue {
             navigate(correctionUrl)
             break
 
+          case FilingTypes.ANNUAL_REPORT:
+          case FilingTypes.CHANGE_OF_ADDRESS:
+          case FilingTypes.CHANGE_OF_DIRECTORS:
           default:
             // resume local correction for all other filings
             this.setCurrentFilingStatus(FilingStatus.DRAFT)

--- a/tests/unit/FilingHistoryList1.spec.ts
+++ b/tests/unit/FilingHistoryList1.spec.ts
@@ -400,6 +400,12 @@ describe('Filing History List - misc functionality', () => {
       expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(false)
     }
 
+    // Annual Report, Alteration, Change of Address, Change of Directors, Conversion
+    const names = ['annualReport', 'alteration', 'changeOfAddress', 'changeOfDirectors', 'conversion']
+    for (const name of names) {
+      expect(vm.disableCorrection({ ...item, name })).toBe(false)
+    }
+
     //
     // Verify NOT ALLOWED (disabled=true):
     //
@@ -418,25 +424,19 @@ describe('Filing History List - misc functionality', () => {
     // only conditions[3]
     expect(vm.disableCorrection({ ...item, isFutureEffective: true })).toBe(true)
 
-    // only conditions[4]: Alteration
-    expect(vm.disableCorrection({ ...item, name: 'alteration' })).toBe(true)
-
-    // only conditions[5]: Conversion
-    expect(vm.disableCorrection({ ...item, name: 'conversion' })).toBe(true)
-
-    // only conditions[6]: IA as not a BEN
+    // only conditions[4]: IA as not a BEN
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(true)
 
-    // only conditions[7]: Change of Registration as not a firm
+    // only conditions[5]: Change of Registration as not a firm
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(true)
 
-    // only conditions[8]: Correction as not a firm nor BEN
+    // only conditions[6]: Correction as not a firm nor BEN
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(true)
 
-    // only conditions[9]: Registration as not a firm
+    // only conditions[7]: Registration as not a firm
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(true)
   })

--- a/tests/unit/FilingHistoryList1.spec.ts
+++ b/tests/unit/FilingHistoryList1.spec.ts
@@ -370,74 +370,73 @@ describe('Filing History List - misc functionality', () => {
       name: null
     }
 
-    // no conditions:
+    //
+    // Verify ALLOWED (disabled=false):
+    //
+
+    // no conditions
     jest.spyOn(vm, 'isAllowed').mockReturnValue(true)
     expect(vm.disableCorrection({ ...item })).toBe(false)
 
-    // corrected filing:
-    expect(vm.disableCorrection({ ...item, status: 'CORRECTED' })).toBe(false)
-
-    // IA as a BEN:
+    // conditions[6]: IA as a BEN
     store.state.entityType = 'BEN'
     expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(false)
 
-    // Change of Registration as a firm:
-    store.state.entityType = 'SP'
-    expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(false)
+    // conditions[7]: Change of Registration as a firm
+    for (const entityType of ['SP', 'GP']) {
+      store.state.entityType = entityType
+      expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(false)
+    }
 
-    // Conversion as a firm:
-    store.state.entityType = 'SP'
-    expect(vm.disableCorrection({ ...item, name: 'conversion' })).toBe(false)
+    // conditions[8]: Correction as a firm or BEN
+    for (const entityType of ['SP', 'GP', 'BEN']) {
+      store.state.entityType = entityType
+      expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(false)
+    }
 
-    // Correction as a firm:
-    store.state.entityType = 'SP'
-    expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(false)
+    // conditions[9]: Registration as a firm
+    for (const entityType of ['SP', 'GP']) {
+      store.state.entityType = entityType
+      expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(false)
+    }
 
-    // Correction as a BEN:
-    store.state.entityType = 'BEN'
-    expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(false)
+    //
+    // Verify NOT ALLOWED (disabled=true):
+    //
 
-    // Registration as a firm:
-    store.state.entityType = 'SP'
-    expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(false)
-
-    // only conditions[0]:
+    // only conditions[0]
     jest.spyOn(vm, 'isAllowed').mockReturnValue(false)
     expect(vm.disableCorrection({ ...item })).toBe(true)
     jest.spyOn(vm, 'isAllowed').mockReturnValue(true)
 
-    // only conditions[1]:
+    // only conditions[1]
     expect(vm.disableCorrection({ ...item, availableOnPaperOnly: true })).toBe(true)
 
-    // only conditions[2]:
+    // only conditions[2]
     expect(vm.disableCorrection({ ...item, isTypeStaff: true })).toBe(true)
 
-    // only conditions[3]:
+    // only conditions[3]
     expect(vm.disableCorrection({ ...item, isFutureEffective: true })).toBe(true)
 
-    // only conditions[4]:
+    // only conditions[4]: Alteration
     expect(vm.disableCorrection({ ...item, name: 'alteration' })).toBe(true)
 
-    // only conditions[5]:
-    expect(vm.disableCorrection({ ...item, name: 'transition' })).toBe(true)
+    // only conditions[5]: Conversion
+    expect(vm.disableCorrection({ ...item, name: 'conversion' })).toBe(true)
 
-    // only conditions[6] (as not a BEN):
+    // only conditions[6]: IA as not a BEN
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'incorporationApplication' })).toBe(true)
 
-    // only conditions[7] (as not a firm):
+    // only conditions[7]: Change of Registration as not a firm
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'changeOfRegistration' })).toBe(true)
 
-    // only conditions[8] (as not a firm):
-    store.state.entityType = 'CP'
-    expect(vm.disableCorrection({ ...item, name: 'conversion' })).toBe(true)
-
-    // only conditions[9] (as not a firm):
+    // only conditions[8]: Correction as not a firm nor BEN
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'correction' })).toBe(true)
 
-    // only conditions[10] (as not a firm):
+    // only conditions[9]: Registration as not a firm
     store.state.entityType = 'CP'
     expect(vm.disableCorrection({ ...item, name: 'registration' })).toBe(true)
   })

--- a/tests/unit/allowable-actions-mixin.spec.ts
+++ b/tests/unit/allowable-actions-mixin.spec.ts
@@ -121,9 +121,9 @@ describe('Allowable Actions Mixin', () => {
       { businessId: null, entityType: null, flag: 'CP BEN', expected: false },
       // only first condition:
       { businessId: 'CP1234567', entityType: null, flag: 'CP BEN', expected: false },
-      // // only second condition:
+      // only second condition:
       { businessId: null, entityType: 'CP', flag: 'CP BEN', expected: false },
-      // // all conditions:
+      // all conditions:
       { businessId: 'CP1234567', entityType: 'CP', flag: 'CP BEN', expected: true },
       { businessId: 'BC1234567', entityType: 'BEN', flag: 'CP BEN', expected: true },
       { businessId: 'BC1234567', entityType: 'BC', flag: 'CP BEN', expected: false },


### PR DESCRIPTION
*Issue #:* bcgov/entity#14159

*Description of changes:*
- disabled Conversion corrections
- un-disabled Transition corrections (now falls into "others enabled by default")
- updated unit tests
- app version = 5.7.16

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).