### PR TITLE
15042 Added Consent to Continuation Out to dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.9.11",
+  "version": "5.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.9.11",
+      "version": "5.10.0",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.9.11",
+  "version": "5.10.0",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -318,7 +318,9 @@
 
             <!-- is this a consent to continuation out filing? -->
             <template v-else-if="isTypeConsentContinuationOut(filing)">
-              <p class="mt-4">This consent is valid <strong>until {{filing.expiry}}</strong>.</p>
+              <p class="mt-4">
+                This consent is valid <strong>until {{filing.expiry}} at 12:01 am Pacific time</strong>.
+              </p>
               <p class="mt-4">{{filing.comment}}</p>
             </template>
 
@@ -652,8 +654,9 @@ export default class FilingHistoryList extends Vue {
 
       // add properties for Consent to Continuation Outs
       if (this.isTypeConsentContinuationOut(filing)) {
-        item.expiry = this.apiToPacificDateTime(filing.data.consentContinuationOut?.expiry)
-        item.comment = filing.data.consentContinuationOut?.comment
+        // FUTURE: expiry date may come from business object
+        item.expiry = filing.data.consentContinuationOut?.expiry
+        item.details = filing.data.consentContinuationOut?.orderDetails
       }
 
       // add properties for staff filings
@@ -662,9 +665,9 @@ export default class FilingHistoryList extends Vue {
         if (!this.isTypeCourtOrder(filing)) {
           item.documents = [] // no documents
         }
-        item.fileNumber = filing.data.order?.fileNumber || '' // may be falsy
+        item.fileNumber = filing.data.order?.fileNumber || '' // may be absent
         item.isTypeStaff = true
-        item.notationOrOrder = filing.data.order?.orderDetails // should not be falsy
+        item.details = filing.data.order?.orderDetails // should always be present
         item.planOfArrangement = filing.data.order?.effectOfOrder ? 'Pursuant to a Plan of Arrangement' : ''
         item.putBackOnOrAdminDissolution = this.isTypePutBackOn({ name: filing.name }) ||
           this.isTypeAdministrativeDissolution({ name: filing.name,

--- a/src/components/Dashboard/FilingHistoryList/StaffFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/StaffFiling.vue
@@ -1,21 +1,24 @@
 <template>
   <div v-if="filing" class="staff-filing-details body-2">
-    <p>{{filing.notationOrOrder}}</p>
+    <p v-if="filing.notationOrOrder" class="mt-4">
+      {{filing.notationOrOrder}}
+    </p>
 
-    <template v-if="filing.documents && filing.documents.length > 0">
-      <DocumentsList
-        :filing=filing
-        :loadingOne=loadingOne
-        :loadingAll=loadingAll
-        :loadingOneIndex=loadingOneIndex
-        @downloadOne="downloadOne(...arguments)"
-        @downloadAll="downloadAll($event)"
-      />
-   </template>
+    <!-- Documents list may be displayed here or in Filing History List. -->
+    <DocumentsList
+      v-if="showDocumentsList && filing.documents && filing.documents.length > 0"
+      :filing=filing
+      @downloadOne="downloadOne(...arguments)"
+      @downloadAll="downloadAll($event)"
+    />
 
-    <p class="mb-0" v-if="filing.fileNumber">Court Order Number: {{filing.fileNumber}}</p>
+    <p v-if="filing.fileNumber" class="mt-4 mb-0">
+      Court Order Number: {{filing.fileNumber}}
+    </p>
 
-    <p class="mt-0" v-if="filing.planOfArrangement">{{filing.planOfArrangement}}</p>
+    <p v-if="filing.planOfArrangement" class="mt-0">
+      {{filing.planOfArrangement}}
+    </p>
   </div>
 </template>
 
@@ -23,7 +26,6 @@
 import Vue from 'vue'
 import { Component, Emit, Prop } from 'vue-property-decorator'
 import { HistoryItemIF } from '@/interfaces'
-import { Getter } from 'vuex-class'
 import DocumentsList from '@/components/Dashboard/FilingHistoryList/DocumentsList.vue'
 
 @Component({
@@ -35,13 +37,7 @@ export default class StaffFiling extends Vue {
   /** The subject filing. */
   @Prop({ required: true }) readonly filing!: HistoryItemIF
 
-  @Prop({ default: false }) readonly loadingOne!: boolean
-
-  @Prop({ default: false }) readonly loadingAll!: boolean
-
-  @Prop({ default: -1 }) readonly loadingOneIndex!: number
-
-  @Getter isRoleStaff!: boolean
+  @Prop({ default: false }) readonly showDocumentsList!: boolean
 
   @Emit('downloadOne')
   protected downloadOne (document: DocumentIF, index: number): void {}
@@ -50,9 +46,3 @@ export default class StaffFiling extends Vue {
   protected downloadAll (item: HistoryItemIF) : void {}
 }
 </script>
-
-<style lang="scss" scoped>
-p {
-  margin-top: 1rem !important;
-}
-</style>

--- a/src/components/Dashboard/FilingHistoryList/StaffFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/StaffFiling.vue
@@ -1,8 +1,6 @@
 <template>
   <div v-if="filing" class="staff-filing-details body-2">
-    <p v-if="filing.notationOrOrder" class="mt-4">
-      {{filing.notationOrOrder}}
-    </p>
+    <p v-if="filing.details" class="mt-4">{{filing.details}}</p>
 
     <!-- Documents list may be displayed here or in Filing History List. -->
     <DocumentsList
@@ -12,13 +10,9 @@
       @downloadAll="downloadAll($event)"
     />
 
-    <p v-if="filing.fileNumber" class="mt-4 mb-0">
-      Court Order Number: {{filing.fileNumber}}
-    </p>
+    <p v-if="filing.fileNumber" class="mt-4 mb-0">Court Order Number: {{filing.fileNumber}}</p>
 
-    <p v-if="filing.planOfArrangement" class="mt-0">
-      {{filing.planOfArrangement}}
-    </p>
+    <p v-if="filing.planOfArrangement" class="mt-0">{{filing.planOfArrangement}}</p>
   </div>
 </template>
 

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -107,7 +107,7 @@
               <v-list-item
                 data-type="administrative-dissolution"
                 @click="showAdministrativeDissolutionDialog()"
-                :disabled="disabled  || isAdminFreeze"
+                :disabled="disabled || isAdminFreeze"
               >
                 <v-list-item-title>
                   <span class="app-blue">Administrative Dissolution</span>
@@ -136,12 +136,25 @@
                 </v-list-item-title>
               </v-list-item>
             </template>
+
             <template v-if="!isHistorical">
               <v-list-item
                 data-type="admin-freeze"
                 @click="showAdministerFreezeDialog()">
                 <v-list-item-title>
                   <span class="app-blue">{{ isAdminFreeze ? 'Unfreeze Business' : 'Freeze Business' }}</span>
+                </v-list-item-title>
+              </v-list-item>
+            </template>
+
+            <template v-if="isBenBcCccUlc && !isHistorical">
+              <v-list-item
+                data-type="consent-continue-out"
+                @click="goToConsentContinuationOutFiling()"
+                :disabled="disabled || isAdminFreeze"
+              >
+                <v-list-item-title>
+                  <span class="app-blue">Consent to Continuation Out</span>
                 </v-list-item-title>
               </v-list-item>
             </template>
@@ -157,7 +170,7 @@ import Vue from 'vue'
 import { Component, Prop, Emit } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import { navigate } from '@/utils'
-import { DissolutionTypes, DissolutionNames, FilingTypes, FilingNames } from '@/enums'
+import { DissolutionTypes, DissolutionNames, FilingTypes, FilingNames, Routes } from '@/enums'
 import { AddStaffNotationDialog } from '@/components/dialogs'
 import { FilingMixin } from '@/mixins'
 import { LegalServices } from '@/services'
@@ -243,6 +256,11 @@ export default class StaffNotation extends Vue {
   hideAdministrativeDissolutionDialog (needReload: boolean): void {
     this.isAddingAdministrativeDissolution = false
     this.close(needReload)
+  }
+
+  goToConsentContinuationOutFiling ():void {
+    // 0 means "new filing"
+    this.$router.push({ name: Routes.CONSENT_CONTINUATION_OUT, params: { filingId: '0' } })
   }
 
   async goToRestorationFiling (): Promise<void> {

--- a/src/enums/filingCodes.ts
+++ b/src/enums/filingCodes.ts
@@ -1,8 +1,10 @@
+// FUTURE: add these to shared enum and import that instead
 export enum FilingCodes {
   ANNUAL_REPORT_BC = 'BCANN', // BCOMP - Annual Report
   ANNUAL_REPORT_OT = 'OTANN', // Others - Annual Report
   ADDRESS_CHANGE_BC = 'BCADD', // BCOMP - Change of Address
   ADDRESS_CHANGE_OT = 'OTADD', // Others - Change of Address
+  CONSENT_CONTINUATION_OUT = 'CONTO', // All entity types
   CORRECTION = 'CRCTN', // Correction - for both BCOMP and Others
   DIRECTOR_CHANGE_BC = 'BCCDR', // BCOMP - Change of Directors
   DIRECTOR_CHANGE_OT = 'OTCDR', // Others - Change of Directors

--- a/src/enums/filingNames.ts
+++ b/src/enums/filingNames.ts
@@ -1,3 +1,4 @@
+// FUTURE: add these to shared enum and import that instead
 export enum FilingNames {
   ADMIN_FREEZE = 'Freeze Business',
   ALTERATION = 'Alteration',
@@ -8,6 +9,7 @@ export enum FilingNames {
   CHANGE_OF_NAME = 'Legal Name Change',
   CHANGE_OF_REGISTRATION = 'Change of Registration',
   CONVERSION = 'Record Conversion',
+  CONSENT_CONTINUATION_OUT = 'Consent to Continuation Out',
   CORRECTION = 'Correction',
   COURT_ORDER = 'Court Order',
   DISSOLUTION = 'Dissolution',

--- a/src/enums/filingTypes.ts
+++ b/src/enums/filingTypes.ts
@@ -1,3 +1,4 @@
+// FUTURE: add these to shared enum and import that instead
 export enum FilingTypes {
   ADMIN_FREEZE = 'adminFreeze',
   ALTERATION = 'alteration',
@@ -7,6 +8,7 @@ export enum FilingTypes {
   CHANGE_OF_DIRECTORS = 'changeOfDirectors',
   CHANGE_OF_NAME = 'changeOfName',
   CHANGE_OF_REGISTRATION = 'changeOfRegistration',
+  CONSENT_CONTINUATION_OUT = 'consentContinuationOut',
   CONVERSION = 'conversion',
   CORRECTION = 'correction',
   COURT_ORDER = 'courtOrder',

--- a/src/enums/restorationTypes.ts
+++ b/src/enums/restorationTypes.ts
@@ -1,4 +1,7 @@
+// FUTURE: move these to shared enum and import that instead
 export enum RestorationTypes {
   FULL = 'fullRestoration',
-  LIMITED = 'limitedRestoration'
+  LIMITED = 'limitedRestoration',
+  LIMITED_EXTENSION = 'limitedRestorationExtension',
+  LIMITED_TO_FULL = 'limitedRestorationToFull'
 }

--- a/src/enums/routes.ts
+++ b/src/enums/routes.ts
@@ -1,5 +1,6 @@
 export enum Routes {
   ANNUAL_REPORT = 'annual-report',
+  CONSENT_CONTINUATION_OUT = 'consent-continuation-out',
   CORRECTION = 'correction',
   DASHBOARD = 'dashboard',
   STANDALONE_ADDRESSES = 'standalone-addresses',

--- a/src/interfaces/api-filing-interface.ts
+++ b/src/interfaces/api-filing-interface.ts
@@ -54,7 +54,10 @@ export interface ApiFilingIF {
     changeOfDirectors?: any // some object
 
     // consent to continuation out filings only
-    consentContinuationOut?: any // some object
+    consentContinuationOut?: {
+      expiry: IsoDatePacific
+      orderDetails: string
+    }
 
     // conversion filings only
     conversion?: any // some object

--- a/src/interfaces/api-filing-interface.ts
+++ b/src/interfaces/api-filing-interface.ts
@@ -1,5 +1,5 @@
 import { CorpTypeCd, DissolutionTypes, EffectOfOrderTypes, FilingStatus, FilingTypes } from '@/enums'
-import { ApiDateTimeUtc, ChangeOfNameIF, FormattedDateTimeGmt, IsoDatePacific, SpecialResolutionIF } from '@/interfaces'
+import { ApiDateTimeUtc, FormattedDateTimeGmt, IsoDatePacific, SpecialResolutionIF } from '@/interfaces'
 
 /**
  * A list item from the API "filings" call (ie, API object).
@@ -53,7 +53,8 @@ export interface ApiFilingIF {
     // COD filings only
     changeOfDirectors?: any // some object
 
-    changeOfName?: ChangeOfNameIF
+    // consent to continuation out filings only
+    consentContinuationOut?: any // some object
 
     // conversion filings only
     conversion?: any // some object
@@ -81,6 +82,9 @@ export interface ApiFilingIF {
 
     // registrar's order filings only
     registrarsOrder?: any // some object
+
+    // restorations filings only
+    restoration?: any // some object
 
     // special resolution filings only
     specialResolution?: SpecialResolutionIF

--- a/src/interfaces/api-task-interface.ts
+++ b/src/interfaces/api-task-interface.ts
@@ -1,4 +1,4 @@
-import { AlterationIF, BusinessIF, ChangeOfNameIF, RestorationIF, SpecialResolutionIF } from '@/interfaces'
+import { AlterationIF, BusinessIF, RestorationIF, SpecialResolutionIF } from '@/interfaces'
 import { FilingStatus, FilingTypes } from '@/enums'
 
 /** A filing's header object from the API. */
@@ -53,7 +53,6 @@ export interface TaskTodoIF {
   changeOfRegistration?: any
   conversion?: any
   specialResolution?: SpecialResolutionIF
-  changeOfName?: ChangeOfNameIF
   restoration?: RestorationIF
 }
 

--- a/src/interfaces/history-item-interface.ts
+++ b/src/interfaces/history-item-interface.ts
@@ -65,8 +65,13 @@ export interface HistoryItemIF {
   planOfArrangement?: string
   putBackOnOrAdminDissolution?: boolean
 
-  // limited restorations
+  // limited restorations only
   isTypeLimitedRestoration?: boolean
-  expiry?: Date
   legalName?: string
+
+  // consent to continuation outs only
+  comment?: string
+
+  // limited restorations + consent to continuation outs only
+  expiry?: Date
 }

--- a/src/interfaces/history-item-interface.ts
+++ b/src/interfaces/history-item-interface.ts
@@ -61,17 +61,12 @@ export interface HistoryItemIF {
   // staff filings only
   fileNumber?: string
   isTypeStaff?: boolean
-  notationOrOrder?: string
+  details?: string // also used for consent to continuation out
   planOfArrangement?: string
   putBackOnOrAdminDissolution?: boolean
 
   // limited restorations only
   isTypeLimitedRestoration?: boolean
+  expiry?: Date // also used for consent to continuation out
   legalName?: string
-
-  // consent to continuation outs only
-  comment?: string
-
-  // limited restorations + consent to continuation outs only
-  expiry?: Date
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -2,12 +2,12 @@
 // NB: this is how to re-export a type in TS
 // https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/
 import type { CorpInfoIF } from '@bcrs-shared-components/corp-type-module'
-import type { AlterationIF, ChangeOfNameIF, ContactPointIF, NameTranslationIF, ShareStructureIF, CourtOrderIF,
+import type { AlterationIF, ContactPointIF, NameTranslationIF, ShareStructureIF, CourtOrderIF,
   IncorporationApplicationIF, IncorporationAddressIf, ShareClassIF, CommentIF, ConfirmDialogType, StaffPaymentIF,
   ApiDateTimeUtc, FormattedDateTimeGmt, IsoDatePacific, SpecialResolutionIF } from '@bcrs-shared-components/interfaces'
 export type { CorpInfoIF }
 
-export type { AlterationIF, ChangeOfNameIF, ContactPointIF, NameTranslationIF, ShareStructureIF, CourtOrderIF,
+export type { AlterationIF, ContactPointIF, NameTranslationIF, ShareStructureIF, CourtOrderIF,
   IncorporationApplicationIF, IncorporationAddressIf, ShareClassIF, CommentIF, ConfirmDialogType, StaffPaymentIF,
   ApiDateTimeUtc, FormattedDateTimeGmt, IsoDatePacific, SpecialResolutionIF }
 

--- a/src/interfaces/todo-item-interface.ts
+++ b/src/interfaces/todo-item-interface.ts
@@ -42,7 +42,7 @@ export interface TodoItemIF {
   // conversions only
   warnings?: Array<string>
 
-  // IAs only
+  // IAs and registrations only
   isEmptyFiling?: boolean
   nameRequest?: any
 

--- a/src/mixins/enum-mixin.ts
+++ b/src/mixins/enum-mixin.ts
@@ -116,6 +116,11 @@ export default class EnumMixin extends Vue {
     return (item.name === FilingTypes.CHANGE_OF_REGISTRATION)
   }
 
+  /** Returns True if filing is a Consent to Continuation Out. */
+  isTypeConsentContinuationOut (item: any): boolean {
+    return (item.name === FilingTypes.CONSENT_CONTINUATION_OUT)
+  }
+
   /** Returns True if filing is a Conversion. */
   isTypeConversion (item: any): boolean {
     return (item.name === FilingTypes.CONVERSION)

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,15 +1,13 @@
-// Components
 import Dashboard from '@/views/Dashboard.vue'
 import AnnualReport from '@/views/AnnualReport.vue'
 import StandaloneDirectorsFiling from '@/views/StandaloneDirectorsFiling.vue'
 import StandaloneOfficeAddressFiling from '@/views/StandaloneOfficeAddressFiling.vue'
+import ConsentContinuationOut from '@/views/ConsentContinuationOut.vue'
 import Correction from '@/views/Correction.vue'
 import Signin from '@/views/auth/Signin.vue'
 import Signout from '@/views/auth/Signout.vue'
 import { DigitalCredentialRoutes } from '@/resources/DigitalCredentialRoutes'
-
-// Constants
-import { Routes } from '@/enums'
+import { FilingNames, Routes } from '@/enums'
 
 export default [
   {
@@ -28,7 +26,7 @@ export default [
       requiresAuth: true,
       breadcrumb: [
         {
-          text: 'File Annual Report',
+          text: `File ${FilingNames.ANNUAL_REPORT}`,
           disabled: false,
           exact: true,
           to: { name: Routes.ANNUAL_REPORT }
@@ -44,7 +42,7 @@ export default [
       requiresAuth: true,
       breadcrumb: [
         {
-          text: 'Director Change',
+          text: FilingNames.CHANGE_OF_DIRECTORS,
           disabled: false,
           exact: true,
           to: { name: Routes.STANDALONE_DIRECTORS }
@@ -60,10 +58,26 @@ export default [
       requiresAuth: true,
       breadcrumb: [
         {
-          text: 'Address Change',
+          text: FilingNames.CHANGE_OF_ADDRESS,
           disabled: false,
           exact: true,
           to: { name: Routes.STANDALONE_ADDRESSES }
+        }
+      ]
+    }
+  },
+  {
+    path: '/consent-continuation-out',
+    name: Routes.CONSENT_CONTINUATION_OUT,
+    component: ConsentContinuationOut,
+    meta: {
+      requiresAuth: true,
+      breadcrumb: [
+        {
+          text: FilingNames.CONSENT_CONTINUATION_OUT,
+          disabled: false,
+          exact: true,
+          to: { name: Routes.CONSENT_CONTINUATION_OUT }
         }
       ]
     }
@@ -76,7 +90,7 @@ export default [
       requiresAuth: true,
       breadcrumb: [
         {
-          text: 'Correction',
+          text: FilingNames.CORRECTION,
           disabled: false,
           exact: true,
           to: { name: Routes.CORRECTION }

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -990,7 +990,7 @@ export default class AnnualReport extends Vue {
 
     if (this.isCoop) {
       annualReport = {
-        annualReport: {
+        [FilingTypes.ANNUAL_REPORT]: {
           annualGeneralMeetingDate: this.agmDate || null, // API doesn't validate empty string
           // save AGM Extension as false if No AGM is true
           agmExtension: (!this.noAgm && this.agmExtension) || false,
@@ -1007,7 +1007,7 @@ export default class AnnualReport extends Vue {
 
     if (this.isBenBcCccUlc) {
       annualReport = {
-        annualReport: {
+        [FilingTypes.ANNUAL_REPORT]: {
           annualReportDate: this.asOfDate,
           nextARDate: this.nextARDate, // used by BEN/BC/CCC/ULC only
           // NB: there was an enrichment ticket to populate offices and directors here
@@ -1026,7 +1026,7 @@ export default class AnnualReport extends Vue {
       this.hasFilingCode(FilingCodes.FREE_DIRECTOR_CHANGE_OT)
     ) {
       changeOfDirectors = {
-        changeOfDirectors: {
+        [FilingTypes.CHANGE_OF_DIRECTORS]: {
           directors: this.updatedDirectors
         }
       }
@@ -1035,7 +1035,7 @@ export default class AnnualReport extends Vue {
     // non-BCOMP only
     if (this.hasFilingCode(FilingCodes.ADDRESS_CHANGE_OT)) {
       changeOfAddress = {
-        changeOfAddress: {
+        [FilingTypes.CHANGE_OF_ADDRESS]: {
           legalType: this.getEntityType,
           offices: {
             registeredOffice: this.updatedAddresses.registeredOffice
@@ -1044,17 +1044,17 @@ export default class AnnualReport extends Vue {
       }
     }
 
-    // build filing data
-    const data = Object.assign({}, header, business, annualReport, changeOfAddress, changeOfDirectors)
+    // build filing
+    const filing = Object.assign({}, header, business, annualReport, changeOfAddress, changeOfDirectors)
 
     try {
       let ret
       if (this.filingId > 0) {
         // we have a filing id, so update an existing filing
-        ret = await LegalServices.updateFiling(this.getIdentifier, data, this.filingId, isDraft)
+        ret = await LegalServices.updateFiling(this.getIdentifier, filing, this.filingId, isDraft)
       } else {
         // filing id is 0, so create a new filing
-        ret = await LegalServices.createFiling(this.getIdentifier, data, isDraft)
+        ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
     } catch (error) {

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -810,23 +810,23 @@ export default class StandaloneDirectorsFiling extends Vue {
 
     if (this.hasFilingCode(this.feeCode) || this.hasFilingCode(this.freeFeeCode)) {
       changeOfDirectors = {
-        changeOfDirectors: {
+        [FilingTypes.CHANGE_OF_DIRECTORS]: {
           directors: this.updatedDirectors
         }
       }
     }
 
-    // build filing data
-    const data = Object.assign({}, header, business, changeOfDirectors)
+    // build filing
+    const filing = Object.assign({}, header, business, changeOfDirectors)
 
     try {
       let ret
       if (this.filingId > 0) {
         // we have a filing id, so update an existing filing
-        ret = await LegalServices.updateFiling(this.getIdentifier, data, this.filingId, isDraft)
+        ret = await LegalServices.updateFiling(this.getIdentifier, filing, this.filingId, isDraft)
       } else {
         // filing id is 0, so create a new filing
-        ret = await LegalServices.createFiling(this.getIdentifier, data, isDraft)
+        ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
     } catch (error) {

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -688,7 +688,7 @@ export default class StandaloneOfficeAddressFiling extends Vue {
 
     if (this.hasFilingCode(FilingCodes.ADDRESS_CHANGE_OT)) {
       changeOfAddress = {
-        changeOfAddress: {
+        [FilingTypes.CHANGE_OF_ADDRESS]: {
           legalType: this.getEntityType,
           offices: {
             registeredOffice: this.updatedAddresses.registeredOffice
@@ -699,7 +699,7 @@ export default class StandaloneOfficeAddressFiling extends Vue {
 
     if (this.hasFilingCode(FilingCodes.ADDRESS_CHANGE_BC)) {
       changeOfAddress = {
-        changeOfAddress: {
+        [FilingTypes.CHANGE_OF_ADDRESS]: {
           legalType: this.getEntityType,
           offices: {
             registeredOffice: this.updatedAddresses.registeredOffice,
@@ -709,17 +709,17 @@ export default class StandaloneOfficeAddressFiling extends Vue {
       }
     }
 
-    // build filing data
-    const data = Object.assign({}, header, business, changeOfAddress)
+    // build filing
+    const filing = Object.assign({}, header, business, changeOfAddress)
 
     try {
       let ret
       if (this.filingId > 0) {
         // we have a filing id, so update an existing filing
-        ret = await LegalServices.updateFiling(this.getIdentifier, data, this.filingId, isDraft)
+        ret = await LegalServices.updateFiling(this.getIdentifier, filing, this.filingId, isDraft)
       } else {
         // filing id is 0, so create a new filing
-        ret = await LegalServices.createFiling(this.getIdentifier, data, isDraft)
+        ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
     } catch (error) {

--- a/tests/unit/FilingHistoryList1.spec.ts
+++ b/tests/unit/FilingHistoryList1.spec.ts
@@ -1734,7 +1734,7 @@ describe('Filing History List - paper only and other filings', () => {
           order: {
             effectOfOrder: 'planOfArrangement',
             fileNumber: '#1234-5678/90',
-            notationOrOrder: 'A note about order'
+            orderDetails: 'A note about order'
           }
         }
       }
@@ -1791,7 +1791,7 @@ describe('Filing History List - paper only and other filings', () => {
           order: {
             effectOfOrder: 'planOfArrangement',
             fileNumber: '#1234-5678/90',
-            notationOrOrder: 'A note about order'
+            orderDetails: 'A note about order'
           }
         }
       }
@@ -1848,7 +1848,7 @@ describe('Filing History List - paper only and other filings', () => {
           order: {
             effectOfOrder: 'planOfArrangement',
             fileNumber: '#1234-5678/90',
-            notationOrOrder: 'A note about order'
+            orderDetails: 'A note about order'
           }
         }
       }

--- a/tests/unit/FilingHistoryList2.spec.ts
+++ b/tests/unit/FilingHistoryList2.spec.ts
@@ -33,6 +33,7 @@ const isCorrected = (filing) => !!filing.correctionFilingId
 const isIncorporationApplication = (filing) => (filing.name === 'incorporationApplication')
 const isBcompCoa = (filing) => false // FUTURE: implement BComp tests
 const isAlteration = (filing) => (filing.name === 'alteration')
+const isConsentContinuationOut = (filing) => (filing.name === 'consentContinuationOut')
 const isStaff = (filing) => (
   filing.name === 'registrarsNotation' ||
   filing.name === 'registrarsOrder' ||
@@ -124,6 +125,14 @@ filings.forEach((filing: any, index: number) => {
       expect(item.isFutureEffectiveAlterationPending).toBeDefined() // FUTURE: test this more specifically
       expect(item.toLegalType).toBeDefined() // FUTURE: test this more specifically
       expect(item.fromLegalType).toBeDefined() // FUTURE: test this more specifically
+    })
+
+    itIf(isConsentContinuationOut(filing))('consent to continuation out filing', () => {
+      expect(vm.historyItems.length).toBe(1) // sanity check
+      const item = vm.historyItems[0]
+
+      expect(item.comment).toBeDefined() // FUTURE: test this more specifically
+      expect(item.expiry).toBeDefined() // FUTURE: test this more specifically
     })
 
     itIf(isStaff(filing))('staff filing', () => {

--- a/tests/unit/FilingHistoryList2.spec.ts
+++ b/tests/unit/FilingHistoryList2.spec.ts
@@ -131,7 +131,7 @@ filings.forEach((filing: any, index: number) => {
       expect(vm.historyItems.length).toBe(1) // sanity check
       const item = vm.historyItems[0]
 
-      expect(item.comment).toBeDefined() // FUTURE: test this more specifically
+      expect(item.details).toBeDefined() // FUTURE: test this more specifically
       expect(item.expiry).toBeDefined() // FUTURE: test this more specifically
     })
 
@@ -141,7 +141,7 @@ filings.forEach((filing: any, index: number) => {
 
       expect(item.fileNumber).toBeDefined() // FUTURE: test this more specifically
       expect(item.isTypeStaff).toBe(true)
-      // expect(item.notationOrOrder).toBeDefined() // FUTURE: test this more specifically
+      // expect(item.details).toBeDefined() // FUTURE: test this more specifically
       expect(item.planOfArrangement).toBeDefined() // FUTURE: test this more specifically
     })
 

--- a/tests/unit/StaffFiling.spec.ts
+++ b/tests/unit/StaffFiling.spec.ts
@@ -25,7 +25,7 @@ describe('Staff Filing', () => {
       vuetify,
       propsData: {
         filing: {
-          notationOrOrder: 'Notation Or Order',
+          details: 'Notation Or Order',
           fileNumber: '1234',
           planOfArrangement: 'Plan Of Arrangement'
         }

--- a/tests/unit/TodoList2.spec.ts
+++ b/tests/unit/TodoList2.spec.ts
@@ -174,6 +174,91 @@ describe('TodoList - common expansion panel header tests', () => {
     wrapper.destroy()
   })
 
+  it('displays draft consent to continuation out as staff', async () => {
+    // init store
+    store.state.tasks = [
+      {
+        enabled: true,
+        order: 1,
+        task: {
+          filing: {
+            header: {
+              name: 'consentContinuationOut',
+              status: 'DRAFT',
+              filingId: 1,
+              comments: []
+            },
+            business: {},
+            consentContinuationOut: { comment: 'line1\nline2' }
+          }
+        }
+      }
+    ]
+
+    const wrapper = mount(TodoList, {
+      store,
+      computed: { isRoleStaff: () => true },
+      vuetify
+    })
+    await Vue.nextTick()
+
+    // verify title
+    // verify sub-title
+    // verify resume button
+    expect(wrapper.findAll('.todo-item').length).toEqual(1)
+    expect(wrapper.find('.list-item__title').text()).toBe('Consent to Continuation Out')
+    expect(wrapper.find('.todo-subtitle').text()).toBe('DRAFT')
+    expect(wrapper.find('.btn-draft-resume').exists()).toBe(true)
+
+    // open dropdown menu and click Delete button
+    await wrapper.find('#menu-activator').trigger('click')
+    await wrapper.find('#btn-draft-delete').trigger('click')
+
+    // verify confirmation popup is showing
+    expect(wrapper.vm.$refs.confirm).toBeTruthy()
+
+    wrapper.destroy()
+  })
+
+  it('displays draft consent to continuation out as non-staff', async () => {
+    // init store
+    store.state.tasks = [
+      {
+        enabled: true,
+        order: 1,
+        task: {
+          filing: {
+            header: {
+              name: 'consentContinuationOut',
+              status: 'DRAFT',
+              filingId: 1,
+              comments: []
+            },
+            business: {},
+            consentContinuationOut: { comment: 'line1\nline2' }
+          }
+        }
+      }
+    ]
+
+    const wrapper = mount(TodoList, {
+      store,
+      computed: { isRoleStaff: () => false },
+      vuetify
+    })
+    await Vue.nextTick()
+
+    // verify title
+    // verify sub-title
+    // verify no resume button
+    expect(wrapper.findAll('.todo-item').length).toEqual(1)
+    expect(wrapper.find('.list-item__title').text()).toBe('Consent to Continuation Out')
+    expect(wrapper.find('.todo-subtitle').text()).toBe('DRAFT')
+    expect(wrapper.find('.btn-draft-resume').exists()).toBe(false)
+
+    wrapper.destroy()
+  })
+
   xit('displays draft alteration without comments', async () => {
     // verify title
     // verify sub-title

--- a/tests/unit/enum-mixin.spec.ts
+++ b/tests/unit/enum-mixin.spec.ts
@@ -40,6 +40,7 @@ describe('Enum Mixin', () => {
     expect(vm.isTypeChangeOfDirectors({ name: 'changeOfDirectors' })).toBe(true)
     expect(vm.isTypeChangeOfName({ name: 'changeOfName' })).toBe(true)
     expect(vm.isTypeChangeOfRegistration({ name: 'changeOfRegistration' })).toBe(true)
+    expect(vm.isTypeConsentContinuationOut({ name: 'consentContinuationOut' })).toBe(true)
     expect(vm.isTypeConversion({ name: 'conversion' })).toBe(true)
     expect(vm.isTypeCorrection({ name: 'correction' })).toBe(true)
     expect(vm.isTypeDissolution({ name: 'dissolution' })).toBe(true)

--- a/tests/unit/filings.json
+++ b/tests/unit/filings.json
@@ -536,8 +536,8 @@
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112756/comments",
       "data": {
         "consentContinuationOut": {
-          "comment": "A note about this filing",
-          "expiry": "2022-12-31T08:01:00.000+00:00"
+          "orderDetails": "A note about this filing",
+          "expiry": "2023-12-31"
         },
         "legalFilings": [
           "consentContinuationOut"

--- a/tests/unit/filings.json
+++ b/tests/unit/filings.json
@@ -54,7 +54,6 @@
       "commentsCount": 5,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112758/comments",
       "data": {
-        "applicationDate": "2019-09-01",
         "legalFilings": [
           "specialResolution"
         ],
@@ -82,7 +81,6 @@
           "fromLegalType": "BC",
           "toLegalType": "BEN"
         },
-        "applicationDate": "2019-02-01",
         "legalFilings": [
           "alteration"
         ],
@@ -115,7 +113,6 @@
           "fromLegalType": "BC",
           "toLegalType": "BEN"
         },
-        "applicationDate": "2019-01-01",
         "legalFilings": [
           "alteration"
         ],
@@ -143,9 +140,7 @@
       "businessIdentifier": "CP0000840",
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112761/comments",
-      "data": {
-        "applicationDate": "2018-12-01"
-      },
+      "data": {},
       "displayName": "Alteration",
       "documentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112761/documents",
       "effectiveDate": "Sat, 01 Dec 2018 00:02:26 GMT",
@@ -164,7 +159,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112757/comments",
       "data": {
-        "applicationDate": "2018-11-01",
         "legalFilings": [
           "annualReport",
           "changeOfDirectors",
@@ -196,7 +190,6 @@
           "annualGeneralMeetingDate": "2018-10-01",
           "annualReportDate": "2018-10-01"
         },
-        "applicationDate": "2018-10-01",
         "legalFilings": [
           "annualReport",
           "changeOfAddress",
@@ -221,7 +214,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112755/comments",
       "data": {
-        "applicationDate": "2018-08-01",
         "legalFilings": [
           "registrarsOrder"
         ],
@@ -245,7 +237,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112754/comments",
       "data": {
-        "applicationDate": "2018-07-01",
         "legalFilings": [
           "registrarsNotation"
         ],
@@ -269,7 +260,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112753/comments",
       "data": {
-        "applicationDate": "2018-06-01",
         "legalFilings": [
           "courtOrder"
         ],
@@ -298,7 +288,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112752/comments",
       "data": {
-        "applicationDate": "2018-05-01",
         "legalFilings": [
           "transition"
         ],
@@ -322,7 +311,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112751/comments",
       "data": {
-        "applicationDate": "2018-04-01",
         "dissolution": {
           "dissolutionType": "voluntary"
         },
@@ -348,7 +336,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112750/comments",
       "data": {
-        "applicationDate": "2018-03-01",
         "legalFilings": [
           "specialResolution"
         ],
@@ -372,7 +359,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112749/comments",
       "data": {
-        "applicationDate": "2018-02-01",
         "conversion": {},
         "legalFilings": [
           "conversion"
@@ -400,7 +386,6 @@
           "annualGeneralMeetingDate": "2018-01-01",
           "annualReportDate": "2018-01-01"
         },
-        "applicationDate": "2018-01-01",
         "legalFilings": [
           "annualReport"
         ]
@@ -423,7 +408,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112747/comments",
       "data": {
-        "applicationDate": "2017-12-01",
         "changeOfDirectors": {},
         "legalFilings": [
           "changeOfDirectors"
@@ -447,7 +431,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112746/comments",
       "data": {
-        "applicationDate": "2017-11-01",
         "changeOfAddress": {},
         "legalFilings": [
           "changeOfAddress"
@@ -499,7 +482,6 @@
           "fromLegalType": "BC",
           "toLegalType": "BEN"
         },
-        "applicationDate": "2017-10-01",
         "legalFilings": [
           "alteration"
         ],
@@ -528,7 +510,6 @@
       "commentsCount": 0,
       "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112756/comments",
       "data": {
-        "applicationDate": "2018-04-01",
         "dissolution": {
           "dissolutionType": "administrative"
         },
@@ -547,7 +528,32 @@
       "status": "COMPLETED",
       "submittedDate": "Sun, 01 Apr 2018 00:02:26 GMT",
       "submitter": "Registry Staff"
+    },
+    {
+      "availableOnPaperOnly": false,
+      "businessIdentifier": "CP0000840",
+      "commentsCount": 0,
+      "commentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112756/comments",
+      "data": {
+        "consentContinuationOut": {
+          "comment": "A note about this filing",
+          "expiry": "2022-12-31T08:01:00.000+00:00"
+        },
+        "legalFilings": [
+          "consentContinuationOut"
+        ]
+      },
+      "displayName": "6-Month Consent to Continue Out",
+      "documentsLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112756/documents",
+      "effectiveDate": "Fri, 03 Feb 2023 18:52:00 GMT",
+      "filingId": 112751,
+      "filingLink": "https://legal-api-dev.apps.silver.devops.gov.bc.ca/api/v2/businesses/CP0000840/filings/112756",
+      "isFutureEffective": false,
+      "name": "consentContinuationOut",
+      "paymentStatusCode": null,
+      "status": "COMPLETED",
+      "submittedDate": "Fri, 03 Feb 2023 18:52:00 GMT",
+      "submitter": "Registry Staff"
     }
-    
   ]
 }


### PR DESCRIPTION
*Issue #:* bcgov/entity#15042

*Description of changes:*
    - added new route
    - added new enum mixin method
    - added item to staff notation list + route to new page
    - updated Filing History List to support new filing
    - updated Todo List to support new filing (staff and non-staff)
    - removed unused "haveData" from some filings
    - added filing code
    - added filing name
    - added filing type
    - added route name
    - added initial Consent Continuation Out page
    - deleted obsolete "changeOfName" object
    - added "consentContinuationOut" object
    - added properties to HistoryItemIF
    - cleaned up staff filing code
    - added handling for Consent to Continuation Out filings
    - misc cleanup
    - updated unit tests
    - app version = 5.10.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).