### PR TITLE
14965 Fixed register notation disabled for SP/GP filling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.9.3",
+  "version": "5.9.3a",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.9.3",
+      "version": "5.9.3a",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.9.3",
+  "version": "5.9.3a",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -58,7 +58,7 @@
             <v-list-item
               data-type="registrars-notation"
               @click="showRegistrarsNotationDialog()"
-              disabled="disabled"
+              :disabled="disabled"
             >
               <v-list-item-title>
                 <span class="app-blue">Add Registrar's Notation</span>


### PR DESCRIPTION
(cherry picked from commit https://github.com/bcgov/business-filings-ui/commit/0009f0945c3155df98153815d6e4b2579ce56e01)

*Issue #:* bcgov/entity#14965

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
