### PR TITLE
15692 Cleaned up some whitespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/FilingTemplate.vue
+++ b/src/components/Dashboard/FilingHistoryList/FilingTemplate.vue
@@ -49,23 +49,23 @@
     <v-expansion-panel-content>
       <slot name="body">
         <!-- is this a generic paid (not yet completed) filing? -->
-        <div v-if="isStatusPaid" class="body-2 mt-4">
-          <h4>Filing Pending</h4>
+        <div v-if="isStatusPaid" class="body-2">
+          <h4 class="mt-4">Filing Pending</h4>
 
-          <p class="my-4">
+          <p class="mt-4">
             This {{ title }} is paid, but the filing has not been completed by the Business Registry
             yet. Some filings may take longer than expected.
           </p>
 
-          <p v-if="fileNumber">
+          <p v-if="fileNumber" class="mt-4">
             Court Order Number: {{ fileNumber }}
           </p>
 
-          <p v-if="hasEffectOfOrder">
+          <p v-if="hasEffectOfOrder" class="mt-4">
             Pursuant to a Plan of Arrangement
           </p>
 
-          <p>
+          <p class="mt-4">
             Refresh this screen in a few minutes or you can come back later to check on the progress.
             If this issue persists, please contact us.
           </p>
@@ -181,5 +181,6 @@ export default class FilingTemplate extends Vue {
 p {
   color: $gray7;
   font-size: $px-15;
+  margin-bottom: 0 !important;
 }
 </style>

--- a/src/components/Dashboard/FilingHistoryList/filings/StaffFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/StaffFiling.vue
@@ -13,7 +13,7 @@
     </template>
 
     <template #body>
-      <div class="staff-filing-details body-2 mt-4">
+      <div class="staff-filing-details body-2">
         <p v-if="orderDetails" class="mt-4">
           {{ orderDetails }}
         </p>
@@ -22,14 +22,15 @@
         <!-- NB: only court orders have documents - see also FilingTemplate.vue -->
         <DocumentsList
           v-if="isTypeCourtOrder && filing.documents && filing.documents.length > 0"
+          class="mt-4"
           :filing=filing
         />
 
-        <p v-if="fileNumber" class="xmt-4 xmb-0">
+        <p v-if="fileNumber" class="mt-4">
           Court Order Number: {{ fileNumber }}
         </p>
 
-        <p v-if="hasEffectOfOrder" class="xmt-0">
+        <p v-if="hasEffectOfOrder" class="mt-4">
           Pursuant to a Plan of Arrangement
         </p>
       </div>
@@ -95,5 +96,6 @@ export default class StaffFiling extends Vue {
 p {
   color: $gray7;
   font-size: $px-15;
+  margin-bottom: 0 !important;
 }
 </style>


### PR DESCRIPTION
*Issue #:* bcgov/entity#15692

*Description of changes:*
- app version = 6.2.1
- cleaned up whitespace in Filing Template default body
- cleaned up whitespace in Staff Filing body

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).

#### Sample Filing Template:
(I hacked the code to use this template instead of the Staff Filing template)
![Filing Template](https://user-images.githubusercontent.com/10002889/229196712-7d4aab6b-f4c8-4551-a384-eb01a86476ea.png)

#### Sample Staff Filing:
(normal view for this Court Order filing)
![Staff Filing](https://user-images.githubusercontent.com/10002889/229196791-c4626ad2-d8c0-423c-9c68-02945beb2f93.png)
