### PR TITLE
14306 Extend BComp logic to BC/CCC/ULC (Annual Report, etc)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.19",
+  "version": "5.7.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.7.19",
+      "version": "5.7.20",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.19",
+  "version": "5.7.20",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/AnnualReport/ARDate.vue
+++ b/src/components/AnnualReport/ARDate.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card flat class="ar-date-container" v-if="isBComp">
+  <v-card flat class="ar-date-container" v-if="isBenBcCccUlc">
     <div class="timeline">
       <label>Annual Report Date</label>
       <span class="date ar-date">{{formatYyyyMmDd(nextARDate)}}</span>
@@ -20,7 +20,7 @@ import { DateMixin } from '@/mixins'
 })
 export default class ArDate extends Vue {
   @State nextARDate!: string
-  @Getter isBComp!: boolean
+  @Getter isBenBcCccUlc!: boolean
   @Getter getCurrentDate!: string
 }
 </script>

--- a/src/components/Dashboard/AddressListSm.vue
+++ b/src/components/Dashboard/AddressListSm.vue
@@ -107,9 +107,9 @@
         </v-expansion-panel-content>
       </v-expansion-panel>
 
-      <!-- Records Office (BCOMPs and CORPs) -->
+      <!-- Records Office (BEN/BC/CCC/ULC and CORPs) -->
       <v-expansion-panel id="records-office-panel"
-        v-if="isBComp || isCorp"
+        v-if="isBenBcCccUlc || isCorp"
         class="align-items-top"
         :class="{
           'address-overlay': isCoaPending,
