### PR TITLE
14808 - show full and limited restorations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.9.9",
+  "version": "5.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.9.9",
+      "version": "5.9.10",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.9.9",
+  "version": "5.9.10",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -86,8 +86,9 @@
                 <!-- or a completed Alteration? -->
                 <!-- or a completed Dissolution? -->
                 <!-- or a completed Registration? -->
+                <!-- or a limited Restoration? -->
                 <div v-else-if="filing.isCompletedIa || filing.isCompletedAlteration || filing.isCompletedDissolution ||
-                  filing.isCompletedRegistration" class="item-header__subtitle"
+                  filing.isCompletedRegistration || filing.isTypeLimitedRestoration" class="item-header__subtitle"
                 >
                   <span>FILED AND PAID <FiledLabel :filing="filing" /></span>
                   <v-btn
@@ -300,6 +301,11 @@
               <FutureEffective :filing=filing class="mt-6" />
             </template>
 
+            <template v-else-if="filing.isTypeLimitedRestoration"
+            >
+              <LimitedRestorationFiling :filing="filing" class="mt-6" />
+            </template>
+
             <!-- is this a generic paid (not yet completed) filing? -->
             <template v-else-if="isStatusPaid(filing)">
               <PendingFiling :filing=filing class="mt-6" />
@@ -381,9 +387,11 @@ import { ActionBindingIF, ApiFilingIF, CorrectionFilingIF, DocumentIF, HistoryIt
   from '@/interfaces'
 import { AllowableActionsMixin, DateMixin, EnumMixin, FilingMixin } from '@/mixins'
 import { LegalServices } from '@/services/'
+import LimitedRestorationFiling from '@/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue'
 
 @Component({
   components: {
+    LimitedRestorationFiling,
     // sub-components
     CompletedAlteration,
     CompletedDissolution,
@@ -650,6 +658,13 @@ export default class FilingHistoryList extends Vue {
         item.putBackOnOrAdminDissolution = this.isTypePutBackOn({ name: filing.name }) ||
           this.isTypeAdministrativeDissolution({ name: filing.name,
             dissolutionType: filing?.data?.dissolution?.dissolutionType })
+      }
+
+      // add properties for limited restorations
+      if (this.isTypeLimitedRestoration(filing)) {
+        item.isTypeLimitedRestoration = true
+        item.legalName = filing?.data?.restoration?.legalName
+        item.expiryDate = filing?.data?.restoration?.expiryDate
       }
 
       this.historyItems.push(item)

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -664,7 +664,7 @@ export default class FilingHistoryList extends Vue {
       if (this.isTypeLimitedRestoration(filing)) {
         item.isTypeLimitedRestoration = true
         item.legalName = filing.data.restoration?.legalName
-        item.expiryDate = filing.data.restoration?.expiryDate
+        item.expiry = filing.data.restoration?.expiry
       }
 
       this.historyItems.push(item)

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -378,6 +378,7 @@ import DocumentsList from './FilingHistoryList/DocumentsList.vue'
 import FiledLabel from './FilingHistoryList/FiledLabel.vue'
 import FutureEffective from './FilingHistoryList/FutureEffective.vue'
 import FutureEffectivePending from './FilingHistoryList/FutureEffectivePending.vue'
+import LimitedRestorationFiling from '@/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue'
 import PaperFiling from './FilingHistoryList/PaperFiling.vue'
 import PendingFiling from './FilingHistoryList/PendingFiling.vue'
 import StaffFiling from './FilingHistoryList/StaffFiling.vue'
@@ -387,11 +388,9 @@ import { ActionBindingIF, ApiFilingIF, CorrectionFilingIF, DocumentIF, HistoryIt
   from '@/interfaces'
 import { AllowableActionsMixin, DateMixin, EnumMixin, FilingMixin } from '@/mixins'
 import { LegalServices } from '@/services/'
-import LimitedRestorationFiling from '@/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue'
 
 @Component({
   components: {
-    LimitedRestorationFiling,
     // sub-components
     CompletedAlteration,
     CompletedDissolution,
@@ -402,6 +401,7 @@ import LimitedRestorationFiling from '@/components/Dashboard/FilingHistoryList/L
     FiledLabel,
     FutureEffective,
     FutureEffectivePending,
+    LimitedRestorationFiling,
     PaperFiling,
     PendingFiling,
     StaffFiling,
@@ -663,8 +663,8 @@ export default class FilingHistoryList extends Vue {
       // add properties for limited restorations
       if (this.isTypeLimitedRestoration(filing)) {
         item.isTypeLimitedRestoration = true
-        item.legalName = filing?.data?.restoration?.legalName
-        item.expiryDate = filing?.data?.restoration?.expiryDate
+        item.legalName = filing.data.restoration?.legalName
+        item.expiryDate = filing.data.restoration?.expiryDate
       }
 
       this.historyItems.push(item)

--- a/src/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue
@@ -31,7 +31,7 @@ export default class LimitedRestorationFiling extends Vue {
 
   /** The expiry datetime of the limited restoration filing. */
   get expiryDateFriendly (): string {
-    return (this.formatYyyyMmDd(this.filing.expiryDate) || 'Unknown')
+    return (this.formatYyyyMmDd(this.filing.expiry) || 'Unknown')
   }
 }
 

--- a/src/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue
@@ -1,0 +1,47 @@
+<template>
+  <div v-if="filing">
+    <h4>Limited Restoration Period</h4>
+
+    <p class="limited-restoration-period">
+      The Company <strong>{{ filing.legalName }}</strong> was successfully
+      restored and active <strong>until {{ expiryDateFriendly }}</strong>
+      At the end of the limited restoration period, the company will be automatically dissolved.
+      If you require assistance to extend a limited restoration/reinstatement or wish to convert
+      your restoration from a limited period to a full restoration, please contact BC Registries staff:
+    </p>
+
+    <ContactInfo class="mt-4" />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+import { HistoryItemIF } from '@/interfaces'
+import { ContactInfo } from '@/components/common'
+import { DateMixin } from '@/mixins'
+
+@Component({
+  components: { ContactInfo },
+  mixins: [DateMixin]
+})
+export default class LimitedRestorationFiling extends Vue {
+  /** The subject filing. */
+  @Prop({ required: true }) readonly filing!: HistoryItemIF
+
+  /** The expiry datetime of the limited restoration filing. */
+  get expiryDateFriendly (): string {
+    return (this.formatYyyyMmDd(this.filing.expiryDate) || 'Unknown')
+  }
+}
+
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/styles/theme.scss';
+
+.limited-restoration-period {
+  color: dimgrey;
+  font-size: $px-15;
+}
+</style>

--- a/src/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue
@@ -4,7 +4,7 @@
 
     <p class="limited-restoration-period .font-15">
       The Company <strong>{{ filing.legalName }}</strong> was successfully
-      restored and active <strong>until {{ expiryDateFriendly }}</strong>.
+      restored and is active <strong>until {{ expiryDateFriendly }}</strong>.
       At the end of the limited restoration period, the company will be automatically dissolved.
       If you require assistance to extend a limited restoration/reinstatement or wish to convert
       your restoration from a limited period to a full restoration, please contact BC Registries staff:

--- a/src/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/LimitedRestorationFiling.vue
@@ -2,9 +2,9 @@
   <div v-if="filing">
     <h4>Limited Restoration Period</h4>
 
-    <p class="limited-restoration-period">
+    <p class="limited-restoration-period .font-15">
       The Company <strong>{{ filing.legalName }}</strong> was successfully
-      restored and active <strong>until {{ expiryDateFriendly }}</strong>
+      restored and active <strong>until {{ expiryDateFriendly }}</strong>.
       At the end of the limited restoration period, the company will be automatically dissolved.
       If you require assistance to extend a limited restoration/reinstatement or wish to convert
       your restoration from a limited period to a full restoration, please contact BC Registries staff:
@@ -41,7 +41,6 @@ export default class LimitedRestorationFiling extends Vue {
 @import '@/assets/styles/theme.scss';
 
 .limited-restoration-period {
-  color: dimgrey;
-  font-size: $px-15;
+  color: $gray7
 }
 </style>

--- a/src/interfaces/history-item-interface.ts
+++ b/src/interfaces/history-item-interface.ts
@@ -67,6 +67,6 @@ export interface HistoryItemIF {
 
   // limited restorations
   isTypeLimitedRestoration?: boolean
-  expiryDate?: Date
+  expiry?: Date
   legalName?: string
 }

--- a/src/interfaces/history-item-interface.ts
+++ b/src/interfaces/history-item-interface.ts
@@ -64,4 +64,9 @@ export interface HistoryItemIF {
   notationOrOrder?: string
   planOfArrangement?: string
   putBackOnOrAdminDissolution?: boolean
+
+  // limited restorations
+  isTypeLimitedRestoration?: boolean
+  expiryDate?: Date
+  legalName?: string
 }

--- a/src/mixins/enum-mixin.ts
+++ b/src/mixins/enum-mixin.ts
@@ -178,7 +178,7 @@ export default class EnumMixin extends Vue {
 
   /** Returns True if filing is a Limited Restoration. */
   isTypeLimitedRestoration (item: any): boolean {
-    return (item.name === FilingTypes.RESTORATION && item.data?.restoration?.type === 'limitedRestoration')
+    return (item.name === FilingTypes.RESTORATION && item.data?.restoration?.type === RestorationTypes.LIMITED)
   }
 
   /** Returns True if filing is a Staff Only filing. */

--- a/src/mixins/enum-mixin.ts
+++ b/src/mixins/enum-mixin.ts
@@ -176,6 +176,11 @@ export default class EnumMixin extends Vue {
     return (item.name === FilingTypes.SPECIAL_RESOLUTION)
   }
 
+  /** Returns True if filing is a Limited Restoration. */
+  isTypeLimitedRestoration (item: any): boolean {
+    return (item.name === FilingTypes.RESTORATION && item.data?.restoration?.type === 'limitedRestoration')
+  }
+
   /** Returns True if filing is a Staff Only filing. */
   isTypeStaff (item: any): boolean {
     const staffType = [

--- a/tests/unit/FilingHistoryList1.spec.ts
+++ b/tests/unit/FilingHistoryList1.spec.ts
@@ -379,7 +379,7 @@ describe('Filing History List - misc functionality', () => {
           restoration: {
             date: '2021-01-01',
             type: 'limitedRestoration',
-            expiryDate: '2021-04-01',
+            expiry: '2021-04-01',
             legalName: 'BC1234567 LTD.'
           }
         }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14808

Add limited restoration component to the dashboard's filing history.  Confirm that full restoration display correctly.

![image](https://user-images.githubusercontent.com/25233684/214963141-61b514f3-faf2-4c96-b109-ebbd880c7881.png)

![image](https://user-images.githubusercontent.com/25233684/214963195-466c4899-1464-48b0-a513-8549939606b3.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
