### PR TITLE
14965 Fixed register notation disabled for SP/GP filling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.9.7",
+  "version": "5.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.9.7",
+      "version": "5.9.8",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.9.7",
+  "version": "5.9.8",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -66,7 +66,7 @@
             <v-list-item
               data-type="registrars-notation"
               @click="showRegistrarsNotationDialog()"
-              disabled="disabled"
+              :disabled="disabled"
             >
               <v-list-item-title>
                 <span class="app-blue">Add Registrar's Notation</span>


### PR DESCRIPTION
Issue #: /bcgov/entity#14965

Description of changes:

Fixed the ability to file register notation for sp/gp filling

![Screenshot (17)](https://user-images.githubusercontent.com/122301442/213571388-c86a5b03-169d-4331-bb61-2383b21843d7.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
