### PR TITLE
16182 Fixed null filing fetch error + fixed Consent orderDetails and effectOfOrder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.3.7",
+  "version": "6.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.3.7",
+      "version": "6.3.8",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.3.7",
+  "version": "6.3.8",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
@@ -4,9 +4,9 @@
       <p class="mt-4">
         This consent is valid <strong>until {{ expiry }} at 12:01 am Pacific time</strong>.
       </p>
-      <p v-if="orderDetails" class="mt-4">{{ orderDetails }}</p>
+      <p v-if="orderDetails" class="mt-4" v-html="orderDetails" />
       <p v-if="fileNumber" class="mt-4 mb-0">Court Order Number: {{ fileNumber }}</p>
-      <p v-if="planOfArrangement" class="mt-0">{{ planOfArrangement }}</p>
+      <p v-if="hasEffectOfOrder" class="mt-0">Pursuant to a Plan of Arrangement</p>
     </template>
   </FilingTemplate>
 </template>
@@ -26,7 +26,6 @@ export default class ConsentContinuationOut extends Vue {
   @Prop({ required: true }) readonly index!: number
 
   get expiry (): string {
-    // FUTURE: expiry date may come from business object
     const expiry = this.filing.data?.consentContinuationOut?.expiry
     if (expiry) {
       return DateUtilities.apiToPacificDate(expiry, true)
@@ -35,7 +34,7 @@ export default class ConsentContinuationOut extends Vue {
   }
 
   get orderDetails (): string {
-    return this.filing.data?.consentContinuationOut?.orderDetails
+    return this.filing.data?.order?.orderDetails?.replace('\n', '<br/>')
   }
 
   /** The court order file number. */
@@ -43,9 +42,9 @@ export default class ConsentContinuationOut extends Vue {
     return this.filing.data?.order?.fileNumber
   }
 
-  /** The court order plan of arrangement. */
-  get planOfArrangement (): string {
-    return this.filing.data?.order?.effectOfOrder ? 'Pursuant to a Plan of Arrangement' : null
+  /** Whether the court order has an effect of order. */
+  get hasEffectOfOrder (): boolean {
+    return Boolean(this.filing.data?.order?.effectOfOrder)
   }
 }
 </script>

--- a/src/components/Dashboard/FilingHistoryList/filings/StaffFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/StaffFiling.vue
@@ -14,9 +14,7 @@
 
     <template #body>
       <div class="staff-filing-details body-2">
-        <p v-if="orderDetails" class="mt-4">
-          {{ orderDetails }}
-        </p>
+        <p v-if="orderDetails" class="mt-4" v-html="orderDetails" />
 
         <!-- if we have documents, show them -->
         <!-- NB: only court orders have documents - see also FilingTemplate.vue -->
@@ -70,7 +68,7 @@ export default class StaffFiling extends Vue {
   }
 
   get orderDetails (): string {
-    return this.filing.data?.order?.orderDetails
+    return this.filing.data?.order?.orderDetails?.replace('\n', '<br/>')
   }
 
   /** The court order file number. */

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -83,7 +83,10 @@ export default {
       const stateFilingUrl = rootGetters.getStateFilingUrl
 
       // if there is no state filing url, return null
-      if (!stateFilingUrl) resolve(null)
+      if (!stateFilingUrl) {
+        resolve(null)
+        return
+      }
 
       LegalServices.fetchFiling(stateFilingUrl)
         .then(filing => {

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -92,7 +92,9 @@
             <section>
               <header>
                 <h2>Documents Delivery</h2>
-                <p class="grey-text">Copies of the consent to continue out documents will be sent to the email addresses listed below.</p>
+                <p class="grey-text">
+                  Copies of the consent to continue out documents will be sent to the email addresses listed below.
+                </p>
               </header>
               <div :class="{ 'invalid-section': !documentDeliveryValid && showErrors }" id="document-delivery-section">
                 <v-card flat class="py-8 px-5">
@@ -112,7 +114,9 @@
             <section>
               <header>
                 <h2>Certify</h2>
-                <p class="grey-text">Enter the legal name of the person authorized to complete and submit this correction.</p>
+                <p class="grey-text">
+                  Enter the legal name of the person authorized to complete and submit this correction.
+                </p>
               </header>
               <div :class="{ 'invalid-section': !certifyFormValid && showErrors }" id="certify-form-section">
                 <Certify
@@ -131,8 +135,10 @@
             <section>
               <header>
                 <h2>Court Order and Plan of Arrangement</h2>
-                <p class="grey-text">If this filing is pursuant to a court order, enter the court order number. If this filing is pursuant
-                  to a plan of arrangement, enter the court order number and select Plan of Arrangement.</p>
+                <p class="grey-text">
+                  If this filing is pursuant to a court order, enter the court order number. If this filing is pursuant
+                  to a plan of arrangement, enter the court order number and select Plan of Arrangement.
+                </p>
               </header>
               <div :class="{ 'invalid-section': !courtOrderValid && showErrors }" id="court-order-section">
                 <v-card flat class="py-8 px-5">

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -245,8 +245,8 @@ import { Certify, DetailComment } from '@/components/common'
 import { ConfirmDialog, PaymentErrorDialog, ResumeErrorDialog, SaveErrorDialog, StaffPaymentDialog }
   from '@/components/dialogs'
 import { CommonMixin, DateMixin, EnumMixin, FilingMixin, ResourceLookupMixin } from '@/mixins'
-import { LegalServices } from '@/services/'
-import { FilingCodes, FilingStatus, FilingTypes, Routes, SaveErrorReasons,
+import { EnumUtilities, LegalServices } from '@/services/'
+import { EffectOfOrderTypes, FilingCodes, FilingStatus, FilingTypes, Routes, SaveErrorReasons,
   StaffPaymentOptions } from '@/enums'
 import { ConfirmDialogType, CourtOrderIF, FilingDataIF, StaffPaymentIF } from '@/interfaces'
 import { CourtOrderPoa } from '@bcrs-shared-components/court-order-poa'
@@ -468,10 +468,10 @@ export default class ConsentContinuationOut extends Vue {
       const comment: string = filing.consentContinuationOut.details || ''
       this.detailComment = comment.split('\n').slice(1).join('\n')
 
-      if (filing.consentContinuationOut.courtOrder) {
-        const courtOrder = filing.consentContinuationOut.courtOrder
+      const courtOrder = filing.consentContinuationOut.courtOrder
+      if (courtOrder) {
         this.fileNumber = courtOrder.fileNumber
-        this.hasPlanOfArrangement = courtOrder.hasPlanOfArrangement
+        this.hasPlanOfArrangement = EnumUtilities.isEffectOfOrderPlanOfArrangement(courtOrder.effectOfOrder)
       }
 
       if (filing.header.documentOptionalEmail) {
@@ -728,7 +728,7 @@ export default class ConsentContinuationOut extends Vue {
     if (this.fileNumber !== '') {
       data[FilingTypes.CONSENT_CONTINUATION_OUT].courtOrder = {
         fileNumber: this.fileNumber,
-        hasPlanOfArrangement: this.hasPlanOfArrangement || false
+        effectOfOrder: (this.hasPlanOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : '') as string
       }
     }
 

--- a/tests/unit/StoreActions.spec.ts
+++ b/tests/unit/StoreActions.spec.ts
@@ -6,7 +6,7 @@ describe('Business Actions', () => {
 
   it('loads dissolution state filing', async () => {
     // init store properties we need
-    store.commit('stateFiling', 'dummy_url')
+    store.commit('setStateFiling', 'dummy_url')
     store.state.corpTypeCd = 'BEN'
 
     // mock filing data and services call
@@ -35,7 +35,7 @@ describe('Business Actions', () => {
 
   it('loads consent to continuation out state filing', async () => {
     // init store properties we need
-    store.commit('stateFiling', 'dummy_url')
+    store.commit('setStateFiling', 'dummy_url')
     store.state.corpTypeCd = 'BEN'
 
     // mock filing data and services call


### PR DESCRIPTION
*Issue #:* bcgov/entity#16182

*Description of changes:*

Commit 1:
- app version = 6.3.8
- get order details from correct filing object (in consent)
- display newlines in order details (consents and staff filings)
- fixed store action fetching null filing
- fixed some lint errors (maxlen)
- fixed broken consent tests
- fixed broken actions tests

Commit 2:
- now restore hasPlanOfArrangement flag from effectOfOrder property
- now save effectOfOrder property depending on hasPlanOfArrangement flag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).