### PR TITLE
add back session variables for SBC Header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.11.0",
+      "version": "5.11.1",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/store/Configuration/mutations.ts
+++ b/src/store/Configuration/mutations.ts
@@ -18,7 +18,7 @@ export default {
   },
 
   setSessionVariables (state: ConfigurationStateIF, responseData: any) {
-    // The following three session variables are used by SBC Header (a common component)
+    // The following four session variables are used by SBC Header (a common component)
     sessionStorage.setItem('AUTH_WEB_URL', responseData['AUTH_WEB_URL'])
     sessionStorage.setItem('REGISTRY_HOME_URL', responseData['REGISTRY_HOME_URL'])
     sessionStorage.setItem('AUTH_API_URL', responseData['AUTH_API_URL'] + responseData['AUTH_API_VERSION'] + '/')

--- a/src/store/Configuration/mutations.ts
+++ b/src/store/Configuration/mutations.ts
@@ -18,6 +18,10 @@ export default {
   },
 
   setSessionVariables (state: ConfigurationStateIF, responseData: any) {
+    // The following two session variables are used by SBC Header (a common component)
+    sessionStorage.setItem('AUTH_WEB_URL', responseData['AUTH_WEB_URL'])
+    sessionStorage.setItem('REGISTRY_HOME_URL', responseData['REGISTRY_HOME_URL'])
+
     const hotjarId: string = responseData['HOTJAR_ID'];
     (<any>window).hotjarId = hotjarId
 

--- a/src/store/Configuration/mutations.ts
+++ b/src/store/Configuration/mutations.ts
@@ -18,9 +18,10 @@ export default {
   },
 
   setSessionVariables (state: ConfigurationStateIF, responseData: any) {
-    // The following two session variables are used by SBC Header (a common component)
+    // The following three session variables are used by SBC Header (a common component)
     sessionStorage.setItem('AUTH_WEB_URL', responseData['AUTH_WEB_URL'])
     sessionStorage.setItem('REGISTRY_HOME_URL', responseData['REGISTRY_HOME_URL'])
+    sessionStorage.setItem('AUTH_API_URL', responseData['AUTH_API_URL'] + responseData['AUTH_API_VERSION'] + '/')
 
     const hotjarId: string = responseData['HOTJAR_ID'];
     (<any>window).hotjarId = hotjarId

--- a/src/store/Configuration/mutations.ts
+++ b/src/store/Configuration/mutations.ts
@@ -22,6 +22,7 @@ export default {
     sessionStorage.setItem('AUTH_WEB_URL', responseData['AUTH_WEB_URL'])
     sessionStorage.setItem('REGISTRY_HOME_URL', responseData['REGISTRY_HOME_URL'])
     sessionStorage.setItem('AUTH_API_URL', responseData['AUTH_API_URL'] + responseData['AUTH_API_VERSION'] + '/')
+    sessionStorage.setItem('STATUS_API_URL', responseData['STATUS_API_URL'] + responseData['STATUS_API_VERSION'])
 
     const hotjarId: string = responseData['HOTJAR_ID'];
     (<any>window).hotjarId = hotjarId

--- a/tests/unit/Configuration.spec.ts
+++ b/tests/unit/Configuration.spec.ts
@@ -160,6 +160,7 @@ describe('Fetch Config', () => {
       .then(() => {
         expect(sessionStorage.getItem('REGISTRY_HOME_URL')).toBe('registry home url')
         expect(sessionStorage.getItem('AUTH_WEB_URL')).toBe('auth web url')
+        expect(sessionStorage.getItem('AUTH_API_URL')).toBe('auth api url/auth api version/')
       })
   })
 })

--- a/tests/unit/Configuration.spec.ts
+++ b/tests/unit/Configuration.spec.ts
@@ -152,4 +152,14 @@ describe('Fetch Config', () => {
       setBaseRouteAndBusinessId('ZZ1234567', '/business/', window.location.origin)
     }).toThrow('Missing or invalid Business ID or Temp Reg Number.')
   })
+
+  it('sessions variables correctly set for the SBC header', async () => {
+    const store = await getVuexStore() as any // remove typings for unit tests
+    const applicationUrl = 'http://localhost/business/'
+    await store.dispatch('fetchConfiguration', applicationUrl)
+      .then(() => {
+        expect(sessionStorage.getItem('REGISTRY_HOME_URL')).toBe('registry home url')
+        expect(sessionStorage.getItem('AUTH_WEB_URL')).toBe('auth web url')
+      })
+  })
 })

--- a/tests/unit/Configuration.spec.ts
+++ b/tests/unit/Configuration.spec.ts
@@ -161,6 +161,7 @@ describe('Fetch Config', () => {
         expect(sessionStorage.getItem('REGISTRY_HOME_URL')).toBe('registry home url')
         expect(sessionStorage.getItem('AUTH_WEB_URL')).toBe('auth web url')
         expect(sessionStorage.getItem('AUTH_API_URL')).toBe('auth api url/auth api version/')
+        expect(sessionStorage.getItem('STATUS_API_URL')).toBe('status api url/status api version')
       })
   })
 })


### PR DESCRIPTION
*Issue #:* DEV fix

The SBC Header uses session variables to determine the AUTH_WEB_URL and other URL paths.  This PR adds back the session variables that were removed in the previous commit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
