### PR TITLE
13232 Upgraded vue-test-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.16",
+  "version": "5.7.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.7.16",
+      "version": "5.7.17",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.2",
@@ -54,7 +54,7 @@
         "@vue/cli-service": "^4.5.19",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/eslint-config-typescript": "^4.0.0",
-        "@vue/test-utils": "1.0.0-beta.28",
+        "@vue/test-utils": "^1.3.3",
         "eslint": "^6.8.0",
         "eslint-plugin-vue": "^9.5.1",
         "flush-promises": "^1.0.2",
@@ -4736,13 +4736,14 @@
       "peer": true
     },
     "node_modules/@vue/test-utils": {
-      "version": "1.0.0-beta.28",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.28.tgz",
-      "integrity": "sha512-uVbFJG0g/H9hf2pgWUdhvQYItRGzQ44cMFf00wp0YEo85pxuvM9e3mx8QLQfx6R2CogxbK4CvV7qvkLblehXeQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.3.3.tgz",
+      "integrity": "sha512-DmZkKrH5/MSkrU0hhHhv5+aOXcEJSaOhutKMOh2viuiLiMaFeOLPiTEvtegLunO3rXBagzHO681qW1sNMaB1sQ==",
       "dev": true,
       "dependencies": {
         "dom-event-types": "^1.0.0",
-        "lodash": "^4.17.4"
+        "lodash": "^4.17.15",
+        "pretty": "^2.0.0"
       },
       "peerDependencies": {
         "vue": "2.x",
@@ -26991,13 +26992,14 @@
       "peer": true
     },
     "@vue/test-utils": {
-      "version": "1.0.0-beta.28",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.28.tgz",
-      "integrity": "sha512-uVbFJG0g/H9hf2pgWUdhvQYItRGzQ44cMFf00wp0YEo85pxuvM9e3mx8QLQfx6R2CogxbK4CvV7qvkLblehXeQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.3.3.tgz",
+      "integrity": "sha512-DmZkKrH5/MSkrU0hhHhv5+aOXcEJSaOhutKMOh2viuiLiMaFeOLPiTEvtegLunO3rXBagzHO681qW1sNMaB1sQ==",
       "dev": true,
       "requires": {
         "dom-event-types": "^1.0.0",
-        "lodash": "^4.17.4"
+        "lodash": "^4.17.15",
+        "pretty": "^2.0.0"
       }
     },
     "@vue/web-component-wrapper": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.16",
+  "version": "5.7.17",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",
@@ -61,7 +61,7 @@
     "@vue/cli-service": "^4.5.19",
     "@vue/eslint-config-standard": "^4.0.0",
     "@vue/eslint-config-typescript": "^4.0.0",
-    "@vue/test-utils": "1.0.0-beta.28",
+    "@vue/test-utils": "^1.3.3",
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "^9.5.1",
     "flush-promises": "^1.0.2",

--- a/tests/click.ts
+++ b/tests/click.ts
@@ -1,0 +1,10 @@
+import flushPromises from 'flush-promises'
+
+/** Dispatches click event on specified element. */
+export async function click (vm: any, id: string) {
+  const button = vm.$el.querySelector(id)
+  const window = button.ownerDocument.defaultView
+  const event = new window.Event('click')
+  button.dispatchEvent(event)
+  await flushPromises() // wait for DOM to settle
+}

--- a/tests/setValue.ts
+++ b/tests/setValue.ts
@@ -1,0 +1,11 @@
+import flushPromises from 'flush-promises'
+
+/** Dispatches input event with specified value on specified element. */
+export async function setValue (vm: any, id: string, value: string) {
+  const input = vm.$el.querySelector(id)
+  input.value = value
+  const window = input.ownerDocument.defaultView
+  const event = new window.Event('input')
+  input.dispatchEvent(event)
+  await flushPromises() // wait for DOM to settle
+}

--- a/tests/unit/AGMDate.spec.ts
+++ b/tests/unit/AGMDate.spec.ts
@@ -43,18 +43,18 @@ describe('AgmDate', () => {
     expect(vm.$data.noAgm).toBe(false)
   })
 
-  it('does not render the checkbox if today is before max AGM date', () => {
-    store.state.currentDate = '2019-03-15'
+  it('does not render the checkbox if today is before max AGM date', async () => {
+    await vm.$store.commit('currentDate', '2019-03-15')
     expect(wrapper.find('#no-agm-checkbox').exists()).toBe(false)
   })
 
-  it('renders the checkbox if today is after max AGM date', () => {
-    store.state.currentDate = '2020-01-01'
+  it('renders the checkbox if today is after max AGM date', async () => {
+    await vm.$store.commit('currentDate', '2020-01-01')
     expect(wrapper.find('#no-agm-checkbox').exists()).toBe(true)
   })
 
-  it('sets AGM Date when date picker is set', () => {
-    wrapper.setData({ datePicker: '2019-05-10' })
+  it('sets AGM Date when date picker is set', async () => {
+    await wrapper.setData({ datePicker: '2019-05-10' })
     vm.onDatePickerChanged('2019-05-10')
 
     // verify local variables
@@ -73,8 +73,8 @@ describe('AgmDate', () => {
     expect(valids[0]).toEqual([true])
   })
 
-  xit('sets No AGM when checkbox is checked', () => {
-    wrapper.setData({ noAgm: true })
+  xit('sets No AGM when checkbox is checked', async () => {
+    await wrapper.setData({ noAgm: true })
     vm.onCheckboxChanged(true)
 
     // verify local variables
@@ -99,8 +99,7 @@ describe('AgmDate', () => {
   })
 
   it('sets AGM Date when AGM Date prop is set to a date', async () => {
-    wrapper.setProps({ newAgmDate: '2019-05-10' })
-    await Vue.nextTick()
+    await wrapper.setProps({ newAgmDate: '2019-05-10' })
 
     // verify local variables
     expect(vm.$data.dateText).toBe('2019-05-10')
@@ -118,8 +117,8 @@ describe('AgmDate', () => {
     expect(valids[0]).toEqual([true])
   })
 
-  xit('clears AGM Date when AGM Date prop is set to empty', () => {
-    wrapper.setProps({ newAgmDate: '' })
+  xit('clears AGM Date when AGM Date prop is set to empty', async () => {
+    await wrapper.setProps({ newAgmDate: '' })
 
     // verify local variables
     expect(vm.$data.dateText).toBe('')
@@ -137,8 +136,8 @@ describe('AgmDate', () => {
     expect(valids[0]).toEqual([false])
   })
 
-  xit('sets No AGM when No AGM prop is set to true', () => {
-    wrapper.setProps({ newNoAgm: true })
+  xit('sets No AGM when No AGM prop is set to true', async () => {
+    await wrapper.setProps({ newNoAgm: true })
 
     // verify local variables
     expect(vm.$data.dateText).toBe('')
@@ -156,9 +155,9 @@ describe('AgmDate', () => {
     expect(valids[0]).toEqual([true])
   })
 
-  xit('displays disabled address change message when allowCoa is false', () => {
-    wrapper.setData({ dateText: '2019-07-15' })
-    wrapper.setProps({ allowCa: false })
+  xit('displays disabled address change message when allowCoa is false', async () => {
+    await wrapper.setData({ dateText: '2019-07-15' })
+    await wrapper.setProps({ allowCoa: false })
 
     // verify validation error
     expect(vm.$el.querySelector('.restriction-messages').textContent.trim()).toContain(
@@ -166,9 +165,9 @@ describe('AgmDate', () => {
     )
   })
 
-  xit('displays disabled director change message when allowCod is false', () => {
-    wrapper.setData({ dateText: '2019-07-15' })
-    wrapper.setProps({ allowCod: false })
+  xit('displays disabled director change message when allowCod is false', async () => {
+    await wrapper.setData({ dateText: '2019-07-15' })
+    await wrapper.setProps({ allowCod: false })
 
     // verify validation error
     expect(vm.$el.querySelector('.restriction-messages').textContent.trim()).toContain(
@@ -176,9 +175,9 @@ describe('AgmDate', () => {
     )
   })
 
-  xit('displays disabled address + director change message when allowCoa and allowCod are both false', () => {
-    wrapper.setData({ dateText: '2019-07-15' })
-    wrapper.setProps({ allowCoa: false, allowCod: false })
+  xit('displays disabled address + director change message when allowCoa and allowCod are both false', async () => {
+    await wrapper.setData({ dateText: '2019-07-15' })
+    await wrapper.setProps({ allowCoa: false, allowCod: false })
 
     // verify validation error
     expect(vm.$el.querySelector('.restriction-messages').textContent.trim()).toContain(

--- a/tests/unit/AddCommentDialog.spec.ts
+++ b/tests/unit/AddCommentDialog.spec.ts
@@ -32,7 +32,7 @@ describe('AddCommentDialog', () => {
     const vm: any = wrapper.vm
 
     expect(wrapper.find('#dialog-title').text()).toBe('Add Detail')
-    expect(wrapper.find(DetailComment).exists()).toBe(true)
+    expect(wrapper.findComponent(DetailComment).exists()).toBe(true)
     expect(wrapper.find('#dialog-save-button')).toBeDefined()
     expect(wrapper.find('#dialog-cancel-button')).toBeDefined()
 

--- a/tests/unit/AddStaffNotationDialog.spec.ts
+++ b/tests/unit/AddStaffNotationDialog.spec.ts
@@ -31,7 +31,7 @@ describe('AddStaffNotationDialog', () => {
     const vm: any = wrapper.vm
 
     expect(wrapper.find('#dialog-title').text()).toBe('Add a Test')
-    expect(wrapper.find(CourtOrderPoa).exists()).toBe(true)
+    expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(true)
     expect(wrapper.find('#dialog-save-button')).toBeDefined()
     expect(wrapper.find('#dialog-cancel-button')).toBeDefined()
 
@@ -55,7 +55,7 @@ describe('AddStaffNotationDialog', () => {
     const vm: any = wrapper.vm
 
     expect(wrapper.find('#dialog-title').text()).toBe('Administrative Dissolution')
-    expect(wrapper.find(CourtOrderPoa).exists()).toBe(true)
+    expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(true)
     expect(wrapper.find('#dialog-save-button')).toBeDefined()
     expect(wrapper.find('#dialog-cancel-button')).toBeDefined()
 
@@ -78,7 +78,7 @@ describe('AddStaffNotationDialog', () => {
     const vm: any = wrapper.vm
 
     expect(wrapper.find('#dialog-title').text()).toBe('Correction - Put Back On')
-    expect(wrapper.find(CourtOrderPoa).exists()).toBe(true)
+    expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(true)
     expect(wrapper.find('#dialog-save-button')).toBeDefined()
     expect(wrapper.find('#dialog-cancel-button')).toBeDefined()
 
@@ -94,8 +94,7 @@ describe('AddStaffNotationDialog', () => {
           dialog: true,
           displayName: 'Test'
         },
-        store,
-        sync: false
+        store
       })
 
     // click the Cancel button
@@ -117,8 +116,7 @@ describe('AddStaffNotationDialog', () => {
           name: 'registrarsNotation'
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
     // Should not start with validation
@@ -126,7 +124,7 @@ describe('AddStaffNotationDialog', () => {
 
     // Should validate after clicking on 'Save'
     await wrapper.find('#dialog-save-button').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#notation-form').text()).toContain('Enter a Test')
 
@@ -143,8 +141,7 @@ describe('AddStaffNotationDialog', () => {
           name: 'putBackOn'
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
     // Should not start with validation
@@ -152,7 +149,7 @@ describe('AddStaffNotationDialog', () => {
 
     // Should validate after clicking on 'Save'
     await wrapper.find('#dialog-save-button').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#notation-form').text()).toContain('Enter a detailed comment')
 
@@ -170,8 +167,7 @@ describe('AddStaffNotationDialog', () => {
           dissolutionType: 'administrative'
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
     // Should not start with validation
@@ -179,7 +175,7 @@ describe('AddStaffNotationDialog', () => {
 
     // Should validate after clicking on 'Save'
     await wrapper.find('#dialog-save-button').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#notation-form').text()).toContain('Enter a detailed comment')
 
@@ -195,21 +191,20 @@ describe('AddStaffNotationDialog', () => {
           courtOrderNumberRequired: true
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
     // Valid data should be allowed
     await wrapper.find('#notation').setValue('a'.repeat(2000))
     await wrapper.find('#dialog-save-button').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#notation-form').text()).not.toContain('Maximum characters exceeded.')
 
     // Larger than allowed
     await wrapper.find('#notation').setValue('a'.repeat(2001))
     await wrapper.find('#dialog-save-button').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#notation-form').text()).toContain('Maximum characters exceeded.')
 
@@ -224,13 +219,12 @@ describe('AddStaffNotationDialog', () => {
           displayName: 'Test'
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
     // Enables validation
     await wrapper.find('#dialog-save-button').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     // Should not validate if plan of arrangement is not checked
     expect(wrapper.find('#court-order').text()).not.toContain('A Court Order number is required')
@@ -250,8 +244,7 @@ describe('AddStaffNotationDialog', () => {
           courtOrderNumberRequired: true
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
     // Should not start with validation
@@ -259,7 +252,7 @@ describe('AddStaffNotationDialog', () => {
 
     // Validates on 'Save'
     await wrapper.find('#dialog-save-button').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#court-order').text()).toContain('A Court Order number is required')
 
@@ -274,23 +267,22 @@ describe('AddStaffNotationDialog', () => {
           displayName: 'Test'
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
-    // Less than allowed
+    // Less than allowed (min 5)
     wrapper.find('#court-order-number-input').setValue('a'.repeat(4))
     wrapper.find('#dialog-save-button').trigger('click')
     // for some reason, awaiting the 2 statements above doesn't work as expected
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#court-order').text()).toContain('Court order number is invalid')
 
-    // Allowed length
+    // Allowed length (min 5)
     wrapper.find('#court-order-number-input').setValue('a'.repeat(5))
     wrapper.find('#dialog-save-button').trigger('click')
     // for some reason, awaiting the 2 statements above doesn't work as expected
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#court-order').text()).not.toContain('Court order number is invalid')
 
@@ -305,23 +297,22 @@ describe('AddStaffNotationDialog', () => {
           displayName: 'Test'
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
-    // Max length is valid
+    // Max length is valid (max 20)
     wrapper.find('#court-order-number-input').setValue('a'.repeat(20))
     wrapper.find('#dialog-save-button').trigger('click')
     // for some reason, awaiting the 2 statements above doesn't work as expected
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#court-order').text()).not.toContain('Court order number is invalid')
 
-    // Greater than allowed
+    // Greater than allowed (max 20)
     wrapper.find('#court-order-number-input').setValue('a'.repeat(21))
     wrapper.find('#dialog-save-button').trigger('click')
     // for some reason, awaiting the 2 statements above doesn't work as expected
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.find('#court-order').text()).toContain('Court order number is invalid')
 
@@ -349,8 +340,7 @@ describe('AddStaffNotationDialog', () => {
           dialog: true
         },
         store,
-        vuetify,
-        sync: false
+        vuetify
       })
 
     wrapper.find('#notation').setValue('Notation...')

--- a/tests/unit/AddressListSm.spec.ts
+++ b/tests/unit/AddressListSm.spec.ts
@@ -156,7 +156,7 @@ describe('AddressListSm', () => {
 
     // Click the records office tab to display the addresses
     await wrapper.find('#records-office-panel-toggle').trigger('click')
-    await Vue.nextTick()
+    await Vue.nextTick() // wait for DOM to update
 
     expect(vm.registeredAddress).toBeDefined()
     expect(vm.recordsAddress).toBeDefined()
@@ -247,7 +247,7 @@ describe('AddressListSm', () => {
 
     // Click the records office tab to display the addresses
     await wrapper.find('#records-office-panel-toggle').trigger('click')
-    await Vue.nextTick()
+    await Vue.nextTick() // wait for DOM to update
 
     expect(vm.registeredAddress).toBeDefined()
     expect(vm.recordsAddress).toBeDefined()

--- a/tests/unit/AnnualReport.spec.ts
+++ b/tests/unit/AnnualReport.spec.ts
@@ -45,22 +45,23 @@ describe('Annual Report - Part 1 - UI', () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route } })
 
-    expect(wrapper.find(AgmDate).exists()).toBe(true)
-    expect(wrapper.find(OfficeAddresses).exists()).toBe(true)
-    expect(wrapper.find(Directors).exists()).toBe(true)
-    expect(wrapper.find(Certify).exists()).toBe(true)
+    expect(wrapper.findComponent(AgmDate).exists()).toBe(true)
+    expect(wrapper.findComponent(OfficeAddresses).exists()).toBe(true)
+    expect(wrapper.findComponent(Directors).exists()).toBe(true)
+    expect(wrapper.findComponent(Certify).exists()).toBe(true)
 
     wrapper.destroy()
   })
 
-  it('Verify AR Certify contains correct section codes', () => {
+  it('Verify AR Certify contains correct section codes', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route } })
     store.state.entityType = 'CP'
     store.state.configObject = ConfigJson.find(x => x.entityType === store.state.entityType)
-    expect(wrapper.find(Certify).exists()).toBe(true)
-    const certify: any = wrapper.find(Certify)
+    await Vue.nextTick() // wait for DOM to update
 
+    const certify: any = wrapper.findComponent(Certify)
+    expect(certify.exists()).toBe(true)
     expect(certify.vm.message).toContain('See Section 126 of the Cooperative Association Act.')
     expect(certify.vm.entityDisplay).toEqual('Cooperative')
 
@@ -89,16 +90,18 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('enables Validated flag when sub-component flags are valid', () => {
+  it('enables Validated flag when sub-component flags are valid', async () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(true)
@@ -106,16 +109,18 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables Validated flag when AGM Date is invalid', () => {
+  it('disables Validated flag when AGM Date is invalid', async () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.agmDateValid = false
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({
+      agmDateValid: false,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(false)
@@ -123,16 +128,18 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables Validated flag when Addresses form is invalid', () => {
+  it('disables Validated flag when Addresses form is invalid', async () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.agmDateValid = true
-    vm.addressesFormValid = false
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: false,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(false)
@@ -140,19 +147,20 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables address component when AGM Date < Last COA Date', () => {
+  it('disables address component when AGM Date < Last COA Date', async () => {
     store.state.lastAddressChangeDate = '2019-05-06'
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    wrapper.setData({ agmDate: '2019-05-05' })
-
-    // set properties
-    vm.agmDateValid = true
-    vm.addressesFormValid = false
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({
+      agmDate: '2019-05-05',
+      agmDateValid: true,
+      addressesFormValid: false,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that change state is disabled
     expect(vm.allowChange('coa')).toBe(false)
@@ -160,19 +168,20 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('has no effect on address component when Last COA Date is null', () => {
+  it('has no effect on address component when Last COA Date is null', async () => {
     store.state.lastAddressChangeDate = null
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    wrapper.setData({ agmDate: '2019-02-09' })
-
-    // set properties
-    vm.agmDateValid = true
-    vm.addressesFormValid = false
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({
+      agmDate: '2019-02-09',
+      agmDateValid: true,
+      addressesFormValid: false,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that change state is enabled
     expect(vm.allowChange('coa')).toBe(true)
@@ -180,19 +189,20 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables directors component when AGM Date < Last COD Date', () => {
+  it('disables directors component when AGM Date < Last COD Date', async () => {
     store.state.lastDirectorChangeDate = '2019-05-06'
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    wrapper.setData({ agmDate: '2019-05-05' })
-
-    // set properties
-    vm.agmDateValid = true
-    vm.addressesFormValid = false
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({
+      agmDate: '2019-05-05',
+      agmDateValid: true,
+      addressesFormValid: false,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that change state is disabled
     expect(vm.allowChange('cod')).toBe(false)
@@ -200,19 +210,20 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables directors component when Last COD Date is null', () => {
+  it('disables directors component when Last COD Date is null', async () => {
     store.state.lastDirectorChangeDate = null
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    wrapper.setData({ agmDate: '2019-02-09' })
-
-    // set properties
-    vm.agmDateValid = true
-    vm.addressesFormValid = false
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({
+      agmDate: '2019-02-09',
+      agmDateValid: true,
+      addressesFormValid: false,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that change state is enabled
     expect(vm.allowChange('cod')).toBe(true)
@@ -220,16 +231,18 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables Validated flag when Director form is invalid', () => {
+  it('disables Validated flag when Director form is invalid', async () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = false
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: false,
+      certifyFormValid: true
+    })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(false)
@@ -237,16 +250,18 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables Validated flag when Certify form is invalid', () => {
+  it('disables Validated flag when Certify form is invalid', async () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = false
+    // set local properties
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: false
+    })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(false)
@@ -254,7 +269,7 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('enables File & Pay button when form is validated', () => {
+  it('enables File & Pay button when form is validated', async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -279,15 +294,16 @@ describe('Annual Report - Part 1 - UI', () => {
       },
       vuetify
     })
-
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    vm.directorEditInProgress = false
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true,
+      directorEditInProgress: false
+    })
 
     // confirm that button is enabled
     expect(wrapper.find('#ar-file-pay-btn').attributes('disabled')).toBeUndefined()
@@ -295,7 +311,7 @@ describe('Annual Report - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables File & Pay button when form is not validated', () => {
+  it('disables File & Pay button when form is not validated', async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -322,11 +338,13 @@ describe('Annual Report - Part 1 - UI', () => {
     })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.agmDateValid = false
-    vm.addressesFormValid = false
-    vm.directorFormValid = false
-    vm.certifyFormValid = false
+    // set local properties
+    await wrapper.setData({
+      agmDateValid: false,
+      addressesFormValid: false,
+      directorFormValid: false,
+      certifyFormValid: false
+    })
 
     // confirm that button is disabled
     expect(wrapper.find('#ar-file-pay-btn').attributes('disabled')).toBe('disabled')
@@ -349,10 +367,10 @@ describe('Annual Report - Part 1B - UI (BCOMP)', () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route } })
 
-    expect(wrapper.find(ArDate).exists()).toBe(true)
-    expect(wrapper.find(SummaryOfficeAddresses).exists()).toBe(true)
-    expect(wrapper.find(SummaryDirectors).exists()).toBe(true)
-    expect(wrapper.find(Certify).exists()).toBe(true)
+    expect(wrapper.findComponent(ArDate).exists()).toBe(true)
+    expect(wrapper.findComponent(SummaryOfficeAddresses).exists()).toBe(true)
+    expect(wrapper.findComponent(SummaryDirectors).exists()).toBe(true)
+    expect(wrapper.findComponent(Certify).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -374,13 +392,13 @@ describe('Annual Report - Part 1B - UI (BCOMP)', () => {
     wrapper.destroy()
   })
 
-  it('enables Validated flag when sub-component flags are valid', () => {
+  it('enables Validated flag when sub-component flags are valid', async () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.certifyFormValid = true
+    // set local properties
+    await wrapper.setData({ certifyFormValid: true })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(true)
@@ -388,13 +406,13 @@ describe('Annual Report - Part 1B - UI (BCOMP)', () => {
     wrapper.destroy()
   })
 
-  it('disables Validated flag when Certify form is invalid', () => {
+  it('disables Validated flag when Certify form is invalid', async () => {
     const $route = { params: { filingId: '0' } } // new filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.certifyFormValid = false
+    // set local properties
+    await wrapper.setData({ certifyFormValid: false })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(false)
@@ -402,7 +420,7 @@ describe('Annual Report - Part 1B - UI (BCOMP)', () => {
     wrapper.destroy()
   })
 
-  it('enables File & Pay button when form is validated', () => {
+  it('enables File & Pay button when form is validated', async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -426,12 +444,13 @@ describe('Annual Report - Part 1B - UI (BCOMP)', () => {
       },
       vuetify
     })
-
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.certifyFormValid = true
-    vm.directorEditInProgress = false
+    await wrapper.setData({
+      certifyFormValid: true,
+      directorEditInProgress: false
+    })
 
     // confirm that button is enabled
     expect(wrapper.find('#ar-file-pay-bc-btn').attributes('disabled')).toBeUndefined()
@@ -439,7 +458,7 @@ describe('Annual Report - Part 1B - UI (BCOMP)', () => {
     wrapper.destroy()
   })
 
-  it('disables File & Pay button when form is not validated', () => {
+  it('disables File & Pay button when form is not validated', async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -466,7 +485,7 @@ describe('Annual Report - Part 1B - UI (BCOMP)', () => {
     const vm: any = wrapper.vm
 
     // set properties
-    vm.certifyFormValid = false
+    await wrapper.setData({ certifyFormValid: false })
 
     // confirm that button is disabled
     expect(wrapper.find('#ar-file-pay-bc-btn').attributes('disabled')).toBe('disabled')
@@ -528,8 +547,7 @@ describe('Annual Report - Part 2A - Resuming with FAS staff payment', () => {
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm = wrapper.vm as any
-    // wait for draft to be fetched
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // FUTURE: verify that Draft Date (for directors) was restored
     // (should be '2018-07-15')
@@ -611,8 +629,7 @@ describe('Annual Report - Part 2B - Resuming with BCOL staff payment', () => {
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm = wrapper.vm as any
-    // wait for draft to be fetched
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // FUTURE: verify that Draft Date (for directors) was restored
     // (should be '2018-07-15')
@@ -693,8 +710,7 @@ describe('Annual Report - Part 2C - Resuming with No Fee staff payment', () => {
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(AnnualReport, { store, mocks: { $route }, vuetify })
     const vm = wrapper.vm as any
-    // wait for draft to be fetched
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // FUTURE: verify that Draft Date (for directors) was restored
     // (should be '2018-07-15')
@@ -888,20 +904,24 @@ describe('Annual Report - Part 3 - Submitting', () => {
     const vm = wrapper.vm as any
 
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    vm.directorEditInProgress = false
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true,
+      directorEditInProgress: false
+    })
     store.state.filingData = [{ filingTypeCode: 'OTCDR', entityType: 'CP' }] // dummy data
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // make sure a fee is required
     vm.totalFee = 100
@@ -959,20 +979,24 @@ describe('Annual Report - Part 3 - Submitting', () => {
     const vm = wrapper.vm as any
 
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    vm.directorEditInProgress = false
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true,
+      directorEditInProgress: false
+    })
     store.state.filingData = [{ filingTypeCode: 'OTCDR', entityType: 'CP' }] // dummy data
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // make sure a fee is required
     vm.totalFee = 100
@@ -1080,7 +1104,6 @@ describe('Annual Report - Part 3B - Submitting (BCOMP)', () => {
     router.push({ name: 'annual-report', params: { filingId: '0' } }) // new filing id
 
     const wrapper = mount(AnnualReport, {
-      sync: false,
       store,
       localVue,
       router,
@@ -1101,14 +1124,12 @@ describe('Annual Report - Part 3B - Submitting (BCOMP)', () => {
     const vm = wrapper.vm as any
 
     // make sure form is validated
-    vm.certifyFormValid = true
+    await wrapper.setData({ certifyFormValid: true })
     store.state.filingData = [{ filingTypeCode: 'ANNBC', entityType: 'BEN' }] // dummy data
 
     // make sure a fee is required
-    vm.totalFee = 100
-
-    // wait for things to stabilize
-    await flushPromises()
+    await wrapper.setData({ totalFee: 100 })
+    await Vue.nextTick()
 
     // sanity checks
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1202,22 +1223,26 @@ describe('Annual Report - Part 4 - Saving', () => {
 
   it('saves a new filing when the Save button is clicked', async () => {
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
-      },
-      recordsOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        },
+        recordsOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // click the Save button
     await wrapper.find('#ar-save-btn').trigger('click')
@@ -1231,22 +1256,26 @@ describe('Annual Report - Part 4 - Saving', () => {
 
   it('saves a filing and routes to Dashboard URL when the Save & Resume button is clicked', async () => {
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
-      },
-      recordsOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        },
+        recordsOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // click the Save & Resume Later button
     // await wrapper.find('#ar-save-resume-btn').trigger('click')
@@ -1259,10 +1288,12 @@ describe('Annual Report - Part 4 - Saving', () => {
 
   it('routes to Dashboard URL when the Cancel button is clicked', async () => {
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // click the Cancel button
     // await wrapper.find('#ar-cancel-btn').trigger('click')
@@ -1281,7 +1312,7 @@ describe('Annual Report - Part 5 - Data', () => {
 
   const currentFilingYear = 2017
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // init store
     store.state.identifier = 'CP0001191'
     store.state.entityType = 'CP'
@@ -1327,77 +1358,83 @@ describe('Annual Report - Part 5 - Data', () => {
     vm = wrapper.vm
 
     // set up director data
-    vm.updatedDirectors = [
-      // unchanged director
-      {
-        officer: {
-          firstName: 'Unchanged',
-          lastName: 'lastname'
+    await wrapper.setData({
+      updatedDirectors: [
+        // unchanged director
+        {
+          officer: {
+            firstName: 'Unchanged',
+            lastName: 'lastname'
+          },
+          deliveryAddress: {
+            streetAddress: 'a1',
+            addressCity: 'city',
+            addressCountry: 'country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          },
+          appointmentDate: '2019-01-01',
+          cessationDate: null,
+          actions: []
         },
-        deliveryAddress: {
-          streetAddress: 'a1',
-          addressCity: 'city',
-          addressCountry: 'country',
-          postalCode: 'H0H0H0',
-          addressRegion: 'BC'
+        // appointed director
+        {
+          officer: {
+            firstName: 'Appointed',
+            lastName: 'lastname'
+          },
+          deliveryAddress: {
+            streetAddress: 'a1',
+            addressCity: 'city',
+            addressCountry: 'country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          },
+          appointmentDate: '2019-01-01',
+          cessationDate: null,
+          actions: ['appointed']
         },
-        appointmentDate: '2019-01-01',
-        cessationDate: null,
-        actions: []
-      },
-      // appointed director
-      {
-        officer: {
-          firstName: 'Appointed',
-          lastName: 'lastname'
-        },
-        deliveryAddress: {
-          streetAddress: 'a1',
-          addressCity: 'city',
-          addressCountry: 'country',
-          postalCode: 'H0H0H0',
-          addressRegion: 'BC'
-        },
-        appointmentDate: '2019-01-01',
-        cessationDate: null,
-        actions: ['appointed']
-      },
-      // ceased director
-      {
-        officer: {
-          firstName: 'Ceased',
-          lastName: 'lastname'
-        },
-        deliveryAddress: {
-          streetAddress: 'a1',
-          addressCity: 'city',
-          addressCountry: 'country',
-          postalCode: 'H0H0H0',
-          addressRegion: 'BC'
-        },
-        appointmentDate: '2019-01-01',
-        cessationDate: '2019-03-25',
-        actions: ['ceased']
-      }
-    ]
+        // ceased director
+        {
+          officer: {
+            firstName: 'Ceased',
+            lastName: 'lastname'
+          },
+          deliveryAddress: {
+            streetAddress: 'a1',
+            addressCity: 'city',
+            addressCountry: 'country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          },
+          appointmentDate: '2019-01-01',
+          cessationDate: '2019-03-25',
+          actions: ['ceased']
+        }
+      ]
+    })
 
     // stub address data
-    vm.updatedAddresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
-      },
-      recordsOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      updatedAddresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        },
+        recordsOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
   })
 
   afterEach(() => {
@@ -1521,7 +1558,7 @@ describe('Annual Report - Part 5 - Data', () => {
     store.state.currentDate = '2019-03-03'
 
     // set No AGM
-    vm.didNotHoldAgm = true
+    await wrapper.setData({ didNotHoldAgm: true })
 
     // click the Save button
     // await wrapper.find('#ar-save-btn').trigger('click')
@@ -1550,7 +1587,7 @@ describe('Annual Report - Part 5B - Data (BCOMP)', () => {
 
   const currentFilingYear = 2018
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // init store
     store.state.identifier = 'BC0007291'
     store.state.entityName = 'Legal Name - BC0007291'
@@ -1595,7 +1632,6 @@ describe('Annual Report - Part 5B - Data (BCOMP)', () => {
     router.push({ name: 'annual-report', params: { filingId: '0' } }) // new filing id
 
     wrapper = mount(AnnualReport, {
-      sync: false,
       store,
       localVue,
       router,
@@ -1618,10 +1654,12 @@ describe('Annual Report - Part 5B - Data (BCOMP)', () => {
     // no need to set up directors or office addresses - just use initial values
 
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
   })
 
   afterEach(() => {
@@ -1834,10 +1872,12 @@ describe('Annual Report - Part 6 - Error/Warning Dialogs', () => {
 
   it('sets the required fields to display errors from the api after a POST call', async () => {
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(true)
@@ -1846,12 +1886,14 @@ describe('Annual Report - Part 6 - Error/Warning Dialogs', () => {
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // click the File & Pay button
     await wrapper.find('#ar-file-pay-btn').trigger('click')
@@ -1869,10 +1911,12 @@ describe('Annual Report - Part 6 - Error/Warning Dialogs', () => {
 
   it('sets the required fields to display errors from the api after a PUT call', async () => {
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     // confirm that flags are set correctly
     expect(vm.isPageValid).toEqual(true)
@@ -1881,15 +1925,17 @@ describe('Annual Report - Part 6 - Error/Warning Dialogs', () => {
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // set the filingId
-    vm.filingId = 123
+    await wrapper.setData({ filingId: 123 })
 
     // click the File & Pay button
     await wrapper.find('#ar-file-pay-btn').trigger('click')
@@ -1980,19 +2026,23 @@ describe('Annual Report - Part 7 - Concurrent Saves', () => {
   })
 
   it('prevents saving if a pending task exists', async () => {
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    vm.directorEditInProgress = false
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true,
+      directorEditInProgress: false
+    })
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // click the File & Pay button
     await wrapper.find('#ar-file-pay-btn').trigger('click')
@@ -2108,23 +2158,27 @@ describe('Annual Report - payment required error', () => {
       .returns(new Promise(resolve => resolve({ data: { tasks: [] } })))
 
     // make sure form is validated
-    vm.agmDateValid = true
-    vm.addressesFormValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    vm.directorEditInProgress = false
+    await wrapper.setData({
+      agmDateValid: true,
+      addressesFormValid: true,
+      directorFormValid: true,
+      certifyFormValid: true,
+      directorEditInProgress: false
+    })
     store.state.filingData = [{ filingTypeCode: 'OTANN', entityType: 'CP' }] // dummy data
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // make sure a fee is required
-    vm.totalFee = 100
+    await wrapper.setData({ totalFee: 100 })
 
     // sanity check
     expect(vm.saveErrors).toStrictEqual([])

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -966,7 +966,6 @@ describe('App as a Draft IA with approved NR', () => {
     router.push({ name: 'dashboard' })
 
     wrapper = shallowMount(App, {
-      sync: false,
       localVue,
       router,
       store,
@@ -1093,7 +1092,6 @@ describe('App as a Draft IA with conditional-not required NR', () => {
     router.push({ name: 'dashboard' })
 
     wrapper = shallowMount(App, {
-      sync: false,
       localVue,
       router,
       store,
@@ -1200,7 +1198,6 @@ describe('App as a Draft IA with conditional-received NR', () => {
     router.push({ name: 'dashboard' })
 
     wrapper = shallowMount(App, {
-      sync: false,
       localVue,
       router,
       store,
@@ -1307,7 +1304,6 @@ describe('App as a Draft IA with conditional-waived NR', () => {
     router.push({ name: 'dashboard' })
 
     wrapper = shallowMount(App, {
-      sync: false,
       localVue,
       router,
       store,
@@ -1424,7 +1420,6 @@ describe('App as a PAID (pending) Incorporation Application', () => {
     router.push({ name: 'dashboard' })
 
     wrapper = shallowMount(App, {
-      sync: false,
       localVue,
       router,
       store,
@@ -1575,7 +1570,6 @@ describe('App as a COMPLETED Incorporation Application', () => {
     router.push({ name: 'dashboard' })
 
     wrapper = shallowMount(App, {
-      sync: false,
       localVue,
       router,
       store,
@@ -1751,7 +1745,6 @@ describe('App as an historical business', () => {
     router.push({ name: 'dashboard' })
 
     wrapper = shallowMount(App, {
-      sync: false,
       localVue,
       router,
       store,

--- a/tests/unit/CODDate.spec.ts
+++ b/tests/unit/CODDate.spec.ts
@@ -37,8 +37,7 @@ describe('COD Date - COOPs', () => {
   })
 
   it('loads variables properly when initial COD Date is set', async () => {
-    wrapper.setProps({ initialCodDate: '2019-05-10' })
-    await Vue.nextTick()
+    await wrapper.setProps({ initialCodDate: '2019-05-10' })
 
     // verify local variables
     expect(vm.$data.date).toBe('2019-05-10')
@@ -77,20 +76,19 @@ describe('COD Date - COOPs', () => {
   })
 
   it('Shows error message when date has invalid length', async () => {
-    wrapper.setData({ dateFormatted: '2019/11/6' })
-    await Vue.nextTick()
+    await wrapper.setData({ dateFormatted: '2019/11/6' })
 
     expect(vm.$data.date).toBe('')
     expect(vm.$el.querySelector('.v-messages').textContent).toContain('A Director change date is required.')
   })
 
-  it('sets date picker and emits date changed and valid events when date is changed', () => {
-    wrapper.setData({ dateFormatted: '2019/05/10' })
+  it('sets date picker and emits date changed and valid events when date is changed', async () => {
+    await wrapper.setData({ dateFormatted: '2019/05/10' })
 
     // verify local variables
     expect(vm.$data.date).toBe('2019-05-10')
 
-    wrapper.setData({ dateFormatted: '2019/05/11' })
+    await wrapper.setData({ dateFormatted: '2019/05/11' })
 
     // verify local variables
     expect(vm.$data.date).toBe('2019-05-11')
@@ -112,7 +110,7 @@ describe('COD Date - COOPs', () => {
     expect(valids[1]).toEqual([true])
   })
 
-  it('invalidates the component when entered date is after Max Date', () => {
+  it('invalidates the component when entered date is after Max Date', async () => {
     wrapper = mount(CodDate, {
       store,
       vuetify,
@@ -139,7 +137,7 @@ describe('COD Date - COOPs', () => {
     expect(wrapper.find('.validationErrorInfo').exists()).toBe(false)
 
     // set a date after Max Date
-    wrapper.setData({ date: '2019-05-11' })
+    await wrapper.setData({ date: '2019-05-11' })
 
     // verify validators and error message
     expect(wrapper.vm.$v.dateFormatted.isNotNull).toBe(true)
@@ -149,7 +147,7 @@ describe('COD Date - COOPs', () => {
       .toContain('Please enter a day between 2019/05/05 and 2019/05/10.')
   })
 
-  it('invalidates the component when entered date is before Min Date', () => {
+  it('invalidates the component when entered date is before Min Date', async () => {
     wrapper = mount(CodDate, {
       store,
       vuetify,
@@ -173,7 +171,7 @@ describe('COD Date - COOPs', () => {
     expect(wrapper.find('.validationErrorInfo').exists()).toBe(false)
 
     // set a date before Min Date
-    wrapper.setData({ date: '2019-05-04' })
+    await wrapper.setData({ date: '2019-05-04' })
 
     // verify validators and error message
     expect(wrapper.vm.$v.dateFormatted.isNotNull).toBe(true)

--- a/tests/unit/Certify.spec.ts
+++ b/tests/unit/Certify.spec.ts
@@ -18,8 +18,8 @@ import { mount, Wrapper } from '@vue/test-utils'
 import { Certify } from '@/components/common'
 
 Vue.use(Vuetify)
-const vuetify = new Vuetify({})
 
+const vuetify = new Vuetify({})
 const store = getVuexStore() as any // remove typings for unit tests
 
 // Input field selectors to test changes to the DOM elements.
@@ -65,7 +65,6 @@ function createComponent (
   return mount(Certify, {
     vuetify,
     store,
-    sync: false,
     propsData: {
       certifiedBy,
       isCertified

--- a/tests/unit/CompletedAlteration.spec.ts
+++ b/tests/unit/CompletedAlteration.spec.ts
@@ -18,7 +18,8 @@ describe('Alteration Filing', () => {
     })
 
     // verify content
-    expect(wrapper.html()).toBeUndefined()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.html()).toBeFalsy()
 
     wrapper.destroy()
   })

--- a/tests/unit/CompletedDissolution.spec.ts
+++ b/tests/unit/CompletedDissolution.spec.ts
@@ -19,7 +19,8 @@ describe('Dissolution Filing', () => {
     })
 
     // verify content
-    expect(wrapper.html()).toBeUndefined()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.html()).toBeFalsy()
 
     wrapper.destroy()
   })

--- a/tests/unit/ConversionDetails.spec.ts
+++ b/tests/unit/ConversionDetails.spec.ts
@@ -4,7 +4,6 @@ import { mount } from '@vue/test-utils'
 import ConversionDetails from '@/components/Dashboard/TodoList/ConversionDetails.vue'
 
 Vue.use(Vuetify)
-
 const vuetify = new Vuetify({})
 
 describe('Conversion Details component', () => {

--- a/tests/unit/Correction.spec.ts
+++ b/tests/unit/Correction.spec.ts
@@ -81,9 +81,9 @@ describe('Correction - UI', () => {
     const wrapper = shallowMount(Correction, { store, mocks: { $route, $router } })
 
     // verify sub-components
-    expect(wrapper.find(DetailComment).exists()).toBe(true)
-    expect(wrapper.find(Certify).exists()).toBe(true)
-    expect(wrapper.find(SbcFeeSummary).exists()).toBe(true)
+    expect(wrapper.findComponent(DetailComment).exists()).toBe(true)
+    expect(wrapper.findComponent(Certify).exists()).toBe(true)
+    expect(wrapper.findComponent(SbcFeeSummary).exists()).toBe(true)
 
     // verify rendered page
     expect(wrapper.find('#correction-header').text()).toBe('Correction —')
@@ -119,22 +119,27 @@ describe('Correction - UI', () => {
 
     // verify Is Priority = true
     vm.staffPaymentData = { isPriority: true }
+    await flushPromises()
     expect(vm.filingData[0].priority).toBe(true)
 
     // verify Is Priority = false
     vm.staffPaymentData = { isPriority: false }
+    await flushPromises()
     expect(vm.filingData[0].priority).toBe(false)
 
     // verify Is Waive Fees = true
     vm.staffPaymentData = { option: 0 } // NO_FEE
+    await flushPromises()
     expect(vm.filingData[0].waiveFees).toBe(true)
 
     // verify Is Waive Fees = false
     vm.staffPaymentData = { option: 1 } // FAS
+    await flushPromises()
     expect(vm.filingData[0].waiveFees).toBe(false)
 
     // verify Is Waive Fees = false
     vm.staffPaymentData = { option: 2 } // BCOL
+    await flushPromises()
     expect(vm.filingData[0].waiveFees).toBe(false)
 
     wrapper.destroy()

--- a/tests/unit/CorrectionComment.spec.ts
+++ b/tests/unit/CorrectionComment.spec.ts
@@ -13,7 +13,7 @@ describe('DetailComment', () => {
       vuetify
     })
 
-    expect(wrapper.find(CorrectionComment).exists()).toBe(true)
+    expect(wrapper.findComponent(CorrectionComment).exists()).toBe(true)
     expect(wrapper.find('.correction-comment').exists()).toBe(false)
 
     wrapper.destroy()
@@ -25,7 +25,7 @@ describe('DetailComment', () => {
       vuetify
     })
 
-    expect(wrapper.find(CorrectionComment).exists()).toBe(true)
+    expect(wrapper.findComponent(CorrectionComment).exists()).toBe(true)
     expect(wrapper.find('h4 span').text()).toBe('Detail')
     expect(wrapper.find('p').text()).toBe('A test comment')
 

--- a/tests/unit/CustodianListSm.spec.ts
+++ b/tests/unit/CustodianListSm.spec.ts
@@ -4,6 +4,7 @@ import Vuelidate from 'vuelidate'
 import { mount } from '@vue/test-utils'
 import { getVuexStore } from '@/store'
 import CustodianListSm from '@/components/Dashboard/CustodianListSm.vue'
+import { click } from '../click'
 
 Vue.use(Vuetify)
 Vue.use(Vuelidate)
@@ -86,13 +87,6 @@ describe('CustodianListSm', () => {
   })
 
   it('displays multiple custodians as a BCOMP', async () => {
-    function click (id) {
-      const button = vm.$el.querySelector(id)
-      const window = button.ownerDocument.defaultView
-      const click = new window.Event('click')
-      button.dispatchEvent(click)
-    }
-
     // init store
     store.state.entityType = 'BEN'
     const custodians = [
@@ -142,7 +136,7 @@ describe('CustodianListSm', () => {
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
-    click('.address-panel-toggle')
+    await click(vm, '.address-panel-toggle')
     expect(vm.custodians.length).toEqual(2)
     expect(vm.custodians[0].mailingAddress).toBeDefined()
     expect(vm.$el.querySelectorAll('.address-panel').length).toEqual(2)

--- a/tests/unit/Dashboard.spec.ts
+++ b/tests/unit/Dashboard.spec.ts
@@ -43,16 +43,16 @@ describe('Dashboard - UI', () => {
   })
 
   it('renders the dashboard sub-components properly', () => {
-    expect(wrapper.find(CoaWarningDialog).exists()).toBe(true)
-    expect(wrapper.find(TodoList).exists()).toBe(true)
-    expect(wrapper.find(FilingHistoryList).exists()).toBe(true)
-    expect(wrapper.find(AddressListSm).exists()).toBe(true)
-    expect(wrapper.find(DirectorListSm).exists()).toBe(true)
+    expect(wrapper.findComponent(CoaWarningDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(TodoList).exists()).toBe(true)
+    expect(wrapper.findComponent(FilingHistoryList).exists()).toBe(true)
+    expect(wrapper.findComponent(AddressListSm).exists()).toBe(true)
+    expect(wrapper.findComponent(DirectorListSm).exists()).toBe(true)
   })
 
   it('updates its counts from sub-component events', () => {
-    wrapper.find(TodoList).vm.$emit('todo-count', 2)
-    wrapper.find(FilingHistoryList).vm.$emit('history-count', 3)
+    wrapper.findComponent(TodoList).vm.$emit('todo-count', 2)
+    wrapper.findComponent(FilingHistoryList).vm.$emit('history-count', 3)
 
     expect(vm.todoCount).toEqual(2)
     expect(vm.historyCount).toEqual(3)
@@ -76,7 +76,7 @@ describe('Dashboard - UI', () => {
     expect(localWrapper.find('#standalone-directors-button').attributes('disabled')).toBeUndefined()
   })
 
-  it('disables standalone filing buttons when there is a blocker task', () => {
+  it('disables standalone filing buttons when there is a blocker task', async () => {
     // re-mount the component since setting session storage is not reactive
     sessionStorage.setItem('BUSINESS_ID', 'CP1234567')
     const localWrapper: Wrapper<Vue> = shallowMount(Dashboard, { store, vuetify, mocks: { $route } })
@@ -85,6 +85,7 @@ describe('Dashboard - UI', () => {
     store.state.hasBlockerTask = true
     store.state.hasBlockerFiling = false
     store.state.isCoaPending = false
+    await Vue.nextTick()
     expect(localVm.hasBlocker).toEqual(true)
 
     expect(localVm.isAllowed('fileAddressChange')).toBe(false)
@@ -94,7 +95,7 @@ describe('Dashboard - UI', () => {
     expect(localWrapper.find('#standalone-directors-button').attributes('disabled')).toBe('true')
   })
 
-  it('disables standalone filing buttons when there is a blocker filing', () => {
+  it('disables standalone filing buttons when there is a blocker filing', async () => {
     // re-mount the component since setting session storage is not reactive
     sessionStorage.setItem('BUSINESS_ID', 'CP1234567')
     const localWrapper: Wrapper<Vue> = shallowMount(Dashboard, { store, vuetify, mocks: { $route } })
@@ -103,6 +104,7 @@ describe('Dashboard - UI', () => {
     store.state.hasBlockerTask = false
     store.state.hasBlockerFiling = true
     store.state.isCoaPending = false
+    await Vue.nextTick()
     expect(localVm.hasBlocker).toEqual(true)
 
     expect(localVm.isAllowed('fileAddressChange')).toBe(false)
@@ -112,7 +114,7 @@ describe('Dashboard - UI', () => {
     expect(localWrapper.find('#standalone-directors-button').attributes('disabled')).toBe('true')
   })
 
-  it('disables filing buttons when there is a BCOMP Future Effective COA', () => {
+  it('disables filing buttons when there is a BCOMP Future Effective COA', async () => {
     // re-mount the component since setting session storage is not reactive
     sessionStorage.setItem('BUSINESS_ID', 'CP1234567')
     const localWrapper: Wrapper<Vue> = shallowMount(Dashboard, { store, vuetify, mocks: { $route } })
@@ -121,6 +123,7 @@ describe('Dashboard - UI', () => {
     store.state.hasBlockerTask = false
     store.state.hasBlockerFiling = false
     store.state.isCoaPending = true
+    await Vue.nextTick()
     expect(localVm.hasBlocker).toEqual(true)
 
     expect(localVm.isAllowed('fileAddressChange')).toBe(false)
@@ -237,7 +240,7 @@ describe('Dashboard - Click Tests', () => {
     expect(wrapper.find('#dialog-toggle-button')).toBeDefined()
     expect(wrapper.find('#dialog-proceed-button')).toBeDefined()
 
-    wrapper.find(CoaWarningDialog).vm.$emit('proceed', true)
+    wrapper.findComponent(CoaWarningDialog).vm.$emit('proceed', true)
 
     expect(vm.$route.name).toBe('standalone-addresses')
     expect(vm.$route.params.filingId).toBe(0)

--- a/tests/unit/DetailComment.spec.ts
+++ b/tests/unit/DetailComment.spec.ts
@@ -61,7 +61,7 @@ describe('DetailComment', () => {
 
     // change the value
     // NB: need to wait for debounce
-    wrapper.setProps({ value: 'testing 1 2 3' })
+    await wrapper.setProps({ value: 'testing 1 2 3' })
     await sleep(300)
 
     // verify valid event

--- a/tests/unit/DirectorListSm.spec.ts
+++ b/tests/unit/DirectorListSm.spec.ts
@@ -4,6 +4,7 @@ import Vuelidate from 'vuelidate'
 import { mount } from '@vue/test-utils'
 import { getVuexStore } from '@/store'
 import DirectorListSm from '@/components/Dashboard/DirectorListSm.vue'
+import { click } from '../click'
 
 Vue.use(Vuetify)
 Vue.use(Vuelidate)
@@ -98,14 +99,6 @@ describe('DirectorListSm', () => {
   })
 
   it('displays multiple directors - as a BCOMP', async () => {
-    async function click (id) {
-      const button = vm.$el.querySelector(id)
-      const window = button.ownerDocument.defaultView
-      const click = new window.Event('click')
-      button.dispatchEvent(click)
-      await Vue.nextTick()
-    }
-
     // init store
     store.state.entityType = 'BEN'
     store.state.parties = [
@@ -167,7 +160,7 @@ describe('DirectorListSm', () => {
     const vm = wrapper.vm as any
     await Vue.nextTick()
 
-    await click('.address-panel-toggle')
+    await click(vm, '.address-panel-toggle')
 
     expect(vm.directors.length).toEqual(2)
     expect(vm.directors[0].mailingAddress).toBeDefined()

--- a/tests/unit/Directors.spec.ts
+++ b/tests/unit/Directors.spec.ts
@@ -2,35 +2,19 @@ import Vue from 'vue'
 import Vuetify from 'vuetify'
 import Vuelidate from 'vuelidate'
 import { mount, Wrapper } from '@vue/test-utils'
-import flushPromises from 'flush-promises'
 import sinon from 'sinon'
 import axios from '@/axios-auth'
 import { getVuexStore } from '@/store'
 import Directors from '@/components/common/Directors.vue'
 import { ConfigJson } from '@/resources/business-config'
+import { click } from '../click'
+import { setValue } from '../setValue'
 
 Vue.use(Vuetify)
 Vue.use(Vuelidate)
 
 const vuetify = new Vuetify({})
 const store = getVuexStore() as any // remove typings for unit tests
-
-async function click (vm: any, id: string) {
-  const button = vm.$el.querySelector(id)
-  const window = button.ownerDocument.defaultView
-  const event = new window.Event('click')
-  button.dispatchEvent(event)
-  await Vue.nextTick()
-}
-
-async function setValue (vm: any, id: string, value: string) {
-  const input = vm.$el.querySelector(id)
-  input.value = value
-  const window = input.ownerDocument.defaultView
-  const event = new window.Event('input')
-  input.dispatchEvent(event)
-  await Vue.nextTick()
-}
 
 describe('Directors as a COOP', () => {
   let wrapper: Wrapper<Directors>
@@ -173,8 +157,7 @@ describe('Directors as a COOP', () => {
     // change one director to non-Canadian so that now 2 out of 3 are non-Canadian
     const directors = [...vm.allDirectors]
     directors[0].deliveryAddress.addressCountry = 'UK'
-    wrapper.setProps({ directors })
-    await Vue.nextTick()
+    await wrapper.setProps({ directors })
 
     // verify compliance message
     expect(vm.complianceMsg.title).toBe('Canadian Resident Directors Required')
@@ -191,8 +174,7 @@ describe('Directors as a COOP', () => {
     directors[0].deliveryAddress.addressRegion = 'ON'
     directors[1].deliveryAddress.addressRegion = 'ON'
     directors[2].deliveryAddress.addressRegion = 'ON'
-    wrapper.setProps({ directors })
-    await Vue.nextTick()
+    await wrapper.setProps({ directors })
 
     // verify compliance message
     expect(vm.complianceMsg.title).toBe('BC Resident Director Required')
@@ -247,8 +229,7 @@ describe('Directors as a COOP', () => {
 
   it('disables buttons/actions when instructed by parent component', async () => {
     // clear enabled prop
-    wrapper.setProps({ componentEnabled: false })
-    await Vue.nextTick()
+    await wrapper.setProps({ componentEnabled: false })
 
     // confirm that flag is set correctly
     expect(vm.componentEnabled).toEqual(false)
@@ -263,8 +244,7 @@ describe('Directors as a COOP', () => {
 
   it('enables buttons/actions when instructed by parent component', async () => {
     // set enabled prop
-    wrapper.setProps({ componentEnabled: true })
-    await Vue.nextTick()
+    await wrapper.setProps({ componentEnabled: true })
 
     // confirm that flag is set correctly
     expect(vm.componentEnabled).toEqual(true)
@@ -279,8 +259,7 @@ describe('Directors as a COOP', () => {
 
   it('displays Appoint New Director form when button clicked', async () => {
     // set enabled prop
-    wrapper.setProps({ componentEnabled: true })
-    await Vue.nextTick()
+    await wrapper.setProps({ componentEnabled: true })
 
     // confirm that flag is set correctly
     expect(vm.componentEnabled).toEqual(true)
@@ -411,7 +390,7 @@ describe('Directors as a COOP (no sync)', () => {
       })))
 
     // mount the component
-    wrapper = mount(Directors, { sync: false, store, vuetify })
+    wrapper = mount(Directors, { store, vuetify })
     vm = wrapper.vm
 
     // fetch original directors
@@ -788,8 +767,7 @@ describe('Directors as a BCOMP', () => {
 
   it('disables buttons/actions when instructed by parent component', async () => {
     // clear enabled prop
-    wrapper.setProps({ componentEnabled: false })
-    await Vue.nextTick()
+    await wrapper.setProps({ componentEnabled: false })
 
     // confirm that flag is set correctly
     expect(vm.componentEnabled).toEqual(false)
@@ -804,8 +782,7 @@ describe('Directors as a BCOMP', () => {
 
   it('enables buttons/actions when instructed by parent component', async () => {
     // set enabled prop
-    wrapper.setProps({ componentEnabled: true })
-    await Vue.nextTick()
+    await wrapper.setProps({ componentEnabled: true })
 
     // confirm that flag is set correctly
     expect(vm.componentEnabled).toEqual(true)
@@ -820,8 +797,7 @@ describe('Directors as a BCOMP', () => {
 
   it('displays Appoint New Director form when button clicked', async () => {
     // set enabled prop
-    wrapper.setProps({ componentEnabled: true })
-    await Vue.nextTick()
+    await wrapper.setProps({ componentEnabled: true })
 
     // confirm that flag is set correctly
     expect(vm.componentEnabled).toEqual(true)
@@ -917,7 +893,7 @@ describe('Appoint New Director tests', () => {
       })))
 
     // mount the component
-    wrapper = mount(Directors, { sync: false, store, vuetify })
+    wrapper = mount(Directors, { store, vuetify })
     vm = wrapper.vm
 
     // fetch original directors
@@ -933,8 +909,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('accepts valid First Name', async () => {
-    wrapper.find('#new-director__first-name').setValue('First First')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__first-name').setValue('First First')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.firstName).toBe('First First')
 
@@ -943,8 +919,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('displays error for invalid First Name - leading spaces', async () => {
-    wrapper.find('#new-director__first-name').setValue('  First')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__first-name').setValue('  First')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.firstName).toBe('  First')
 
@@ -953,8 +929,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('displays error for invalid First Name - trailing spaces', async () => {
-    wrapper.find('#new-director__first-name').setValue('First  ')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__first-name').setValue('First  ')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.firstName).toBe('First  ')
 
@@ -963,8 +939,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('allows First Name with multiple inline spaces', async () => {
-    wrapper.find('#new-director__first-name').setValue('First  First')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__first-name').setValue('First  First')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.firstName).toBe('First  First')
 
@@ -973,8 +949,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('accepts valid Middle Initial', async () => {
-    wrapper.find('#new-director__middle-initial').setValue('M M')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__middle-initial').setValue('M M')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.middleInitial).toBe('M M')
 
@@ -983,8 +959,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('displays error for invalid Middle Initial - leading spaces', async () => {
-    wrapper.find('#new-director__middle-initial').setValue('  M')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__middle-initial').setValue('  M')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.middleInitial).toBe('  M')
 
@@ -993,8 +969,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('displays error for invalid Middle Initial - trailing spaces', async () => {
-    wrapper.find('#new-director__middle-initial').setValue('M  ')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__middle-initial').setValue('M  ')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.middleInitial).toBe('M  ')
 
@@ -1003,8 +979,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('allows Middle Initial with multiple inline spaces', async () => {
-    wrapper.find('#new-director__middle-initial').setValue('M  M')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__middle-initial').setValue('M  M')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.middleInitial).toBe('M  M')
 
@@ -1013,8 +989,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('accepts valid Last Name', async () => {
-    wrapper.find('#new-director__last-name').setValue('Last Last')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__last-name').setValue('Last Last')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.lastName).toBe('Last Last')
 
@@ -1023,8 +999,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('displays error for invalid Last Name - leading spaces', async () => {
-    wrapper.find('#new-director__last-name').setValue('  Last')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__last-name').setValue('  Last')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.lastName).toBe('  Last')
 
@@ -1033,8 +1009,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('displays error for invalid Last Name - trailing spaces', async () => {
-    wrapper.find('#new-director__last-name').setValue('Last  ')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__last-name').setValue('Last  ')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.lastName).toBe('Last  ')
 
@@ -1043,8 +1019,8 @@ describe('Appoint New Director tests', () => {
   })
 
   it('allows Last Name with multiple inline spaces', async () => {
-    wrapper.find('#new-director__last-name').setValue('Last  Last')
-    await flushPromises() // needed due to sync:false
+    await wrapper.find('#new-director__last-name').setValue('Last  Last')
+    await Vue.nextTick()
 
     expect(vm.newDirector.officer.lastName).toBe('Last  Last')
 

--- a/tests/unit/DocumentsList.spec.ts
+++ b/tests/unit/DocumentsList.spec.ts
@@ -115,7 +115,7 @@ describe('Documents List', () => {
     expect(wrapper.find('.download-all-btn').classes('v-btn--loading')).toBe(false)
 
     // set the props
-    wrapper.setProps({ loadingOne: true, loadingOneIndex: 1 })
+    await wrapper.setProps({ loadingOne: true, loadingOneIndex: 1 })
 
     // verify that all buttons are disabled and that only button 1 is loading
     expect(documentBtns.at(0).attributes('disabled')).toBe('disabled')
@@ -151,7 +151,7 @@ describe('Documents List', () => {
     expect(wrapper.find('.download-all-btn').classes('v-btn--loading')).toBe(false)
 
     // set the prop
-    wrapper.setProps({ loadingAll: true })
+    await wrapper.setProps({ loadingAll: true })
 
     // verify that all buttons are disabled and that only button 1 is loading
     expect(documentBtns.at(0).attributes('disabled')).toBe('disabled')

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -150,7 +150,7 @@ describe('EntityInfo - Staff Comments', () => {
     const wrapper = mount(EntityInfo, { vuetify, store, router })
     await Vue.nextTick()
 
-    expect(wrapper.find(StaffComments).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffComments).exists()).toBe(false)
 
     wrapper.destroy()
   })
@@ -164,7 +164,7 @@ describe('EntityInfo - Staff Comments', () => {
     const wrapper = mount(EntityInfo, { vuetify, store, router })
     await Vue.nextTick()
 
-    expect(wrapper.find(StaffComments).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffComments).exists()).toBe(false)
 
     wrapper.destroy()
   })
@@ -178,7 +178,7 @@ describe('EntityInfo - Staff Comments', () => {
     const wrapper = mount(EntityInfo, { vuetify, store, router })
     await Vue.nextTick()
 
-    expect(wrapper.find(StaffComments).exists()).toBe(true)
+    expect(wrapper.findComponent(StaffComments).exists()).toBe(true)
 
     store.state.keycloakRoles = []
     wrapper.destroy()

--- a/tests/unit/FetchErrorDialog.spec.ts
+++ b/tests/unit/FetchErrorDialog.spec.ts
@@ -22,7 +22,7 @@ describe('FetchErrorDialog', () => {
       .toContain('We were unable to fetch some data needed for your filing.')
     expect(wrapper.find('#dialog-text').text())
       .toContain('You can return to the Business Dashboard and try again.')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
     expect(wrapper.find('#dialog-actions').text()).toBe('Return to dashboard')
 
     wrapper.destroy()
@@ -34,7 +34,7 @@ describe('FetchErrorDialog', () => {
 
     const wrapper = shallowMount(FetchErrorDialog, { propsData: { dialog: true }, store, vuetify })
 
-    expect(wrapper.find(ContactInfo).exists()).toBe(false)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(false)
 
     wrapper.destroy()
   })

--- a/tests/unit/FiledLabel.spec.ts
+++ b/tests/unit/FiledLabel.spec.ts
@@ -15,7 +15,8 @@ describe('Filed Label', () => {
     })
 
     // verify content
-    expect(wrapper.html()).toBeUndefined()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.html()).toBeFalsy()
 
     wrapper.destroy()
   })
@@ -34,7 +35,7 @@ describe('Filed Label', () => {
 
     // verify content
     expect(wrapper.find('.filed-label > span').text()).toBe('Filed by Submitter on May 15, 2020')
-    expect(wrapper.findAll(DateTooltip).length).toBe(1)
+    expect(wrapper.findAllComponents(DateTooltip).length).toBe(1)
 
     wrapper.destroy()
   })
@@ -57,7 +58,7 @@ describe('Filed Label', () => {
     expect(spans.at(0).text()).toBe('(filed by Submitter on May 15, 2020)')
     expect(spans.at(1).text()).toBe('') // vert-pipe
     expect(spans.at(2).text()).toBe('EFFECTIVE as of May 20, 2020')
-    expect(wrapper.findAll(DateTooltip).length).toBe(2)
+    expect(wrapper.findAllComponents(DateTooltip).length).toBe(2)
 
     wrapper.destroy()
   })

--- a/tests/unit/FilingHistoryList1.spec.ts
+++ b/tests/unit/FilingHistoryList1.spec.ts
@@ -226,21 +226,21 @@ describe('Filing History List - misc functionality', () => {
 
     // expand details
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     // verify Close button
     expect(wrapper.find('.expand-btn').text()).toContain('Close')
 
     // verify details
     expect(vm.panel).toBe(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(true)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(true)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     wrapper.destroy()
   })
@@ -281,21 +281,21 @@ describe('Filing History List - misc functionality', () => {
 
     // expand details
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     // verify Hide Documents button
     expect(wrapper.find('.expand-btn').text()).toContain('Hide Documents')
 
     // verify details
     expect(vm.panel).toBe(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     wrapper.destroy()
   })
@@ -747,8 +747,8 @@ describe('Filing History List - redirections', () => {
     const startCorrectionBtn = wrapper.find('#dialog-start-button')
     expect(startCorrectionBtn.exists()).toBe(true)
     await startCorrectionBtn.trigger('click')
+    await Vue.nextTick()
 
-    await flushPromises()
     const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     const createUrl = 'https://edit.url/BC1234567/correction/?correction-id=110514'
     expect(window.location.assign).toHaveBeenCalledWith(createUrl + '&accountid=' + accountId)
@@ -913,14 +913,14 @@ describe('Filing History List - incorporation applications', () => {
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(true)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(true)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     sessionStorage.removeItem('TEMP_REG_NUMBER')
     wrapper.destroy()
@@ -977,14 +977,14 @@ describe('Filing History List - incorporation applications', () => {
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(true)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(true)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     sessionStorage.removeItem('TEMP_REG_NUMBER')
     wrapper.destroy()
@@ -1041,14 +1041,14 @@ describe('Filing History List - incorporation applications', () => {
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(true)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(true)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     sessionStorage.removeItem('TEMP_REG_NUMBER')
     wrapper.destroy()
@@ -1103,14 +1103,14 @@ describe('Filing History List - incorporation applications', () => {
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(true)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(true)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     sessionStorage.removeItem('TEMP_REG_NUMBER')
     wrapper.destroy()
@@ -1167,14 +1167,14 @@ describe('Filing History List - incorporation applications', () => {
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(true)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(true)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     sessionStorage.removeItem('TEMP_REG_NUMBER')
     wrapper.destroy()
@@ -1229,18 +1229,18 @@ describe('Filing History List - incorporation applications', () => {
 
     // expand details
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for expansion transition
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     sessionStorage.removeItem('BUSINESS_ID')
     wrapper.destroy()
@@ -1305,14 +1305,14 @@ describe('Filing History List - paper only and other filings', () => {
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(true)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(true)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
   })
 
   it('displays an "empty" alteration filing', async () => {
@@ -1359,21 +1359,21 @@ describe('Filing History List - paper only and other filings', () => {
     const detailsBtn = wrapper.find('.expand-btn')
     expect(detailsBtn.text()).toContain('View Documents')
     await detailsBtn.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for expansion transition
 
     // verify Hide Documents button
     expect(wrapper.find('.expand-btn').text()).toContain('Hide Documents')
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(true)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(true)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
   })
 
   it('displays a "future effective" alteration filing', async () => {
@@ -1425,21 +1425,21 @@ describe('Filing History List - paper only and other filings', () => {
     const detailsBtn = wrapper.find('.expand-btn')
     expect(detailsBtn.text()).toContain('View Documents')
     await detailsBtn.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for expansion transition
 
     // verify Hide Documents button
     expect(wrapper.find('.expand-btn').text()).toContain('Hide Documents')
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(true)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(true)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
   })
 
   it('displays a "future effective pending" alteration filing', async () => {
@@ -1490,21 +1490,21 @@ describe('Filing History List - paper only and other filings', () => {
     const detailsBtn = wrapper.find('.expand-btn')
     expect(detailsBtn.text()).toContain('View Documents')
     await detailsBtn.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for expansion transition
 
     // verify Hide Documents button
     expect(wrapper.find('.expand-btn').text()).toContain('Hide Documents')
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(true)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(true)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
   })
 
   it('displays a "full" alteration filing', async () => {
@@ -1555,21 +1555,21 @@ describe('Filing History List - paper only and other filings', () => {
     const detailsBtn = wrapper.find('.expand-btn')
     expect(detailsBtn.text()).toContain('View Documents')
     await detailsBtn.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for expansion transition
 
     // verify Hide Documents button
     expect(wrapper.find('.expand-btn').text()).toContain('Hide Documents')
 
     // verify details
     expect(vm.panel).toEqual(0) // first row is expanded
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(true)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(false)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(true)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
   })
 
   it('displays a Registrar\'s Notation (staff only) filing', async () => {
@@ -1619,14 +1619,14 @@ describe('Filing History List - paper only and other filings', () => {
     expect(wrapper.find('.expand-btn').text()).toContain('Hide')
 
     expect(vm.panel).toBe(0)
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(true)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(true)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
   })
 
   it('displays a Registrar\'s Order (staff only) filing', async () => {
@@ -1676,14 +1676,14 @@ describe('Filing History List - paper only and other filings', () => {
     expect(wrapper.find('.expand-btn').text()).toContain('Hide')
 
     expect(vm.panel).toBe(0)
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(true)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(true)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
   })
 
   it('displays a Court Order (staff only) filing', async () => {
@@ -1733,14 +1733,14 @@ describe('Filing History List - paper only and other filings', () => {
     expect(wrapper.find('.expand-btn').text()).toContain('Hide')
 
     expect(vm.panel).toBe(0)
-    expect(wrapper.find(CompletedAlteration).exists()).toBe(false)
-    expect(wrapper.find(CompletedIa).exists()).toBe(false)
-    expect(wrapper.find(FutureEffective).exists()).toBe(false)
-    expect(wrapper.find(FutureEffectivePending).exists()).toBe(false)
-    expect(wrapper.find(PaperFiling).exists()).toBe(false)
-    expect(wrapper.find(PendingFiling).exists()).toBe(false)
-    expect(wrapper.find(StaffFiling).exists()).toBe(true)
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(false)
+    expect(wrapper.findComponent(CompletedIa).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffective).exists()).toBe(false)
+    expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(false)
+    expect(wrapper.findComponent(PaperFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(PendingFiling).exists()).toBe(false)
+    expect(wrapper.findComponent(StaffFiling).exists()).toBe(true)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
   })
 })
 
@@ -1776,7 +1776,7 @@ describe('Filing History List - with documents', () => {
     await Vue.nextTick()
 
     // verify that Documents List component does not exist before the item is expanded
-    expect(wrapper.find(DocumentsList).exists()).toBe(false)
+    expect(wrapper.findComponent(DocumentsList).exists()).toBe(false)
 
     // verify View Documents button
     const button = wrapper.find('.expand-btn')
@@ -1786,7 +1786,7 @@ describe('Filing History List - with documents', () => {
     await button.trigger('click')
 
     // verify that Documents List component is not displayed after the item is expanded
-    expect(wrapper.find(DocumentsList).exists()).toBe(false)
+    expect(wrapper.findComponent(DocumentsList).exists()).toBe(false)
 
     sinon.restore()
     wrapper.destroy()
@@ -1813,7 +1813,7 @@ describe('Filing History List - with documents', () => {
     await Vue.nextTick()
 
     // verify that Documents List component does not exist before the item is expanded
-    expect(wrapper.find(DocumentsList).exists()).toBe(false)
+    expect(wrapper.findComponent(DocumentsList).exists()).toBe(false)
 
     // verify View Documents button
     const button = wrapper.find('.expand-btn')
@@ -1821,10 +1821,10 @@ describe('Filing History List - with documents', () => {
 
     // expand details
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for expansion transition
 
     // verify that Documents List component is displayed after the item is expanded
-    expect(wrapper.find(DocumentsList).exists()).toBe(true)
+    expect(wrapper.findComponent(DocumentsList).exists()).toBe(true)
 
     // verify the number of documents
     expect(wrapper.findAll('.documents-list .download-one-btn').length).toBe(2)
@@ -1857,10 +1857,10 @@ describe('Filing History List - with documents', () => {
 
     // expand details
     await wrapper.find('.expand-btn').trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for expansion transition
 
     // verify that Documents List component is displayed after the item is expanded
-    expect(wrapper.find(DocumentsList).exists()).toBe(true)
+    expect(wrapper.findComponent(DocumentsList).exists()).toBe(true)
 
     // verify document titles
     const downloadBtns = wrapper.findAll('.documents-list .download-one-btn')
@@ -1962,13 +1962,13 @@ describe('Filing History List - detail comments', () => {
     await Vue.nextTick()
 
     // verify that Details List component does not exist before the item is expanded
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     // expand the panel
     await wrapper.find('.expand-btn').trigger('click')
 
     // verify that Details List component is not displayed after the item is expanded
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     sinon.restore()
     wrapper.destroy()
@@ -2007,14 +2007,14 @@ describe('Filing History List - detail comments', () => {
     await Vue.nextTick()
 
     // verify that Details List component does not exist until the item is expanded
-    expect(wrapper.find(DetailsList).exists()).toBe(false)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(false)
 
     // expand the panel
     await wrapper.find('.expand-btn').trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for expansion transition
 
     // verify that Details List component is displayed after the item is expanded
-    expect(wrapper.find(DetailsList).exists()).toBe(true)
+    expect(wrapper.findComponent(DetailsList).exists()).toBe(true)
 
     // verify the number of comments
     expect(wrapper.findAll('.details-list .detail-body').length).toBe(2)
@@ -2049,6 +2049,7 @@ describe('Filing History List - without documents', () => {
     // verify that View Documents Button is not rendered
     const button = wrapper.find('.expand-btn')
     expect(button.text()).toEqual('')
+
     wrapper.destroy()
   })
 })

--- a/tests/unit/FilingHistoryList2.spec.ts
+++ b/tests/unit/FilingHistoryList2.spec.ts
@@ -31,7 +31,7 @@ const isPaperOnly = (filing) => filing.availableOnPaperOnly
 const isCorrection = (filing) => !!filing.correctedFilingId
 const isCorrected = (filing) => !!filing.correctionFilingId
 const isIncorporationApplication = (filing) => (filing.name === 'incorporationApplication')
-const isBcompCoa = () => false // FUTURE: implement BComp tests
+const isBcompCoa = (filing) => false // FUTURE: implement BComp tests
 const isAlteration = (filing) => (filing.name === 'alteration')
 const isStaff = (filing) => (
   filing.name === 'registrarsNotation' ||
@@ -217,7 +217,8 @@ filings.forEach((filing: any, index: number) => {
 
       // click button and verify updated label
       await expandBtn.trigger('click')
-      await flushPromises() // need to wait longer here
+      await flushPromises() // wait for expansion transition
+
       if (isPaperOnly(filing)) {
         expect(expandBtn.text()).toContain('Close')
       } else if (isStaff(filing)) {
@@ -232,25 +233,25 @@ filings.forEach((filing: any, index: number) => {
       const item = vm.historyItems[0]
 
       if (item.isTypeStaff) {
-        expect(wrapper.find(StaffFiling).exists()).toBe(true)
+        expect(wrapper.findComponent(StaffFiling).exists()).toBe(true)
       } else if (item.isFutureEffectiveBcompCoaPending) {
         // no details
       } else if (item.isCompletedIa) {
-        expect(wrapper.find(CompletedIa).exists()).toBe(true)
+        expect(wrapper.findComponent(CompletedIa).exists()).toBe(true)
       } else if (item.isFutureEffectiveIaPending) {
-        expect(wrapper.find(FutureEffectivePending).exists()).toBe(true)
+        expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(true)
       } else if (item.isFutureEffectiveIa) {
-        expect(wrapper.find(FutureEffective).exists()).toBe(true)
+        expect(wrapper.findComponent(FutureEffective).exists()).toBe(true)
       } else if (item.isFutureEffectiveAlterationPending) {
-        expect(wrapper.find(FutureEffectivePending).exists()).toBe(true)
+        expect(wrapper.findComponent(FutureEffectivePending).exists()).toBe(true)
       } else if (item.isFutureEffectiveAlteration) {
-        expect(wrapper.find(FutureEffective).exists()).toBe(true)
+        expect(wrapper.ffindComponentind(FutureEffective).exists()).toBe(true)
       } else if (item.status === 'PAID') {
-        expect(wrapper.find(PendingFiling).exists()).toBe(true)
+        expect(wrapper.findComponent(PendingFiling).exists()).toBe(true)
       } else if (item.name === 'alteration') {
-        expect(wrapper.find(CompletedAlteration).exists()).toBe(true)
+        expect(wrapper.findComponent(CompletedAlteration).exists()).toBe(true)
       } else if (item.availableOnPaperOnly) {
-        expect(wrapper.find(PaperFiling).exists()).toBe(true)
+        expect(wrapper.findComponent(PaperFiling).exists()).toBe(true)
       } else {
         // no details
       }

--- a/tests/unit/FutureEffective.spec.ts
+++ b/tests/unit/FutureEffective.spec.ts
@@ -20,7 +20,8 @@ describe('Future Effective IA', () => {
     })
 
     // verify content
-    expect(wrapper.html()).toBeUndefined()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.html()).toBeFalsy()
 
     wrapper.destroy()
   })
@@ -42,7 +43,7 @@ describe('Future Effective IA', () => {
     expect(paragraphs.at(1).text()).toContain('Registries staff to file a withdrawal. Withdrawing this filing will remove')
     expect(paragraphs.at(1).text()).toContain('this filing and all associated information, and will incur a $20.00 fee.')
     expect(wrapper.findAll('h4').at(1).text()).toBe('BC Registries Contact Information:')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -70,7 +71,7 @@ describe('Future Effective IA', () => {
     expect(paragraphs.at(1).text()).toContain('Registries staff to file a withdrawal. Withdrawing this Incorporation Application will remove')
     expect(paragraphs.at(1).text()).toContain('this incorporation and all associated information, and will incur a $20.00 fee.')
     expect(wrapper.findAll('h4').at(1).text()).toBe('BC Registries Contact Information:')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -98,7 +99,7 @@ describe('Future Effective IA', () => {
     expect(paragraphs.at(1).text()).toContain('Registries staff to file a withdrawal. Withdrawing this Incorporation Application will remove')
     expect(paragraphs.at(1).text()).toContain('this incorporation and all associated information, and will incur a $20.00 fee.')
     expect(wrapper.findAll('h4').at(1).text()).toBe('BC Registries Contact Information:')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -130,7 +131,7 @@ describe('Future Effective IA', () => {
     expect(paragraphs.at(3).text()).toContain('Registries staff to file a withdrawal. Withdrawing this Alteration Notice will remove')
     expect(paragraphs.at(3).text()).toContain('this alteration and all associated information, and will incur a $20.00 fee.')
     expect(wrapper.findAll('h4').at(1).text()).toBe('BC Registries Contact Information:')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })

--- a/tests/unit/FutureEffectivePending.spec.ts
+++ b/tests/unit/FutureEffectivePending.spec.ts
@@ -20,7 +20,8 @@ describe('Future Effective Pending', () => {
     })
 
     // verify content
-    expect(wrapper.html()).toBeUndefined()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.html()).toBeFalsy()
 
     wrapper.destroy()
   })
@@ -40,7 +41,7 @@ describe('Future Effective Pending', () => {
     expect(paragraphs.at(0).text()).toContain('has been recorded as Unknown.')
     expect(paragraphs.at(1).text()).toContain('It may take up to one hour to process this filing. If this issue persists,')
     expect(paragraphs.at(1).text()).toContain('please contact us.')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -67,7 +68,7 @@ describe('Future Effective Pending', () => {
     expect(paragraphs.at(0).text()).toContain('has been recorded as May 15, 2020 at 12:00 pm Pacific time.')
     expect(paragraphs.at(1).text()).toContain('It may take up to one hour to process this filing. If this issue persists,')
     expect(paragraphs.at(1).text()).toContain('please contact us.')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -94,7 +95,7 @@ describe('Future Effective Pending', () => {
     expect(paragraphs.at(0).text()).toContain('has been recorded as May 15, 2020 at 12:00 pm Pacific time.')
     expect(paragraphs.at(1).text()).toContain('It may take up to one hour to process this filing. If this issue persists,')
     expect(paragraphs.at(1).text()).toContain('please contact us.')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -125,7 +126,7 @@ describe('Future Effective Pending', () => {
     expect(paragraphs.at(2).text()).toContain('Pursuant to a Plan of Arrangement')
     expect(paragraphs.at(3).text()).toContain('It may take up to one hour to process this filing. If this issue persists,')
     expect(paragraphs.at(3).text()).toContain('please contact us.')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })

--- a/tests/unit/MissingInformation.spec.ts
+++ b/tests/unit/MissingInformation.spec.ts
@@ -4,6 +4,7 @@ import { mount } from '@vue/test-utils'
 import { getVuexStore } from '@/store'
 import MissingInformation from '@/components/Dashboard/Alerts/MissingInformation.vue'
 import { ContactInfo } from '@/components/common'
+import flushPromises from 'flush-promises'
 
 Vue.use(Vuetify)
 
@@ -26,8 +27,8 @@ describe('Missing Information component', () => {
     const wrapper = mount(MissingInformation, { store, vuetify })
 
     // click the button
-    wrapper.find('.details-btn').trigger('click')
-    await Vue.nextTick()
+    await wrapper.find('.details-btn').trigger('click')
+    await flushPromises() // wait for expansion transition
 
     // verify content
     expect(wrapper.find('h3').text()).toBe('Missing information')
@@ -35,7 +36,7 @@ describe('Missing Information component', () => {
     expect(wrapper.find('.v-expansion-panel-content').exists()).toBe(true)
     expect(wrapper.find('.v-expansion-panel-content__wrap').text()).toContain('BC Registries is missing')
     expect(wrapper.find('.v-expansion-panel-content__wrap').text()).toContain('If further action is required')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })

--- a/tests/unit/NotInGoodStanding.spec.ts
+++ b/tests/unit/NotInGoodStanding.spec.ts
@@ -3,9 +3,9 @@ import Vuetify from 'vuetify'
 import { mount } from '@vue/test-utils'
 import NotInGoodStanding from '@/components/Dashboard/Alerts/NotInGoodStanding.vue'
 import { ContactInfo } from '@/components/common'
+import flushPromises from 'flush-promises'
 
 Vue.use(Vuetify)
-
 const vuetify = new Vuetify({})
 
 describe('Not In Good Standing component', () => {
@@ -24,8 +24,8 @@ describe('Not In Good Standing component', () => {
     const wrapper = mount(NotInGoodStanding, { vuetify })
 
     // click the button
-    wrapper.find('.details-btn').trigger('click')
-    await Vue.nextTick()
+    await wrapper.find('.details-btn').trigger('click')
+    await flushPromises() // wait for expansion transition
 
     // verify content
     expect(wrapper.find('h3').text()).toBe('This business is not in good standing')
@@ -33,7 +33,7 @@ describe('Not In Good Standing component', () => {
     expect(wrapper.find('.v-expansion-panel-content').exists()).toBe(true)
     expect(wrapper.find('.v-expansion-panel-content__wrap').text()).toContain('The most common reason a')
     expect(wrapper.find('.v-expansion-panel-content__wrap').text()).toContain('If further action is required')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })

--- a/tests/unit/NotInGoodStandingDialog.spec.ts
+++ b/tests/unit/NotInGoodStandingDialog.spec.ts
@@ -5,7 +5,6 @@ import { NotInGoodStandingDialog } from '@/components/dialogs'
 import { ContactInfo } from '@/components/common'
 
 Vue.use(Vuetify)
-
 const vuetify = new Vuetify({})
 
 // Prevent the warning "[Vuetify] Unable to locate target [data-app]"
@@ -19,14 +18,14 @@ describe('Not In Good Standing Dialog', () => {
         propsData: { dialog: true, message: 'dissolve' }
       })
 
-    expect(wrapper.attributes('content-class')).toBe('not-in-good-standing-dialog')
+    expect(wrapper.attributes('contentclass')).toBe('not-in-good-standing-dialog')
     expect(wrapper.isVisible()).toBe(true)
     expect(wrapper.find('.warning-title').text()).toContain('Business is not in good standing')
     expect(wrapper.findAll('.warning-text').at(0).text())
       .toContain('This business cannot be dissolved at this time because it is not in good standing')
     expect(wrapper.findAll('.warning-text').at(1).text())
       .toContain('Please file any overdue annual reports in your To Do list and try your voluntary')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
     expect(wrapper.find('#dialog-close-button').exists()).toBe(true)
 
     wrapper.destroy()
@@ -39,14 +38,14 @@ describe('Not In Good Standing Dialog', () => {
         propsData: { dialog: true, message: 'changeCompanyInfo' }
       })
 
-    expect(wrapper.attributes('content-class')).toBe('not-in-good-standing-dialog')
+    expect(wrapper.attributes('contentclass')).toBe('not-in-good-standing-dialog')
     expect(wrapper.isVisible()).toBe(true)
     expect(wrapper.find('.warning-title').text()).toContain('Business is not in good standing')
     expect(wrapper.findAll('.warning-text').at(0).text())
       .toContain('The complete company information for this business cannot be viewed or changed at')
     expect(wrapper.findAll('.warning-text').at(1).text())
       .toContain('Please file any overdue annual reports in your To Do list and try to view and change')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
     expect(wrapper.find('#dialog-close-button').exists()).toBe(true)
 
     wrapper.destroy()
@@ -59,11 +58,11 @@ describe('Not In Good Standing Dialog', () => {
         propsData: { dialog: true }
       })
 
-    expect(wrapper.attributes('content-class')).toBe('not-in-good-standing-dialog')
+    expect(wrapper.attributes('contentclass')).toBe('not-in-good-standing-dialog')
     expect(wrapper.isVisible()).toBe(true)
     expect(wrapper.find('.warning-title').text()).toContain('Business is not in good standing')
     expect(wrapper.find('.warning-text').text()).toContain('Please contact BC Registries staff:')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
     expect(wrapper.find('#dialog-close-button').exists()).toBe(true)
 
     wrapper.destroy()

--- a/tests/unit/PaperFiling.spec.ts
+++ b/tests/unit/PaperFiling.spec.ts
@@ -16,7 +16,7 @@ describe('Paper Filing', () => {
     expect(paraText).toContain('This filing is available on paper only.')
     expect(paraText).toContain('To request copies of paper documents,')
     expect(paraText).toContain('contact BC Registries staff:')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -14,7 +14,7 @@ const store = getVuexStore() as any // remove typings for unit tests
 document.body.setAttribute('data-app', 'true')
 
 describe('Payment Error Dialog', () => {
-  it('displays generic message for normal users', () => {
+  it('displays generic message for normal users', async () => {
     // init store
     store.state.keycloakRoles = []
 
@@ -27,15 +27,16 @@ describe('Payment Error Dialog', () => {
         store,
         vuetify
       })
+    await Vue.nextTick()
 
-    expect(wrapper.attributes('content-class')).toBe('payment-error-dialog')
+    expect(wrapper.attributes('contentclass')).toBe('payment-error-dialog')
     expect(wrapper.isVisible()).toBe(true)
     expect(wrapper.find('#dialog-title').text()).toBe('Unable to Process Payment')
     expect(wrapper.find('#dialog-text').text()).toContain('We are unable to process your payment')
     expect(wrapper.find('#dialog-text').text()).toContain('This FILING has been')
     expect(wrapper.find('#dialog-text').text()).toContain('PayBC is normally available')
     expect(wrapper.find('#dialog-text').text()).toContain('If this error persists')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
 
     wrapper.destroy()
@@ -55,7 +56,7 @@ describe('Payment Error Dialog', () => {
         vuetify
       })
 
-    expect(wrapper.attributes('content-class')).toBe('payment-error-dialog')
+    expect(wrapper.attributes('contentclass')).toBe('payment-error-dialog')
     expect(wrapper.isVisible()).toBe(true)
     expect(wrapper.find('#dialog-title').text()).toBe('Unable to Process Payment')
     expect(wrapper.find('#dialog-text').text()).toContain('We are unable to process your payment')

--- a/tests/unit/PendingFiling.spec.ts
+++ b/tests/unit/PendingFiling.spec.ts
@@ -15,7 +15,8 @@ describe('Pending Filing', () => {
     })
 
     // verify content
-    expect(wrapper.html()).toBeUndefined()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.html()).toBeFalsy()
 
     wrapper.destroy()
   })
@@ -33,7 +34,7 @@ describe('Pending Filing', () => {
     expect(paragraphs.at(0).text()).toContain('This Filing is paid')
     expect(paragraphs.at(1).text()).toContain('Refresh this screen')
     expect(paragraphs.at(1).text()).toContain('If this issue persists')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -59,7 +60,7 @@ describe('Pending Filing', () => {
     expect(paragraphs.at(2).text()).toContain('Pursuant to a Plan of Arrangement')
     expect(paragraphs.at(3).text()).toContain('Refresh this screen')
     expect(paragraphs.at(3).text()).toContain('If this issue persists')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -81,7 +82,7 @@ describe('Pending Filing', () => {
     expect(paragraphs.at(0).text()).toContain('This Incorporation Application is paid')
     expect(paragraphs.at(1).text()).toContain('Refresh this screen')
     expect(paragraphs.at(1).text()).toContain('If this issue persists')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
 
     wrapper.destroy()
   })

--- a/tests/unit/SaveErrorDialog.spec.ts
+++ b/tests/unit/SaveErrorDialog.spec.ts
@@ -14,7 +14,7 @@ const store = getVuexStore() as any // remove typings for unit tests
 document.body.setAttribute('data-app', 'true')
 
 describe('Save Error Dialog', () => {
-  it('displays generic message for normal users', () => {
+  it('displays generic message for normal users', async () => {
     // init store
     store.state.keycloakRoles = []
 
@@ -27,14 +27,15 @@ describe('Save Error Dialog', () => {
         store,
         vuetify
       })
+    await Vue.nextTick()
 
-    expect(wrapper.attributes('content-class')).toBe('save-error-dialog')
+    expect(wrapper.attributes('contentclass')).toBe('save-error-dialog')
     expect(wrapper.isVisible()).toBe(true)
     expect(wrapper.find('#dialog-title').text()).toBe('Unable to Save FILING')
     expect(wrapper.find('#dialog-text').text()).toContain('We were unable to save your FILING.')
     expect(wrapper.find('#dialog-text').text()).toContain('If you exit this FILING,')
     expect(wrapper.find('#dialog-text').text()).toContain('If this error persists, please contact us:')
-    expect(wrapper.find(ContactInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(true)
     expect(wrapper.find('#dialog-exit-button')).toBeDefined()
     expect(wrapper.find('#dialog-retry-button')).toBeDefined()
 
@@ -59,7 +60,7 @@ describe('Save Error Dialog', () => {
     expect(wrapper.find('#dialog-text').text()).toContain('We were unable to save your FILING.')
     expect(wrapper.find('#dialog-text').text()).toContain('If you exit this FILING,')
     expect(wrapper.find('#dialog-text').text()).not.toContain('If this error persists, please contact us:')
-    expect(wrapper.find(ContactInfo).exists()).toBe(false)
+    expect(wrapper.findComponent(ContactInfo).exists()).toBe(false)
     expect(wrapper.find('#dialog-exit-button')).toBeDefined()
     expect(wrapper.find('#dialog-retry-button')).toBeDefined()
 

--- a/tests/unit/StaffFiling.spec.ts
+++ b/tests/unit/StaffFiling.spec.ts
@@ -14,7 +14,8 @@ describe('Staff Filing', () => {
     })
 
     // verify content
-    expect(wrapper.html()).toBeUndefined()
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.html()).toBeFalsy()
 
     wrapper.destroy()
   })

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
-import flushPromises from 'flush-promises'
 import { mount } from '@vue/test-utils'
 import { getVuexStore } from '@/store'
 import StaffNotation from '@/components/Dashboard/StaffNotation.vue'
@@ -43,11 +42,7 @@ describe('StaffNotation', () => {
   })
 
   it('renders the menu correctly', async () => {
-    const wrapper = mount(StaffNotation, {
-      vuetify,
-      sync: false,
-      store
-    })
+    const wrapper = mount(StaffNotation, { vuetify, store })
 
     // Open menu
     await wrapper.find('.menu-btn').trigger('click')
@@ -62,11 +57,7 @@ describe('StaffNotation', () => {
   })
 
   it('emits close', async () => {
-    const wrapper = mount(StaffNotation, {
-      vuetify,
-      sync: false,
-      store
-    })
+    const wrapper = mount(StaffNotation, { vuetify, store })
 
     // Open menu
     await wrapper.find('.menu-btn').trigger('click')
@@ -74,7 +65,7 @@ describe('StaffNotation', () => {
 
     // Click on first item
     await wrapper.find('.v-list .v-item-group .v-list-item').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     expect(wrapper.vm.$data.isAddingRegistrarsNotation).toBeTruthy()
 
@@ -89,11 +80,7 @@ describe('StaffNotation', () => {
 
   for (const test of staffFilingTypes) {
     it(`renders the modal correctly for ${test.name}`, async () => {
-      const wrapper = mount(StaffNotation, {
-        vuetify,
-        sync: false,
-        store
-      })
+      const wrapper = mount(StaffNotation, { vuetify, store })
 
       // Open menu
       await wrapper.find('.menu-btn').trigger('click')

--- a/tests/unit/StaffPaymentDialog.spec.ts
+++ b/tests/unit/StaffPaymentDialog.spec.ts
@@ -9,7 +9,6 @@ import { StaffPayment } from '@bcrs-shared-components/staff-payment'
 Vue.config.silent = true
 
 Vue.use(Vuetify)
-
 const vuetify = new Vuetify({})
 
 // Prevent the warning "[Vuetify] Unable to locate target [data-app]"
@@ -27,7 +26,7 @@ describe('StaffPaymentDialog', () => {
 
     // verify displayed elements
     expect(wrapper.find('.v-card__title div').text()).toBe('Staff Payment')
-    expect(wrapper.find(StaffPayment).exists()).toBe(true)
+    expect(wrapper.findComponent(StaffPayment).exists()).toBe(true)
     expect(wrapper.find('#dialog-close-button').text()).toBe('Exit Payment')
     expect(wrapper.find('#dialog-submit-button').text()).toBe('Submit')
 
@@ -53,10 +52,9 @@ describe('StaffPaymentDialog', () => {
       // NB: stub the Staff Payment component to avoid nested event errors
       stubs: { StaffPayment: true }
     })
-    await Vue.nextTick()
 
     // set form valid since the Staff Payment component is stubbed
-    wrapper.setData({ staffPaymentFormValid: true })
+    await wrapper.setData({ staffPaymentFormValid: true })
 
     // click the Exit button
     await wrapper.find('#dialog-close-button').trigger('click')
@@ -81,10 +79,9 @@ describe('StaffPaymentDialog', () => {
       // NB: stub the Staff Payment component to avoid nested event errors
       stubs: { StaffPayment: true }
     })
-    await Vue.nextTick()
 
     // set form valid since the Staff Payment component is stubbed
-    wrapper.setData({ staffPaymentFormValid: true })
+    await wrapper.setData({ staffPaymentFormValid: true })
 
     // click the Submit button
     await wrapper.find('#dialog-submit-button').trigger('click')

--- a/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -85,23 +85,25 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route } })
 
-    expect(wrapper.find(CodDate).exists()).toBe(true)
-    expect(wrapper.find(Directors).exists()).toBe(true)
-    expect(wrapper.find(Certify).exists()).toBe(true)
+    expect(wrapper.findComponent(CodDate).exists()).toBe(true)
+    expect(wrapper.findComponent(Directors).exists()).toBe(true)
+    expect(wrapper.findComponent(Certify).exists()).toBe(true)
 
     wrapper.destroy()
   })
 
-  it('enables page valid flags when sub-component flags are valid', () => {
+  it('enables page valid flags when sub-component flags are valid', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    // set local properties
+    await wrapper.setData({
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that flags are set correctly
     expect(vm.isEditPageValid).toEqual(true)
@@ -110,16 +112,18 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables page valid flags when COD Date component is invalid', () => {
+  it('disables page valid flags when COD Date component is invalid', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.codDateValid = false
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    // set local properties
+    await wrapper.setData({
+      codDateValid: false,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that flags are set correctly
     expect(vm.isEditPageValid).toEqual(false)
@@ -128,16 +132,18 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables page valid flags when Directors component is invalid', () => {
+  it('disables page valid flags when Directors component is invalid', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.codDateValid = true
-    vm.directorFormValid = false
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    // set local properties
+    await wrapper.setData({
+      codDateValid: true,
+      directorFormValid: false,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that flags are set correctly
     expect(vm.isEditPageValid).toEqual(false)
@@ -146,30 +152,33 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('Verify COD Certify contains correct section codes', () => {
+  it('Verify COD Certify contains correct section codes', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route } })
     store.state.entityType = 'CP'
     store.state.configObject = ConfigJson.find(x => x.entityType === store.state.entityType)
-    expect(wrapper.find(Certify).exists()).toBe(true)
-    const certify: any = wrapper.find(Certify)
+    await Vue.nextTick()
 
-    expect(certify.vm.message).toContain('See Section 78 of the Cooperative Association Act.')
-    expect(certify.vm.entityDisplay).toEqual('Cooperative')
+    const certify = wrapper.findComponent(Certify)
+    expect(certify.exists()).toBe(true)
+    expect((certify.vm as any).message).toContain('See Section 78 of the Cooperative Association Act.')
+    expect((certify.vm as any).entityDisplay).toEqual('Cooperative')
 
     wrapper.destroy()
   })
 
-  it('disables page valid flags when Certify component is invalid', () => {
+  it('disables page valid flags when Certify component is invalid', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = false
-    store.state.filingData = [{}] // dummy data
+    // set local properties
+    await wrapper.setData({
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: false
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that flags are set correctly
     expect(vm.isEditPageValid).toEqual(true)
@@ -178,16 +187,18 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables page valid flags when no filing changes were made (ie: nothing to file)', () => {
+  it('disables page valid flags when no filing changes were made (ie: nothing to file)', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [] // no data
+    // set local properties
+    await wrapper.setData({
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', []) // no data
 
     // confirm that flags are set correctly
     expect(vm.isEditPageValid).toEqual(false)
@@ -196,7 +207,7 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('enables File & Pay button when page valid flag is true', () => {
+  it('enables File & Pay button when page valid flag is true', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = mount(StandaloneDirectorsFiling, {
       store,
@@ -216,12 +227,14 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.inFilingReview = true
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    // set local properties
+    await wrapper.setData({
+      inFilingReview: true,
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that button is enabled
     expect(wrapper.find('#cod-file-pay-btn').attributes('disabled')).toBeUndefined()
@@ -229,7 +242,7 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables File & Pay button when page valid flag is false', () => {
+  it('disables File & Pay button when page valid flag is false', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = mount(StandaloneDirectorsFiling, {
       store,
@@ -249,12 +262,14 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.inFilingReview = true
-    vm.codDateValid = false
-    vm.directorFormValid = false
-    vm.certifyFormValid = false
-    store.state.filingData = [] // no data
+    // set local properties
+    await wrapper.setData({
+      inFilingReview: true,
+      codDateValid: false,
+      directorFormValid: false,
+      certifyFormValid: false
+    })
+    await vm.$store.commit('filingData', []) // no data
 
     // confirm that button is disabled
     expect(wrapper.find('#cod-file-pay-btn').attributes('disabled')).toBe('disabled')
@@ -309,8 +324,7 @@ describe('Standalone Directors Filing - Part 2A - Resuming with FAS staff paymen
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route } })
     const vm = wrapper.vm as any
-    // wait for draft to be fetched
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // verify that Certified By was restored
     expect(vm.certifiedBy).toBe('Full Name')
@@ -399,8 +413,7 @@ describe('Standalone Directors Filing - Part 2B - Resuming with BCOL staff payme
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route } })
     const vm = wrapper.vm as any
-    // wait for draft to be fetched
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // verify that Certified By was restored
     expect(vm.certifiedBy).toBe('Full Name')
@@ -488,8 +501,7 @@ describe('Standalone Directors Filing - Part 2C - Resuming with No Fee staff pay
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route } })
     const vm = wrapper.vm as any
-    // wait for draft to be fetched
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // verify that Certified By was restored
     expect(vm.certifiedBy).toBe('Full Name')
@@ -679,7 +691,6 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
 
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = mount(StandaloneDirectorsFiling, {
-      sync: false,
       store,
       mocks: { $route },
       stubs: {
@@ -698,17 +709,16 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     const vm: any = wrapper.vm as any
 
     // make sure form is validated
-    vm.inFilingReview = true
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{ filingTypeCode: 'OTCDR', entityType: 'CP' }] // dummy data
+    await wrapper.setData({
+      inFilingReview: true,
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{ filingTypeCode: 'OTCDR', entityType: 'CP' }]) // dummy data
 
     // make sure a fee is required
-    vm.totalFee = 100
-
-    // wait for things to stabilize
-    await flushPromises()
+    await wrapper.setData({ totalFee: 100 })
 
     // sanity checks
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -723,7 +733,7 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
 
     // click the File & Pay button and wait for async methods to finish
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for save to complete and everything to update
 
     // verify v-tooltip text
     // FUTURE: Tool tip is outside the wrapper. Have yet to find out how to get hold of that.
@@ -751,7 +761,6 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
 
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = mount(StandaloneDirectorsFiling, {
-      sync: false,
       store,
       mocks: { $route },
       stubs: {
@@ -769,17 +778,16 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     const vm: any = wrapper.vm as any
 
     // make sure form is validated
-    vm.inFilingReview = true
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{ filingTypeCode: 'OTCDR', entityType: 'BEN' }] // dummy data
+    await wrapper.setData({
+      inFilingReview: true,
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{ filingTypeCode: 'OTCDR', entityType: 'BEN' }]) // dummy data
 
     // make sure a fee is required
-    vm.totalFee = 100
-
-    // wait for things to stabilize
-    await flushPromises()
+    await wrapper.setData({ totalFee: 100 })
 
     // sanity checks
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -840,17 +848,16 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
     const vm: any = wrapper.vm as any
 
     // make sure form is validated
-    vm.inFilingReview = true
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      inFilingReview: true,
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // make sure a fee is required
-    vm.totalFee = 100
-
-    // wait for things to stabilize
-    await flushPromises()
+    await wrapper.setData({ totalFee: 100 })
 
     // sanity check
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -865,7 +872,7 @@ describe('Standalone Directors Filing - Part 3A - Submitting filing that needs t
 
     // click the File & Pay button and wait for async methods to finish
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for save to complete and everything to update
 
     // verify v-tooltip text - To find out how to get the tool tip text outside the wrapper
     // const tooltipText = wrapper.find('#cod-file-pay-btn + span').text()
@@ -953,11 +960,13 @@ describe('Standalone Directors Filing - Part 3B - Submitting filing that doesn\'
     const vm: any = wrapper.vm as any
 
     // make sure form is validated
-    vm.inFilingReview = true
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      codDateValid: true,
+      inFilingReview: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // NB: can't find button because Vuetify hasn't rendered it
     // const button = wrapper.find('#cod-file-pay-btn')
@@ -1056,10 +1065,12 @@ describe('Standalone Directors Filing - Part 4 - Saving', () => {
       const vm = wrapper.vm as any
 
       // make sure form is validated
-      vm.codDateValid = true
-      vm.directorFormValid = true
-      vm.certifyFormValid = true
-      store.state.filingData = [{}] // dummy data
+      await wrapper.setData({
+        codDateValid: true,
+        directorFormValid: true,
+        certifyFormValid: true
+      })
+      await vm.$store.commit('filingData', [{}]) // dummy data
 
       // sanity check
       expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1096,11 +1107,13 @@ describe('Standalone Directors Filing - Part 4 - Saving', () => {
     const vm = wrapper.vm as any
 
     // make sure form is validated
-    vm.inFilingReview = true
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      inFilingReview: true,
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // sanity check
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1131,7 +1144,7 @@ describe('Standalone Directors Filing - Part 5 - Data', () => {
   let vm: any
   let spy: any
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // init store
     store.state.identifier = 'CP0001191'
     store.state.entityName = 'Legal Name - CP0001191'
@@ -1171,64 +1184,68 @@ describe('Standalone Directors Filing - Part 5 - Data', () => {
     vm = wrapper.vm
 
     // set up director data
-    vm.updatedDirectors = [
-      // unchanged director
-      {
-        officer: {
-          firstName: 'Unchanged',
-          lastName: 'lastname'
+    await wrapper.setData({
+      updatedDirectors: [
+        // unchanged director
+        {
+          officer: {
+            firstName: 'Unchanged',
+            lastName: 'lastname'
+          },
+          deliveryAddress: {
+            streetAddress: 'a1',
+            addressCity: 'city',
+            addressCountry: 'country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          },
+          appointmentDate: '2019-01-01',
+          cessationDate: null,
+          actions: []
         },
-        deliveryAddress: {
-          streetAddress: 'a1',
-          addressCity: 'city',
-          addressCountry: 'country',
-          postalCode: 'H0H0H0',
-          addressRegion: 'BC'
+        // appointed director
+        {
+          officer: {
+            firstName: 'Appointed',
+            lastName: 'lastname'
+          },
+          deliveryAddress: {
+            streetAddress: 'a1',
+            addressCity: 'city',
+            addressCountry: 'country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          },
+          appointmentDate: '2019-01-01',
+          cessationDate: null,
+          actions: ['appointed']
         },
-        appointmentDate: '2019-01-01',
-        cessationDate: null,
-        actions: []
-      },
-      // appointed director
-      {
-        officer: {
-          firstName: 'Appointed',
-          lastName: 'lastname'
-        },
-        deliveryAddress: {
-          streetAddress: 'a1',
-          addressCity: 'city',
-          addressCountry: 'country',
-          postalCode: 'H0H0H0',
-          addressRegion: 'BC'
-        },
-        appointmentDate: '2019-01-01',
-        cessationDate: null,
-        actions: ['appointed']
-      },
-      // ceased director
-      {
-        officer: {
-          firstName: 'Ceased',
-          lastName: 'lastname'
-        },
-        deliveryAddress: {
-          streetAddress: 'a1',
-          addressCity: 'city',
-          addressCountry: 'country',
-          postalCode: 'H0H0H0',
-          addressRegion: 'BC'
-        },
-        appointmentDate: '2019-01-01',
-        cessationDate: '2019-03-25',
-        actions: ['ceased']
-      }
-    ]
+        // ceased director
+        {
+          officer: {
+            firstName: 'Ceased',
+            lastName: 'lastname'
+          },
+          deliveryAddress: {
+            streetAddress: 'a1',
+            addressCity: 'city',
+            addressCountry: 'country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          },
+          appointmentDate: '2019-01-01',
+          cessationDate: '2019-03-25',
+          actions: ['ceased']
+        }
+      ]
+    })
 
     // make sure form is validated
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
 
     vm.onDirectorsPaidChange(true)
   })
@@ -1433,11 +1450,13 @@ describe('Standalone Directors Filing - Part 6 - Error/Warning Dialogs', () => {
       const vm = wrapper.vm as any
 
       // make sure form is validated
-      vm.inFilingReview = true
-      vm.codDateValid = true
-      vm.directorFormValid = true
-      vm.certifyFormValid = true
-      store.state.filingData = [{}] // dummy data
+      await wrapper.setData({
+        inFilingReview: true,
+        codDateValid: true,
+        directorFormValid: true,
+        certifyFormValid: true
+      })
+      await vm.$store.commit('filingData', [{}]) // dummy data
 
       // sanity check
       expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1468,11 +1487,13 @@ describe('Standalone Directors Filing - Part 6 - Error/Warning Dialogs', () => {
       const vm = wrapper.vm as any
 
       // make sure form is validated
-      vm.inFilingReview = true
-      vm.codDateValid = true
-      vm.directorFormValid = true
-      vm.certifyFormValid = true
-      store.state.filingData = [{}] // dummy data
+      await wrapper.setData({
+        inFilingReview: true,
+        codDateValid: true,
+        directorFormValid: true,
+        certifyFormValid: true
+      })
+      await vm.$store.commit('filingData', [{}]) // dummy data
 
       // sanity check
       expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1580,26 +1601,29 @@ describe('Standalone Directors Filing - payment required error', () => {
       },
       vuetify
     })
-
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.inFilingReview = true
-    vm.codDateValid = true
-    vm.directorFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{ filingTypeCode: 'OTCDR', entityType: 'CP' }] // dummy data
+    await wrapper.setData({
+      inFilingReview: true,
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true
+    })
+    await vm.$store.commit('filingData', [{ filingTypeCode: 'OTCDR', entityType: 'CP' }]) // dummy data
 
     // stub address data
-    vm.addresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      addresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // make sure a fee is required
-    vm.totalFee = 100
+    await wrapper.setData({ totalFee: 100 })
 
     // sanity check
     expect(vm.saveErrors).toStrictEqual([])

--- a/tests/unit/StandaloneOfficeAddressFiling.spec.ts
+++ b/tests/unit/StandaloneOfficeAddressFiling.spec.ts
@@ -26,6 +26,7 @@ Vue.use(Vuelidate)
 
 const vuetify = new Vuetify({})
 const store = getVuexStore() as any // remove typings for unit tests
+
 store.state.currentJsDate = new Date('2019-07-15T12:00:00')
 store.state.currentDate = '2019-07-15'
 
@@ -60,8 +61,8 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route } })
 
-    expect(wrapper.find(OfficeAddresses).exists()).toBe(true)
-    expect(wrapper.find(Certify).exists()).toBe(true)
+    expect(wrapper.findComponent(OfficeAddresses).exists()).toBe(true)
+    expect(wrapper.findComponent(Certify).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -71,11 +72,12 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.certifyFormValid = true
-    vm.addressesFormValid = true
-    store.state.filingData = [{}] // dummy data
-    await flushPromises()
+    // set local properties
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that flag is set correctly
     expect(vm.isPageValid).toEqual(true)
@@ -83,15 +85,17 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables Validated flag when Office Address form is invalid', () => {
+  it('disables Validated flag when Office Address form is invalid', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.certifyFormValid = true
-    vm.addressesFormValid = false
-    store.state.filingData = [{}] // dummy data
+    // set local properties
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: false
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that flag is set correctly
     expect(vm.isPageValid).toEqual(false)
@@ -99,15 +103,17 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables Validated flag when Certify form is invalid', () => {
+  it('disables Validated flag when Certify form is invalid', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.certifyFormValid = false
-    vm.addressesFormValid = true
-    store.state.filingData = [{}] // dummy data
+    // set local properties
+    await wrapper.setData({
+      certifyFormValid: false,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that flag is set correctly
     expect(vm.isPageValid).toEqual(false)
@@ -115,21 +121,23 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables Validated flag when filing data is invalid', () => {
+  it('disables Validated flag when filing data is invalid', async () => {
     const $route = { params: { filingId: 0 } } // new filing id
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route }, vuetify })
     const vm: any = wrapper.vm
 
-    // set properties
-    vm.certifyFormValid = true
-    vm.addressesFormValid = true
-    store.state.filingData = [] // no data
+    // set local properties
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', []) // no data
 
     // confirm that flag is set correctly
     expect(vm.isPageValid).toEqual(false)
   })
 
-  it('enables File & Pay button when Validated is true', () => {
+  it('enables File & Pay button when Validated is true', async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -154,9 +162,11 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     const vm: any = wrapper.vm
 
     // set all properties truthy
-    vm.certifyFormValid = true
-    vm.addressesFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // confirm that button is enabled
     expect(wrapper.find('#coa-file-pay-btn').attributes('disabled')).toBeUndefined()
@@ -164,7 +174,7 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('disables File & Pay button when Validated is false', () => {
+  it('disables File & Pay button when Validated is false', async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -189,11 +199,11 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     const vm: any = wrapper.vm
 
     // set all properties falsy
-    vm.certifyFormValid = false
-    vm.addressesFormValid = false
-
-    // set no filing data
-    store.state.filingData = []
+    await wrapper.setData({
+      certifyFormValid: false,
+      addressesFormValid: false
+    })
+    await vm.$store.commit('filingData', []) // no data
 
     // confirm that button is disabled
     expect(wrapper.find('#coa-file-pay-btn').attributes('disabled')).toBe('disabled')
@@ -201,7 +211,7 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
     wrapper.destroy()
   })
 
-  it('Verify COA Certify contains correct section codes', () => {
+  it('Verify COA Certify contains correct section codes', async () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -226,10 +236,10 @@ describe('Standalone Office Address Filing - Part 1 - UI', () => {
 
     store.state.entityType = 'BEN'
     store.state.configObject = ConfigJson.find(x => x.entityType === store.state.entityType)
+    await Vue.nextTick()
 
-    expect(wrapper.find(Certify).exists()).toBe(true)
-    const certify: any = wrapper.find(Certify)
-
+    const certify: any = wrapper.findComponent(Certify)
+    expect(certify.exists()).toBe(true)
     expect(certify.vm.message).toContain('See Sections 35 and 36 of the Business Corporations Act.')
     expect(certify.vm.entityDisplay).toEqual('Benefit Company')
 
@@ -286,7 +296,7 @@ describe('Standalone Office Address Filing - Part 2A - Resuming with FAS staff p
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route }, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // verify that Certified By was restored
     expect(vm.certifiedBy).toBe('Full Name')
@@ -359,7 +369,7 @@ describe('Standalone Office Address Filing - Part 2B - Resuming with BCOL staff 
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route }, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // verify that Certified By was restored
     expect(vm.certifiedBy).toBe('Full Name')
@@ -431,7 +441,7 @@ describe('Standalone Office Address Filing - Part 2C - Resuming with No Fee staf
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route }, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // verify that Certified By was restored
     expect(vm.certifiedBy).toBe('Full Name')
@@ -503,7 +513,7 @@ describe('Standalone Office Address Filing - Part 2D - Resuming (BCOMP)', () => 
     const $route = { params: { filingId: '123' } } // draft filing id
     const wrapper = shallowMount(StandaloneOfficeAddressFiling, { store, mocks: { $route }, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await flushPromises() // wait for draft to be fetched
 
     // verify that Certified By was restored
     expect(vm.certifiedBy).toBe('Full Name')
@@ -699,9 +709,12 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.addressesFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
+
     expect(vm.isPageValid).toEqual(true)
 
     // make sure a fee is required
@@ -717,7 +730,7 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
 
     // click the File & Pay button
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for save to complete and everything to update
 
     // verify redirection
     const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
@@ -757,9 +770,12 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.addressesFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
+
     expect(vm.isPageValid).toEqual(true)
 
     // make sure a fee is required
@@ -775,7 +791,7 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
 
     // click the File & Pay button
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for save to complete and everything to update
 
     // verify v-tooltip text
     // FUTURE: How to get the tool tip rendered outside the wrapper?
@@ -981,9 +997,12 @@ describe('Standalone Office Address Filing - Part 3B - Submitting (BCOMP)', () =
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.addressesFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
+
     expect(vm.isPageValid).toEqual(true)
 
     // make sure a fee is required
@@ -999,7 +1018,7 @@ describe('Standalone Office Address Filing - Part 3B - Submitting (BCOMP)', () =
 
     // click the File & Pay button
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for save to complete and everything to update
 
     // verify redirection
     const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
@@ -1039,9 +1058,12 @@ describe('Standalone Office Address Filing - Part 3B - Submitting (BCOMP)', () =
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.addressesFormValid = true
-    vm.certifyFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
+
     expect(vm.isPageValid).toEqual(true)
 
     // make sure a fee is required
@@ -1057,7 +1079,7 @@ describe('Standalone Office Address Filing - Part 3B - Submitting (BCOMP)', () =
 
     // click the File & Pay button
     await button.trigger('click')
-    await flushPromises() // need to wait longer here
+    await flushPromises() // wait for save to complete and everything to update
 
     // verify v-tooltip text
     // FUTURE: How to get the tool tip rendered outside the wrapper?
@@ -1152,8 +1174,10 @@ describe('Standalone Office Address Filing - Part 4 - Saving', () => {
       const vm = wrapper.vm as any
 
       // make sure form is validated
-      vm.addressesFormValid = true
-      vm.certifyFormValid = true
+      await wrapper.setData({
+        certifyFormValid: true,
+        addressesFormValid: true
+      })
 
       // sanity check
       expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1183,8 +1207,10 @@ describe('Standalone Office Address Filing - Part 4 - Saving', () => {
     const vm = wrapper.vm as any
 
     // make sure form is validated
-    vm.addressesFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
 
     // click the Save & Resume Later button
     // await wrapper.find('#coa-save-resume-btn').trigger('click')
@@ -1286,8 +1312,10 @@ describe('Standalone Office Address Filing - Part 4B - Saving (BCOMP)', () => {
       const vm = wrapper.vm as any
 
       // make sure form is validated
-      vm.addressesFormValid = true
-      vm.certifyFormValid = true
+      await wrapper.setData({
+        certifyFormValid: true,
+        addressesFormValid: true
+      })
 
       // sanity check
       expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1317,8 +1345,10 @@ describe('Standalone Office Address Filing - Part 4B - Saving (BCOMP)', () => {
     const vm = wrapper.vm as any
 
     // make sure form is validated
-    vm.addressesFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
 
     // click the Save & Resume Later button
     // await wrapper.find('#coa-save-resume-btn').trigger('click')
@@ -1680,8 +1710,10 @@ describe('Standalone Office Address Filing - Part 6 - Error/Warning Dialogs', ()
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.addressesFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
 
     // sanity check
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1729,8 +1761,10 @@ describe('Standalone Office Address Filing - Part 6 - Error/Warning Dialogs', ()
     const vm: any = wrapper.vm
 
     // make sure form is validated
-    vm.addressesFormValid = true
-    vm.certifyFormValid = true
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
 
     // sanity check
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -1843,20 +1877,24 @@ describe('Standalone Office Address Filing - payment required error', () => {
     const vm: any = wrapper.vm
 
     // set all properties truthy
-    vm.certifyFormValid = true
-    vm.addressesFormValid = true
-    store.state.filingData = [{}] // dummy data
+    await wrapper.setData({
+      certifyFormValid: true,
+      addressesFormValid: true
+    })
+    await vm.$store.commit('filingData', [{}]) // dummy data
 
     // stub address data
-    vm.updatedAddresses = {
-      registeredOffice: {
-        deliveryAddress: {},
-        mailingAddress: {}
+    await wrapper.setData({
+      updatedAddresses: {
+        registeredOffice: {
+          deliveryAddress: {},
+          mailingAddress: {}
+        }
       }
-    }
+    })
 
     // make sure a fee is required
-    vm.totalFee = 100
+    await wrapper.setData({ totalFee: 100 })
 
     // sanity check
     expect(vm.saveErrors).toStrictEqual([])

--- a/tests/unit/TodoList1.spec.ts
+++ b/tests/unit/TodoList1.spec.ts
@@ -119,7 +119,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(3)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(3)
@@ -245,7 +245,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -287,7 +287,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -329,7 +329,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -383,7 +383,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -439,7 +439,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -498,7 +498,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -513,7 +513,7 @@ describe('TodoList - UI', () => {
     expect(item.querySelector('.expand-btn').textContent).toContain('View Details')
 
     // Validate the child component does NOT exist on the parent before opening the dropdown
-    expect(wrapper.find(CorrectionComment).exists()).toBe(false)
+    expect(wrapper.findComponent(CorrectionComment).exists()).toBe(false)
 
     // click the View Details button
     await wrapper.find('.expand-btn').trigger('click')
@@ -526,7 +526,7 @@ describe('TodoList - UI', () => {
     expect(item.querySelector('.list-item__actions .v-btn')).toBeNull()
 
     // Validate the child component exists on the parent after opening the dropdown
-    expect(wrapper.find(CorrectionComment).exists()).toBe(true)
+    expect(wrapper.findComponent(CorrectionComment).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -561,7 +561,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -613,7 +613,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -628,7 +628,7 @@ describe('TodoList - UI', () => {
     expect(item.querySelector('.expand-btn').textContent).toContain('View Details')
 
     // Validate the child component does NOT exist on the parent before opening the dropdown
-    expect(wrapper.find(CorrectionComment).exists()).toBe(false)
+    expect(wrapper.findComponent(CorrectionComment).exists()).toBe(false)
 
     // click the View Details button
     await wrapper.find('.expand-btn').trigger('click')
@@ -641,7 +641,7 @@ describe('TodoList - UI', () => {
     expect(item.querySelector('.list-item__actions .v-btn')).toBeNull()
 
     // Validate the child component exists on the parent after opening the dropdown
-    expect(wrapper.find(CorrectionComment).exists()).toBe(true)
+    expect(wrapper.findComponent(CorrectionComment).exists()).toBe(true)
 
     wrapper.destroy()
   })
@@ -675,7 +675,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -693,7 +693,7 @@ describe('TodoList - UI', () => {
     await Vue.nextTick()
 
     // validate that child component exists
-    expect(wrapper.find(PaymentPending).exists()).toBe(true)
+    expect(wrapper.findComponent(PaymentPending).exists()).toBe(true)
 
     const button = item.querySelector('.list-item__actions .v-btn')
     expect(button.disabled).toBe(false)
@@ -731,7 +731,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -749,7 +749,7 @@ describe('TodoList - UI', () => {
     await Vue.nextTick()
 
     // validate that child component exists
-    expect(wrapper.find(PaymentUnsuccessful).exists()).toBe(true)
+    expect(wrapper.findComponent(PaymentUnsuccessful).exists()).toBe(true)
 
     const button = item.querySelector('.list-item__actions .v-btn')
     expect(button.disabled).toBe(false)
@@ -788,7 +788,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -806,7 +806,7 @@ describe('TodoList - UI', () => {
     await Vue.nextTick()
 
     // validate that child component exists
-    expect(wrapper.find(PaymentPendingOnlineBanking).exists()).toBe(true)
+    expect(wrapper.findComponent(PaymentPendingOnlineBanking).exists()).toBe(true)
 
     const button = item.querySelector('.list-item__actions .v-btn')
     expect(button.disabled).toBe(false)
@@ -838,7 +838,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -855,7 +855,7 @@ describe('TodoList - UI', () => {
     await Vue.nextTick()
 
     // validate that child component exists
-    expect(wrapper.find(PaymentPaid).exists()).toBe(true)
+    expect(wrapper.findComponent(PaymentPaid).exists()).toBe(true)
 
     const button = item.querySelector('.list-item__actions .v-btn')
     expect(button).toBeNull()
@@ -886,10 +886,10 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     // set the "in progress" task
-    vm.inProcessFiling = 123
+    await wrapper.setData({ inProcessFiling: 123 })
 
     const item = vm.$el.querySelector('.list-item')
     expect(item.querySelector('.list-item__title').textContent).toContain('File Director Change')
@@ -925,7 +925,7 @@ describe('TodoList - UI', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     // clear the "in progress" task
     vm.inProcessFiling = NaN
@@ -1022,7 +1022,7 @@ describe('TodoList - UI - BCOMPs', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(3)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(3)
@@ -1225,7 +1225,7 @@ describe('TodoList - UI - BCOMPs', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1273,7 +1273,7 @@ describe('TodoList - UI - BCOMPs', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1315,7 +1315,7 @@ describe('TodoList - UI - BCOMPs', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1356,10 +1356,10 @@ describe('TodoList - UI - BCOMPs', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     // set the "in progress" task
-    vm.inProcessFiling = 123
+    await wrapper.setData({ inProcessFiling: 123 })
 
     const item = vm.$el.querySelector('.list-item')
     expect(item.querySelector('.list-item__title').textContent).toContain('File Director Change')
@@ -1395,7 +1395,7 @@ describe('TodoList - UI - BCOMPs', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     // clear the "in progress" task
     vm.inProcessFiling = NaN
@@ -1443,7 +1443,7 @@ describe('TodoList - UI - Incorp Apps', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1492,7 +1492,7 @@ describe('TodoList - UI - Incorp Apps', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1540,7 +1540,7 @@ describe('TodoList - UI - Incorp Apps', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1590,7 +1590,7 @@ describe('TodoList - UI - Incorp Apps', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await Vue.nextTick()
 
     expect(vm.todoItems.length).toEqual(1)
     expect(vm.$el.querySelectorAll('.todo-item').length).toEqual(1)
@@ -1925,7 +1925,7 @@ describe('TodoList - Click Tests', () => {
 
     const wrapper = mount(TodoList, { store, vuetify })
     const vm = wrapper.vm as any
-    await flushPromises()
+    await flushPromises() // wait for pay error to finish loading
 
     // validate that todo item exists
     const todoItem = vm.$el.querySelector('.pay-error')
@@ -1938,10 +1938,10 @@ describe('TodoList - Click Tests', () => {
 
     // click the View Details button
     await wrapper.find('.expand-btn').trigger('click')
-    await flushPromises() // need to wait longer here
+    await Vue.nextTick()
 
     // validate that child component exists
-    expect(wrapper.find(PaymentIncomplete).exists()).toBe(true)
+    expect(wrapper.findComponent(PaymentIncomplete).exists()).toBe(true)
 
     // confirm the message is visible after expansion panel clicked
     const bcolPanel = vm.$el.querySelector('.payment-incomplete-details')


### PR DESCRIPTION
*Issue #:* bcgov/entity#13232

Hopefully the tests are more async now and with fewer `flushPromises` (meaning you don't really understand what it's waiting for) -- and I commented a number of them where legitimately needed.

*Description of changes:*
- upgraded vue test-utils to v1.3.3
- replaced "find()" by "findComponent()" where needed
- added "await Vue.nextTick()" where needed
- replaced some "await flushPromises()" by "await Vue.nextTick()"
- replaced some "vm.x =" by wrapper.setData() (which is async)
- replaced some "store.state.val =" by "$store.commit()" (which is async)
- moved test helpers to own files
- misc cleanup
- app version = 5.7.17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).