### PR TITLE
14350 Redirect alteration corrections to the Edit UI instead of handling locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.24",
+  "version": "5.7.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.7.24",
+      "version": "5.7.25",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.7.24",
+  "version": "5.7.25",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -707,6 +707,7 @@ export default class FilingHistoryList extends Vue {
   protected async correctThisFiling (item: HistoryItemIF): Promise<void> {
     // see also TodoList.vue:doResumeFiling()
     switch (item?.name) {
+      case FilingTypes.ALTERATION:
       case FilingTypes.INCORPORATION_APPLICATION:
       case FilingTypes.CHANGE_OF_REGISTRATION:
       case FilingTypes.CORRECTION:
@@ -717,7 +718,6 @@ export default class FilingHistoryList extends Vue {
         break
 
       case FilingTypes.ANNUAL_REPORT:
-      case FilingTypes.ALTERATION:
       case FilingTypes.CHANGE_OF_ADDRESS:
       case FilingTypes.CHANGE_OF_DIRECTORS:
       case FilingTypes.CONVERSION:

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1383,6 +1383,7 @@ export default class TodoList extends Vue {
       case FilingTypes.CORRECTION:
         // see also FilingHistoryList.vue:correctThisFiling()
         switch (item.correctedFilingType) {
+          case FilingTypes.ALTERATION:
           case FilingNames.INCORPORATION_APPLICATION:
           case FilingNames.CHANGE_OF_REGISTRATION:
           case FilingNames.CORRECTION:
@@ -1393,7 +1394,6 @@ export default class TodoList extends Vue {
             break
 
           case FilingTypes.ANNUAL_REPORT:
-          case FilingTypes.ALTERATION:
           case FilingTypes.CHANGE_OF_ADDRESS:
           case FilingTypes.CHANGE_OF_DIRECTORS:
           case FilingTypes.CONVERSION:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14530

*Description of changes:*
 - App version -> 5.7.25
 - Alteration corrections redirect to edit ui

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
