### PR TITLE
15892 Director & Address change correction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.3.1",
+      "version": "6.3.2",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -115,6 +115,8 @@ export default class HeaderActions extends Vue {
     conditions[4] = () => (EnumUtilities.isTypeChangeOfRegistration(this.filing) && !this.isFirm)
     conditions[5] = () => (EnumUtilities.isTypeCorrection(this.filing) && !this.isFirm && !this.isBenBcCccUlc)
     conditions[6] = () => (EnumUtilities.isTypeRegistration(this.filing) && !this.isFirm)
+    conditions[7] = () => (EnumUtilities.isTypeChangeOfAddress(this.filing) && !this.isBenBcCccUlc)
+    conditions[8] = () => (EnumUtilities.isTypeChangeOfDirectors(this.filing) && !this.isBenBcCccUlc)
 
     // check if any condition is True
     return conditions.some(condition => condition())

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -115,8 +115,6 @@ export default class HeaderActions extends Vue {
     conditions[4] = () => (EnumUtilities.isTypeChangeOfRegistration(this.filing) && !this.isFirm)
     conditions[5] = () => (EnumUtilities.isTypeCorrection(this.filing) && !this.isFirm && !this.isBenBcCccUlc)
     conditions[6] = () => (EnumUtilities.isTypeRegistration(this.filing) && !this.isFirm)
-    conditions[7] = () => (EnumUtilities.isTypeChangeOfAddress(this.filing) && !this.isBenBcCccUlc)
-    conditions[8] = () => (EnumUtilities.isTypeChangeOfDirectors(this.filing) && !this.isBenBcCccUlc)
 
     // check if any condition is True
     return conditions.some(condition => condition())
@@ -127,8 +125,6 @@ export default class HeaderActions extends Vue {
     // see also TodoList.vue:doResumeFiling()
     switch (filing?.name) {
       case FilingTypes.ALTERATION:
-      case FilingTypes.CHANGE_OF_ADDRESS:
-      case FilingTypes.CHANGE_OF_DIRECTORS:
       case FilingTypes.CHANGE_OF_REGISTRATION:
       case FilingTypes.CORRECTION:
       case FilingTypes.INCORPORATION_APPLICATION:
@@ -137,6 +133,22 @@ export default class HeaderActions extends Vue {
         this.mutateCurrentFiling(filing)
         this.mutateFileCorrectionDialog(true)
         break
+
+      case FilingTypes.CHANGE_OF_ADDRESS:
+      case FilingTypes.CHANGE_OF_DIRECTORS:
+        if (this.isBenBcCccUlc) {
+          // correction via Edit UI if current type is BC, CC, ULC, or BEN
+          this.mutateCurrentFiling(filing)
+          this.mutateFileCorrectionDialog(true)
+          break
+        } else {
+          // Local correction otherwise
+          this.$router.push({
+            name: Routes.CORRECTION,
+            params: { correctedFilingId: filing.filingId.toString() }
+          })
+          break
+        }
 
       case FilingTypes.ANNUAL_REPORT:
       case FilingTypes.CONVERSION:

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -125,9 +125,11 @@ export default class HeaderActions extends Vue {
     // see also TodoList.vue:doResumeFiling()
     switch (filing?.name) {
       case FilingTypes.ALTERATION:
-      case FilingTypes.INCORPORATION_APPLICATION:
+      case FilingTypes.CHANGE_OF_ADDRESS:
+      case FilingTypes.CHANGE_OF_DIRECTORS:
       case FilingTypes.CHANGE_OF_REGISTRATION:
       case FilingTypes.CORRECTION:
+      case FilingTypes.INCORPORATION_APPLICATION:
       case FilingTypes.REGISTRATION:
         // correction via Edit UI
         this.mutateCurrentFiling(filing)
@@ -135,8 +137,6 @@ export default class HeaderActions extends Vue {
         break
 
       case FilingTypes.ANNUAL_REPORT:
-      case FilingTypes.CHANGE_OF_ADDRESS:
-      case FilingTypes.CHANGE_OF_DIRECTORS:
       case FilingTypes.CONVERSION:
       default:
         // local correction for all other filings

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -138,6 +138,7 @@ export default class HeaderActions extends Vue {
       case FilingTypes.CHANGE_OF_DIRECTORS:
         if (this.isBenBcCccUlc) {
           // correction via Edit UI if current type is BC, CC, ULC, or BEN
+          // To-Do for the future: Revisit this when we do Coop corrections in Edit UI
           this.mutateCurrentFiling(filing)
           this.mutateFileCorrectionDialog(true)
           break

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1403,9 +1403,11 @@ export default class TodoList extends Vue {
         // see also ItemHeaderActions.vue:correctThisFiling()
         switch (item.correctedFilingType) {
           case FilingNames.ALTERATION:
-          case FilingNames.INCORPORATION_APPLICATION:
+          case FilingNames.CHANGE_OF_ADDRESS:
+          case FilingNames.CHANGE_OF_DIRECTORS:
           case FilingNames.CHANGE_OF_REGISTRATION:
           case FilingNames.CORRECTION:
+          case FilingNames.INCORPORATION_APPLICATION:
           case FilingNames.REGISTRATION:
             // resume correction via Edit UI
             const correctionUrl = `${this.getEditUrl}${this.getIdentifier}/correction/?correction-id=${item.filingId}`
@@ -1413,8 +1415,6 @@ export default class TodoList extends Vue {
             break
 
           case FilingTypes.ANNUAL_REPORT:
-          case FilingTypes.CHANGE_OF_ADDRESS:
-          case FilingTypes.CHANGE_OF_DIRECTORS:
           case FilingTypes.CONVERSION:
           default:
             // resume local correction for all other filings

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -449,6 +449,7 @@ import PaymentPaid from './TodoList/PaymentPaid.vue'
 import PaymentPending from './TodoList/PaymentPending.vue'
 import PaymentPendingOnlineBanking from './TodoList/PaymentPendingOnlineBanking.vue'
 import PaymentUnsuccessful from './TodoList/PaymentUnsuccessful.vue'
+import VueRouter from 'vue-router'
 import { AllowableActionsMixin, DateMixin, EnumMixin } from '@/mixins'
 import { EnumUtilities, LegalServices, PayServices } from '@/services/'
 import { AllowableActions, CorpTypeCd, FilingNames, FilingStatus, FilingTypes, Routes } from '@/enums'
@@ -1407,37 +1408,25 @@ export default class TodoList extends Vue {
           case FilingNames.CORRECTION:
           case FilingNames.INCORPORATION_APPLICATION:
           case FilingNames.REGISTRATION:
-            // resume correction via Edit UI
-            const correctionUrl = `${this.getEditUrl}${this.getIdentifier}/correction/?correction-id=${item.filingId}`
-            navigate(correctionUrl)
+            navigateToCorrectionEditUi(this.getEditUrl, this.getIdentifier)
             break
 
           case FilingNames.CHANGE_OF_ADDRESS:
           case FilingNames.CHANGE_OF_DIRECTORS:
             if (this.isBenBcCccUlc) {
-              // resume correction via Edit UI if current type is BC, CC, ULC, or BEN
-              const correctionUrl = `${this.getEditUrl}${this.getIdentifier}/correction/?correction-id=${item.filingId}`
-              navigate(correctionUrl)
+              navigateToCorrectionEditUi(this.getEditUrl, this.getIdentifier)
               break
             } else {
-              // resume local correction otherwise
               this.setCurrentFilingStatus(FilingStatus.DRAFT)
-              this.$router.push({
-                name: Routes.CORRECTION,
-                params: { filingId: item.filingId.toString(), correctedFilingId: item.correctedFilingId.toString() }
-              })
+              routeToLocalCorrection(this.$router)
               break
             }
 
           case FilingTypes.ANNUAL_REPORT:
           case FilingTypes.CONVERSION:
           default:
-            // resume local correction for all other filings
             this.setCurrentFilingStatus(FilingStatus.DRAFT)
-            this.$router.push({
-              name: Routes.CORRECTION,
-              params: { filingId: item.filingId.toString(), correctedFilingId: item.correctedFilingId.toString() }
-            })
+            routeToLocalCorrection(this.$router)
             break
         }
         break
@@ -1519,6 +1508,20 @@ export default class TodoList extends Vue {
         // eslint-disable-next-line no-console
         console.log('doResumeFiling(), invalid type for item =', item)
         break
+    }
+
+    function navigateToCorrectionEditUi (editUrl: string, identifier: string): void {
+      // resume correction via Edit UI
+      const correctionUrl = `${editUrl}${identifier}/correction/?correction-id=${item.filingId}`
+      navigate(correctionUrl)
+    }
+
+    function routeToLocalCorrection (router: VueRouter): void {
+      // resume local correction
+      router.push({
+        name: Routes.CORRECTION,
+        params: { filingId: item.filingId.toString(), correctedFilingId: item.correctedFilingId.toString() }
+      })
     }
   }
 

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1403,8 +1403,6 @@ export default class TodoList extends Vue {
         // see also ItemHeaderActions.vue:correctThisFiling()
         switch (item.correctedFilingType) {
           case FilingNames.ALTERATION:
-          case FilingNames.CHANGE_OF_ADDRESS:
-          case FilingNames.CHANGE_OF_DIRECTORS:
           case FilingNames.CHANGE_OF_REGISTRATION:
           case FilingNames.CORRECTION:
           case FilingNames.INCORPORATION_APPLICATION:
@@ -1413,6 +1411,23 @@ export default class TodoList extends Vue {
             const correctionUrl = `${this.getEditUrl}${this.getIdentifier}/correction/?correction-id=${item.filingId}`
             navigate(correctionUrl)
             break
+
+          case FilingNames.CHANGE_OF_ADDRESS:
+          case FilingNames.CHANGE_OF_DIRECTORS:
+            if (this.isBenBcCccUlc) {
+              // resume correction via Edit UI if current type is BC, CC, ULC, or BEN
+              const correctionUrl = `${this.getEditUrl}${this.getIdentifier}/correction/?correction-id=${item.filingId}`
+              navigate(correctionUrl)
+              break
+            } else {
+              // resume local correction otherwise
+              this.setCurrentFilingStatus(FilingStatus.DRAFT)
+              this.$router.push({
+                name: Routes.CORRECTION,
+                params: { filingId: item.filingId.toString(), correctedFilingId: item.correctedFilingId.toString() }
+              })
+              break
+            }
 
           case FilingTypes.ANNUAL_REPORT:
           case FilingTypes.CONVERSION:

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1414,6 +1414,7 @@ export default class TodoList extends Vue {
           case FilingNames.CHANGE_OF_ADDRESS:
           case FilingNames.CHANGE_OF_DIRECTORS:
             if (this.isBenBcCccUlc) {
+              // To-Do for the future: Revisit this when we do Coop corrections in Edit UI
               navigateToCorrectionEditUi(this.getEditUrl, this.getIdentifier)
               break
             } else {

--- a/tests/unit/TodoList1.spec.ts
+++ b/tests/unit/TodoList1.spec.ts
@@ -2406,9 +2406,16 @@ describe('TodoList - Click Tests - Corrections', () => {
       // await flushPromises()
 
       // verify routing to Correction page with filing id = 123 and corrected filing id = 456
-      expect(vm.$route.name).toBe('correction')
-      expect(vm.$route.params.filingId).toBe('123')
-      expect(vm.$route.params.correctedFilingId).toBe('456')
+      if (test !== 'changeOfAddress' && test !== 'changeOfDirectors') {
+        expect(vm.$route.name).toBe('correction')
+        expect(vm.$route.params.filingId).toBe('123')
+        expect(vm.$route.params.correctedFilingId).toBe('456')
+      } else {
+        // verify redirection if correction of change of Address/Directors
+        const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
+        const editUrl = 'https://edit.url/BC1234567/correction/?correction-id=123'
+        expect(window.location.assign).toHaveBeenCalledWith(editUrl + '&accountid=' + accountId)
+      }
 
       wrapper.destroy()
     })


### PR DESCRIPTION
*Issue #:* bcgov/entity#15892 & bcgov/entity#15893

*Description of changes:*
- Open File Correction dialog when filing a correction for Director & Address change
- Redirect to Edit UI
- Save and resume redirects to Edit UI also
- The ability to correct is dependent on `supported-correction-entities` feature flag. If entity is not supported in a specific environment, the "File a Correction" button will be disabled.

For reference:

https://user-images.githubusercontent.com/122301442/233743788-a1a235ee-b5e3-411f-8c4b-5effd03fdb88.mp4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
