### PR TITLE
15092 - separate restoration endpoints in edit-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "5.11.4",
+  "version": "5.11.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "5.11.4",
+      "version": "5.11.5",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "5.11.4",
+  "version": "5.11.5",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -307,8 +307,7 @@ export default class StaffNotation extends Vue {
         url = `${this.getCreateUrl}?id=${this.getIdentifier}`
       }
       if (applicationName === ApplicationTypes.EDIT_UI) {
-        url = `${this.getEditUrl}${this.getIdentifier}/restoration` +
-          `?restoration-id=${id}`
+        url = `${this.getEditUrl}${this.getIdentifier}/` + restorationType + `?restoration-id=${id}`
       }
       navigate(url)
     } catch (error) {

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -509,7 +509,7 @@ describe('StaffNotation', () => {
 
     // verify redirection
     expect(window.location.assign).toHaveBeenCalledWith(
-      'https://edit.url/BC1234567/restoration?restoration-id=1234')
+      'https://edit.url/BC1234567/limitedRestorationExtension?restoration-id=1234')
 
     wrapper.destroy()
     sinon.restore()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15092

In edit-ui, we're overloading the restoration endpoint and reusing it for ~~full restorations,~~ limited-to-full restorations and limited-extension restorations.  By separating restorations to different ~~endpoints~~ routes (thanks Sev!), we can keep the code in edit-ui cleaner and easier to read.  

### Caution, this change will break existing functionality until the receiving endpoints are configured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