@@ -231,7 +231,7 @@ export default class AddressListSm extends Vue {
   /** Whether to gray out (disable) the director list. */
   @Prop({ default: false }) readonly showGrayedOut!: boolean
 
-  @Getter isBComp!: boolean
+  @Getter isBenBcCccUlc!: boolean
   @Getter isCorp!: boolean
   @Getter isFirm!: boolean
   @Getter isCoaPending!: boolean

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -75,14 +75,14 @@
                 <span class="app-blue">Record Conversion</span>
               </v-list-item-title>
             </v-list-item>
-            <template v-if="isFirm || isCoop || isBComp">
+            <template v-if="isFirm || isCoop || isBenBcCccUlc">
               <v-list-item v-if="isHistorical" @click="showPutBackOnDialog()" :disabled="!isHistorical">
                 <v-list-item-title>
                   <span class="app-blue">Put Back On</span>
                 </v-list-item-title>
               </v-list-item>
             </template>
-            <template v-if="isFirm || isCoop || isBComp">
+            <template v-if="isFirm || isCoop || isBenBcCccUlc">
               <v-list-item v-if="!isHistorical" @click="showAdministrativeDissolutionDialog()" :disabled="disabled">
                 <v-list-item-title>
                   <span class="app-blue">Administrative Dissolution</span>
@@ -129,7 +129,7 @@ export default class StaffNotation extends Vue {
   @Prop({ default: false }) readonly disabled!: boolean
 
   @Getter isFirm!: boolean
-  @Getter isBComp!: boolean
+  @Getter isBenBcCccUlc!: boolean
   @Getter isCoop!: boolean
   @Getter getIdentifier: string
   @Getter isHistorical!: boolean

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -53,10 +53,8 @@
                 </v-btn>
               </h3>
 
-              <!-- BCOMP AR special case -->
-              <div v-if="businessId && isBComp && item.enabled && isTypeAnnualReport(item) && isStatusNew(item)"
-                class="list-item__subtitle pt-4"
-              >
+              <!-- Annual Report verify checbox -->
+              <div v-if="isShowAnnualReportCheckbox(item)" class="list-item__subtitle pt-4">
                 <p>Verify your Office Address and Current Directors before filing your Annual Report.</p>
                 <v-checkbox
                   id="enable-checkbox"
@@ -64,7 +62,7 @@
                   label="All information about the Office Addresses and Current Directors is correct."
                   :disabled="!item.enabled || isCoaPending"
                   v-model="enableCheckbox[index]"
-                  @click.native.stop
+                  @click.stop
                 />
               </div>
 
@@ -101,7 +99,7 @@
                 </div>
 
                 <!-- alteration in good standing -->
-                <div v-else-if="isTypeAlteration(item) && item.goodStanding && !isBComp && !isCoop"
+                <div v-else-if="isTypeAlteration(item) && item.goodStanding && !isBenBcCccUlc && !isCoop"
                   class="todo-subtitle my-4"
                 >
                   <span>Your business is ready to alter from a {{ item.legalType }} to a BC
@@ -168,8 +166,8 @@
 
             <div class="list-item__actions">
               <div style="width:100%">
-                <!-- BCOMP AR special case -->
-                <template v-if="isBComp && item.enabled && isTypeAnnualReport(item) && isStatusNew(item)">
+                <!-- BEN/BC/CCC/ULC AR special case -->
+                <template v-if="isBenBcCccUlc && item.enabled && isTypeAnnualReport(item) && isStatusNew(item)">
                   <p class="date-subtitle">Due: {{item.arDueDate}}</p>
                 </template>
 
@@ -390,7 +388,7 @@
                     class="btn-file-now"
                     color="primary"
                     :disabled="isFileAnnualReportDisabled(item, index)"
-                    @click.native.stop="doFileNow(item)"
+                    @click.stop="doFileNow(item)"
                   >
                     <span>File Annual Report</span>
                   </v-btn>
@@ -560,6 +558,7 @@ export default class TodoList extends Vue {
   @Getter isCoaPending!: boolean
   @Getter getTodoListResource!: TodoListResourceIF
   @Getter getBusinessWarnings!: BusinessWarningIF
+  @Getter isBenBcCccUlc!: boolean
 
   @State nameRequest!: any
   @State lastAnnualReportDate!: string
@@ -634,11 +633,22 @@ export default class TodoList extends Vue {
     return this.getTodoListResource?.title
   }
 
+  /** Whether the Annual Report verify checkbox should be shown. */
+  protected isShowAnnualReportCheckbox (item: TodoItemIF): boolean {
+    return (
+      item.enabled &&
+      this.businessId &&
+      this.isBenBcCccUlc &&
+      this.isTypeAnnualReport(item) &&
+      this.isStatusNew(item)
+    )
+  }
+
   /** Whether the File Annual Report button should be disabled. */
   protected isFileAnnualReportDisabled (item: TodoItemIF, index: number): boolean {
     return (
       !item.enabled ||
-      (this.isBComp && !this.enableCheckbox[index]) ||
+      (this.isBenBcCccUlc && !this.enableCheckbox[index]) ||
       !this.isAllowed(AllowableActions.FILE_ANNUAL_REPORT)
     )
   }
@@ -775,7 +785,7 @@ export default class TodoList extends Vue {
       const ARFilingYear = header.ARFilingYear
 
       let subtitle: string = null
-      if (task.enabled && !this.isBComp) {
+      if (task.enabled && !this.isBenBcCccUlc) {
         subtitle = '(including Address and/or Director Change)'
       }
 

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -803,7 +803,7 @@ export default class TodoList extends Vue {
         status: header.status || FilingStatus.NEW,
         enabled: task.enabled,
         order: task.order,
-        nextArDate: this.apiToYyyyMmDd(business.nextAnnualReport), // BCOMP only
+        nextArDate: this.apiToYyyyMmDd(business.nextAnnualReport), // BEN/BC/CC/ULC only
         arDueDate: this.formatYyyyMmDd(header.arMaxDate)
       }
       this.todoItems.push(item)
@@ -966,7 +966,7 @@ export default class TodoList extends Vue {
 
   /**
    * Loads a DRAFT/PENDING/ERROR/PAID Annual Report filing.
-   * (Currently used for Coop ARs only, as BComps can't save draft ARs.)
+   * (Currently used for Coop ARs only, as BEN/BC/CCC/ULC can't save draft ARs.)
    */
   private async loadAnnualReport (task: ApiTaskIF): Promise<void> {
     const filing = task.task.filing
@@ -990,6 +990,7 @@ export default class TodoList extends Vue {
         status: header.status || FilingStatus.NEW,
         enabled: task.enabled,
         order: task.order,
+        nextArDate: annualReport.nextARDate, // BEN/BC/CCC/ULC only
         paymentMethod: header.paymentMethod || null,
         paymentToken: header.paymentToken || null,
         payErrorObj
@@ -1335,7 +1336,7 @@ export default class TodoList extends Vue {
         this.setARFilingYear(item.ARFilingYear)
         this.setArMinDate(item.arMinDate) // COOP only
         this.setArMaxDate(item.arMaxDate) // COOP only
-        this.setNextARDate(item.nextArDate) // BCOMP only
+        this.setNextARDate(item.nextArDate) // BEN/BC/CCC/ULC only
         this.setCurrentFilingStatus(FilingStatus.NEW)
         this.$router.push({ name: Routes.ANNUAL_REPORT, params: { filingId: '0' } }) // 0 means "new AR"
         break
@@ -1359,7 +1360,7 @@ export default class TodoList extends Vue {
         this.setARFilingYear(item.ARFilingYear)
         this.setArMinDate(item.arMinDate) // COOP only
         this.setArMaxDate(item.arMaxDate) // COOP only
-        this.setNextARDate(item.nextArDate) // BCOMP only
+        this.setNextARDate(item.nextArDate) // BEN/BC/CCC/ULC only
         this.setCurrentFilingStatus(FilingStatus.DRAFT)
         this.$router.push({ name: Routes.ANNUAL_REPORT, params: { filingId: item.filingId.toString() } })
         break

--- a/src/components/StandaloneDirectorChange/CODDate.vue
+++ b/src/components/StandaloneDirectorChange/CODDate.vue
@@ -68,7 +68,7 @@ export default class CodDate extends Vue {
   @State lastAnnualReportDate!: string
   @State entityFoundingDate!: Date
   @State lastDirectorChangeDate!: string
-  @Getter isBComp!: boolean
+  @Getter isBenBcCccUlc!: boolean
   @Getter getCurrentDate!: string
 
   // Local properties.
@@ -92,8 +92,8 @@ export default class CodDate extends Vue {
   get minDate (): string {
     let date: string = null
 
-    if (this.isBComp) {
-      // For BComps, use the last COD filing in filing history.
+    if (this.isBenBcCccUlc) {
+      // For BEN/BC/CCC/ULC, use the last COD filing in filing history.
       date = (this.lastDirectorChangeDate || this.dateToYyyyMmDd(this.entityFoundingDate))
     } else if (this.lastDirectorChangeDate || this.lastAnnualReportDate) {
       // For Coops, use the latest of the following dates:

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -87,7 +87,7 @@
                     />
                   </div>
 
-                  <div class="form__row" v-if="isBComp">
+                  <div class="form__row" v-if="isBenBcCccUlc">
                     <v-checkbox
                       class="inherit-checkbox"
                       label="Mailing Address same as Delivery Address"
@@ -182,7 +182,7 @@
         <v-subheader v-if="allDirectors.length && !directorEditInProgress" class="director-header">
           <span>Names</span>
           <span>Delivery Address</span>
-          <span v-if="isBComp">Mailing Address</span>
+          <span v-if="isBenBcCccUlc">Mailing Address</span>
           <span>Appointed/Elected</span>
         </v-subheader>
 
@@ -244,7 +244,7 @@
                     <base-address :address="dir.deliveryAddress" />
                   </div>
 
-                  <div class="address same-address" v-if="isBComp">
+                  <div class="address same-address" v-if="isBenBcCccUlc">
                     <span v-if="isSame(dir.deliveryAddress, dir.mailingAddress)">
                       Same as Delivery Address
                     </span>
@@ -379,7 +379,7 @@
                       />
                     </div>
 
-                    <div class="form__row" v-if="isBComp">
+                    <div class="form__row" v-if="isBenBcCccUlc">
                       <v-checkbox
                         class="inherit-checkbox"
                         label="Mailing Address same as Delivery Address"
@@ -584,6 +584,7 @@ export default class Directors extends Vue {
 
   @Getter getIdentifier!: string
   @Getter getCurrentDate!: string
+  @Getter isBenBcCccUlc!: boolean
   @State lastAnnualReportDate!: string
   @State entityFoundingDate!: Date
   @State lastDirectorChangeDate!: string
@@ -958,8 +959,8 @@ export default class Directors extends Vue {
       cessationDate: null // when implemented: this.newDirector.cessationDate
     }
 
-    // Add the mailing address property if the entity is a BCOMP
-    if (this.isBComp) {
+    // Add the mailing address property if the entity is a BEN/BC/CCC/ULC
+    if (this.isBenBcCccUlc) {
       director.mailingAddress = { ...this.inProgressMailAddress }
     }
 
@@ -1079,7 +1080,7 @@ export default class Directors extends Vue {
         director.deliveryAddress = this.inProgressDelivAddress
       }
 
-      if (this.isBComp) {
+      if (this.isBenBcCccUlc) {
         if (!Object.values(this.inProgressMailAddress).every(el => el === undefined)) {
           director.mailingAddress = this.inProgressMailAddress
         }

--- a/src/components/common/OfficeAddresses.vue
+++ b/src/components/common/OfficeAddresses.vue
@@ -93,7 +93,7 @@
           </div>
         </li>
 
-        <div v-if="isBComp">
+        <div v-if="isBenBcCccUlc">
           <div class="address-edit-header" v-if="showAddressForm">
             <label class="address-edit-title">Records Office</label>
             <v-checkbox
@@ -228,7 +228,7 @@ export default class OfficeAddresses extends Vue {
    */
   @Prop({ default: () => {} }) readonly addresses!: RegRecAddressesIF
 
-  @Getter isBComp!: boolean
+  @Getter isBenBcCccUlc!: boolean
   @Getter getIdentifier!: string
 
   /** Effective date for fetching office addresses. */
@@ -304,7 +304,7 @@ export default class OfficeAddresses extends Vue {
             deliveryAddress: { ...recordsOffice.deliveryAddress, actions: [] },
             mailingAddress: { ...recordsOffice.mailingAddress, actions: [] }
           }
-        } else if (this.isBComp) {
+        } else if (this.isBenBcCccUlc) {
           throw new Error('Missing records office address')
         }
       }).catch(error => {
@@ -357,7 +357,7 @@ export default class OfficeAddresses extends Vue {
     this.inheritDeliveryAddress =
       this.isSame(this.deliveryAddress, this.mailingAddress, ['addressType'])
 
-    if (this.isBComp) {
+    if (this.isBenBcCccUlc) {
       this.recDeliveryAddress = { ...addresses?.recordsOffice?.deliveryAddress }
       this.recMailingAddress = { ...addresses?.recordsOffice?.mailingAddress }
 
@@ -406,7 +406,7 @@ export default class OfficeAddresses extends Vue {
       // inherit the registered delivery address
       this.mailingAddress = { ...this.deliveryAddress, addressType: 'mailing' }
     }
-    if (this.isBComp) {
+    if (this.isBenBcCccUlc) {
       if (this.inheritRecDeliveryAddress) {
         // inherit the records delivery address
         this.recMailingAddress = { ...this.recDeliveryAddress, addressType: 'mailing' }
@@ -455,7 +455,7 @@ export default class OfficeAddresses extends Vue {
   /** Emits original addresses object to the parent page. */
   @Emit('original')
   private emitOriginalAddresses (): RegRecAddressesIF {
-    if (this.isBComp) {
+    if (this.isBenBcCccUlc) {
       return {
         registeredOffice: this.original.registeredOffice,
         recordsOffice: this.original.recordsOffice
@@ -487,7 +487,7 @@ export default class OfficeAddresses extends Vue {
         ? this.removeAction(mailingAddress, Actions.ADDRESSCHANGED)
         : this.addAction(mailingAddress, Actions.ADDRESSCHANGED)
 
-      if (this.isBComp) {
+      if (this.isBenBcCccUlc) {
         // update records delivery action
         this.isSame(this.recDeliveryAddress, this.original?.recordsOffice?.deliveryAddress)
           ? this.removeAction(recDeliveryAddress, Actions.ADDRESSCHANGED)

--- a/src/components/common/SummaryDirectors.vue
+++ b/src/components/common/SummaryDirectors.vue
@@ -6,7 +6,7 @@
         <v-subheader class="director-header">
           <span>Names</span>
           <span>Delivery Address</span>
-          <span v-if="isBComp">Mailing Address</span>
+          <span v-if="isBenBcCccUlc">Mailing Address</span>
           <span class="header-appointed">Appointed/Elected</span>
         </v-subheader>
 
@@ -67,7 +67,7 @@
                     <base-address :address="director.deliveryAddress" />
                   </div>
 
-                  <div class="address same-address" v-if="isBComp">
+                  <div class="address same-address" v-if="isBenBcCccUlc">
                     <span v-if="isSame(director.deliveryAddress, director.mailingAddress)">
                       Same as Delivery Address
                     </span>
@@ -153,7 +153,7 @@
                     <div class="address">
                       <base-address :address="director.deliveryAddress" />
                     </div>
-                    <div class="address same-address" v-if="isBComp">
+                    <div class="address same-address" v-if="isBenBcCccUlc">
                       <span v-if="isSame(director.deliveryAddress, director.mailingAddress)">
                         Same as Delivery Address
                       </span>
@@ -195,7 +195,7 @@ export default class SummaryDirectors extends Vue {
   // Directors array passed into this component.
   @Prop({ default: () => [] }) readonly directors!: Array<DirectorIF>
 
-  @Getter isBComp!: boolean
+  @Getter isBenBcCccUlc!: boolean
 
   // Local properties
   protected directorSummary: Array<DirectorIF> = []

--- a/src/interfaces/history-item-interface.ts
+++ b/src/interfaces/history-item-interface.ts
@@ -40,8 +40,8 @@ export interface HistoryItemIF {
   // Registrations only
   isCompletedRegistration?: boolean
 
-  // BCOMP COAs only
-  isFutureEffectiveBcompCoaPending?: boolean
+  // BEN/BC/CCC/ULC COAs only
+  isFutureEffectiveCoaPending?: boolean
 
   // alterations only
   courtOrderNumber?: string

--- a/src/mixins/allowable-actions-mixin.ts
+++ b/src/mixins/allowable-actions-mixin.ts
@@ -10,16 +10,13 @@ export default class AllowableActionsMixin extends Vue {
   @Getter hasBlocker!: boolean
   @Getter hasBlockerExceptStaffApproval!: boolean
   @Getter isBComp!: boolean
-  @Getter isBcCompany!: boolean
-  @Getter isCcc!: boolean
+  @Getter isBenBcCccUlc!: boolean
   @Getter isCoop!: boolean
-  @Getter isFirm!: boolean
   @Getter isGoodStanding!: boolean
   @Getter isHistorical!: boolean
   @Getter isPartnership!: boolean
   @Getter isRoleStaff!: boolean
   @Getter isSoleProp!: boolean
-  @Getter isUlc!: boolean
 
   /**
    * Returns True if the specified action is allowed, else False.
@@ -83,13 +80,10 @@ export default class AllowableActionsMixin extends Vue {
 
       case AllowableActions.VIEW_CHANGE_COMPANY_INFO: {
         const isAllowedEntityType = (
-          this.isBComp ||
-          this.isBcCompany ||
-          this.isCcc ||
+          this.isBenBcCccUlc ||
           (this.isCoop && !!getFeatureFlag('special-resolution-ui-enabled')) ||
           this.isPartnership ||
-          this.isSoleProp ||
-          this.isUlc
+          this.isSoleProp
         )
         return (!this.isHistorical && !!businessId && isAllowedEntityType)
       }

--- a/src/mixins/resource-lookup-mixin.ts
+++ b/src/mixins/resource-lookup-mixin.ts
@@ -10,7 +10,7 @@ import { FilingCodes } from '@/enums'
 @Component({})
 export default class ResourceLookupMixin extends Vue {
     @State configObject!: any
-    @Getter isBComp!: boolean
+    @Getter isBenBcCccUlc!: boolean
 
     /**
      * Returns certify message using the configuration lookup object.
@@ -40,7 +40,7 @@ export default class ResourceLookupMixin extends Vue {
      * @returns the compliance message or null (if the configuration has been loaded)
      */
     directorWarning (directors: Array<any>): AlertMessageIF {
-      const filingCode = this.isBComp ? FilingCodes.DIRECTOR_CHANGE_BC : FilingCodes.DIRECTOR_CHANGE_OT
+      const filingCode = this.isBenBcCccUlc ? FilingCodes.DIRECTOR_CHANGE_BC : FilingCodes.DIRECTOR_CHANGE_OT
       // FUTURE: Too much code for this. Can be condensed and made more reusable.
       if (directors?.length) {
         const warnings = this.configObject?.flows?.find(x => x.feeCode === filingCode)?.warnings

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -132,6 +132,12 @@ export default {
     return (state.entityType === CorpTypeCd.BC_ULC_COMPANY)
   },
 
+  /** Is True if entity is a BEN/BC/CCC/ULC. */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  isBenBcCccUlc (state: StateIF, getters: any): boolean {
+    return (getters.isBComp || getters.isBcCompany || getters.isCcc || getters.isUlc)
+  },
+
   /** Is True if Staff role is set. */
   isRoleStaff (state: StateIF): boolean {
     return state.keycloakRoles.includes('staff')

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -1009,7 +1009,7 @@ export default class AnnualReport extends Vue {
       annualReport = {
         annualReport: {
           annualReportDate: this.asOfDate,
-          nextARDate: this.nextARDate, // used by BCOMP only
+          nextARDate: this.nextARDate, // used by BEN/BC/CCC/ULC only
           // NB: there was an enrichment ticket to populate offices and directors here
           offices: {
             registeredOffice: this.originalAddresses.registeredOffice,

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -189,7 +189,7 @@ import { ConfirmDialog, LoadCorrectionDialog, PaymentErrorDialog, ResumeErrorDia
 import { CommonMixin, DateMixin, EnumMixin, FilingMixin, LegalApiMixin, ResourceLookupMixin } from '@/mixins'
 import { FilingCodes, FilingStatus, FilingTypes, Routes, SaveErrorReasons,
   StaffPaymentOptions } from '@/enums'
-import { ConfirmDialogType, StaffPaymentIF } from '@/interfaces'
+import { ConfirmDialogType, FilingDataIF, StaffPaymentIF } from '@/interfaces'
 
 @Component({
   components: {
@@ -219,6 +219,7 @@ export default class Correction extends Vue {
   }
 
   @State entityFoundingDate!: Date
+  @State filingData!: Array<FilingDataIF>
 
   @Getter isRoleStaff!: boolean
   @Getter getEntityName!: string

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -138,7 +138,7 @@
             </section>
 
             <!-- Proprietor / Partners -->
-            <section v-if="isSoleProp || isPartnership">
+            <section v-else-if="isSoleProp || isPartnership">
               <header class="aside-header mb-3">
                 <h2 v-if="isSoleProp" data-test-id="dashboard-proprietor-subtitle">Proprietor</h2>
                 <h2 v-if="isPartnership" data-test-id="dashboard-partners-subtitle">Partners</h2>
@@ -223,7 +223,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['isBComp', 'isHistorical', 'isRoleStaff', 'isCoaPending', 'getCoaEffectiveDate',
+    ...mapGetters(['isBenBcCccUlc', 'isHistorical', 'isRoleStaff', 'isCoaPending', 'getCoaEffectiveDate',
       'isAppTask', 'isAppFiling', 'getParties', 'isFirm', 'isSoleProp', 'isPartnership', 'getIdentifier',
       'hasMissingInfoWarning', 'hasComplianceWarning']),
 
@@ -302,7 +302,7 @@ export default {
       if (this.isFirm) {
         const url = `${this.editUrl}${this.getIdentifier}/change`
         navigate(url)
-      } else if (this.isBComp) {
+      } else if (this.isBenBcCccUlc) {
         this.toggleCoaWarning()
       } else {
         this.goToStandaloneAddresses()

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -81,7 +81,7 @@
                       one for each unique date.</p>
 
                   <v-alert type="info" outlined
-                    v-if="!isBComp"
+                    v-if="!isBenBcCccUlc"
                     icon="mdi-information"
                     class="white-background"
                   >
@@ -342,9 +342,11 @@ export default class StandaloneDirectorsFiling extends Vue {
   }
 
   @State entityFoundingDate!: Date
+  @State filingData!: Array<FilingDataIF>
 
   @Getter isRoleStaff!: boolean
   @Getter getEntityName!: string
+  @Getter isBenBcCccUlc!: boolean
 
   // variables
   private updatedDirectors = []
@@ -428,12 +430,12 @@ export default class StandaloneDirectorsFiling extends Vue {
 
   /** The Director Change fee code based on entity type. */
   get feeCode (): FilingCodes {
-    return this.isBComp ? FilingCodes.DIRECTOR_CHANGE_BC : FilingCodes.DIRECTOR_CHANGE_OT
+    return this.isBenBcCccUlc ? FilingCodes.DIRECTOR_CHANGE_BC : FilingCodes.DIRECTOR_CHANGE_OT
   }
 
   /** The Free Director Change fee code based on entity type. */
   get freeFeeCode (): FilingCodes {
-    return this.isBComp ? FilingCodes.FREE_DIRECTOR_CHANGE_BC : FilingCodes.FREE_DIRECTOR_CHANGE_OT
+    return this.isBenBcCccUlc ? FilingCodes.FREE_DIRECTOR_CHANGE_BC : FilingCodes.FREE_DIRECTOR_CHANGE_OT
   }
 
   /** Called when component is created. */

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -75,13 +75,11 @@
             <header>
               <h1 id="address-change-header">Address Change</h1>
 
-              <p>
-                <span v-if="isCoop">Please change your Registered Office Address.</span>
-                <span v-if="isBComp">Please change your Registered Office Address and Records Address.</span>
-              </p>
+              <p v-if="isCoop">Please change your Registered Office Address.</p>
+              <p v-else-if="isBenBcCccUlc">Please change your Registered Office Address and Records Address.</p>
 
               <v-alert type="info" outlined
-                v-if="isBComp"
+                v-if="isBenBcCccUlc"
                 icon="mdi-information"
                 class="white-background"
               >
@@ -203,7 +201,7 @@ import { ConfirmDialog, FetchErrorDialog, PaymentErrorDialog, ResumeErrorDialog,
   StaffPaymentDialog } from '@/components/dialogs'
 import { CommonMixin, DateMixin, FilingMixin, LegalApiMixin, ResourceLookupMixin } from '@/mixins'
 import { FilingCodes, FilingTypes, Routes, SaveErrorReasons, StaffPaymentOptions } from '@/enums'
-import { ConfirmDialogType, StaffPaymentIF } from '@/interfaces'
+import { ConfirmDialogType, FilingDataIF, StaffPaymentIF } from '@/interfaces'
 
 @Component({
   components: {
@@ -233,8 +231,10 @@ export default class StandaloneOfficeAddressFiling extends Vue {
   }
 
   @State entityFoundingDate!: Date
+  @State filingData!: Array<FilingDataIF>
 
   @Getter isCoop!: boolean
+  @Getter isBenBcCccUlc!: boolean
   @Getter isRoleStaff!: boolean
   @Getter getEntityName!: string
 
@@ -312,7 +312,7 @@ export default class StandaloneOfficeAddressFiling extends Vue {
 
   /** Local computed value for the fee code based on entity type */
   get feeCode (): FilingCodes {
-    return this.isBComp ? FilingCodes.ADDRESS_CHANGE_BC : FilingCodes.ADDRESS_CHANGE_OT
+    return this.isBenBcCccUlc ? FilingCodes.ADDRESS_CHANGE_BC : FilingCodes.ADDRESS_CHANGE_OT
   }
 
   /** Called when component is created. */
@@ -432,9 +432,9 @@ export default class StandaloneOfficeAddressFiling extends Vue {
         // records office is required for BCOMP only
         const registeredOffice = changeOfAddress.offices?.registeredOffice
         const recordsOffice = changeOfAddress.offices?.recordsOffice
-        if (this.isBComp && registeredOffice && recordsOffice) {
+        if (this.isBenBcCccUlc && registeredOffice && recordsOffice) {
           this.updatedAddresses = { registeredOffice, recordsOffice }
-        } else if (!this.isBComp && registeredOffice) {
+        } else if (!this.isBenBcCccUlc && registeredOffice) {
           this.updatedAddresses = { registeredOffice }
         } else {
           throw new Error('Invalid change of address object')

--- a/tests/unit/FilingHistoryList2.spec.ts
+++ b/tests/unit/FilingHistoryList2.spec.ts
@@ -111,7 +111,7 @@ filings.forEach((filing: any, index: number) => {
       expect(vm.historyItems.length).toBe(1) // sanity check
       const item = vm.historyItems[0]
 
-      expect(item.isFutureEffectiveBcompCoaPending).toBeDefined()
+      expect(item.isFutureEffectiveCoaPending).toBeDefined()
     })
 
     itIf(isAlteration(filing))('alteration filing', () => {
@@ -156,7 +156,7 @@ filings.forEach((filing: any, index: number) => {
         } else {
           expect(wrapper.find('.item-header__subtitle').text()).toContain('Filed by Registry Staff on')
         }
-      } else if (item.isFutureEffectiveBcompCoaPending) {
+      } else if (item.isFutureEffectiveCoaPending) {
         expect(wrapper.find('.item-header__subtitle').text()).toContain('FILED AND PENDING')
         expect(wrapper.find('.item-header__subtitle').text()).not.toContain('PAID')
         expect(wrapper.find('.item-header__subtitle').text()).toContain('(filed by Registry Staff on')
@@ -234,7 +234,7 @@ filings.forEach((filing: any, index: number) => {
 
       if (item.isTypeStaff) {
         expect(wrapper.findComponent(StaffFiling).exists()).toBe(true)
-      } else if (item.isFutureEffectiveBcompCoaPending) {
+      } else if (item.isFutureEffectiveCoaPending) {
         // no details
       } else if (item.isCompletedIa) {
         expect(wrapper.findComponent(CompletedIa).exists()).toBe(true)


### PR DESCRIPTION
*Issue #:* bcgov/entity#14306 + bcgov/entity#14322 + bcgov/entity#14343

*Description of changes:*
- replaced most isBComp with isBenBcCccUlc to extend functionality to new entity types
- renamed isFutureEffectiveBcompCoaPending -> isFutureEffectiveCoaPending
- show AR checkbox for new entity types
- added method to simplify template logic
- updated method to disable File button for new entity types
- added isBenBcCccUlc getter
- updated unit tests
- app version = 5.7.20
- added missing todo item field for a resumed BEN/BC/CCC/ULC annual report

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).