### PR TITLE
Hide "Consent to Continuation Out" menu when historical

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.3.9",
+  "version": "6.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.3.9",
+      "version": "6.3.10",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.11",
@@ -3416,31 +3416,27 @@
       }
     },
     "node_modules/@volar-plugins/vetur": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@volar-plugins/vetur/-/vetur-0.1.0.tgz",
-      "integrity": "sha512-Qaws7TI8d/kkjihSQrW/3YGqiLeLZ1dMjfxDBe4vJKhzXw82sN4+Wr8NwGf2s15KyVDPQTjkPHv6ukn4vFD9Og==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@volar-plugins/vetur/-/vetur-2.0.0.tgz",
+      "integrity": "sha512-RsubwRwnv497I8Dtru8gE/C6P+nmvmMLNnQnyLU3njTqO5Dm4KaBr6cbVl8iQOXHOxfBXzI3lmQSPWdsp3dXRA==",
       "dev": true,
       "dependencies": {
-        "@volar/vue-language-service-types": "^0.34.0",
-        "vls": "^0.8.0",
-        "vscode-html-languageservice": "^5.0.0",
-        "vscode-uri": "^3.0.3"
-      }
-    },
-    "node_modules/@volar/vue-language-service-types": {
-      "version": "0.34.17",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-service-types/-/vue-language-service-types-0.34.17.tgz",
-      "integrity": "sha512-skDO8ZS6Vs0M+zbnYeoBWk7JX8WbCeCohOwnkstqYxXtcqEU4HTeTShhVxrfyWGS0FLHVE79VAhicxjul2EnHw==",
-      "dev": true,
-      "dependencies": {
-        "vscode-languageserver-protocol": "^3.17.1",
-        "vscode-languageserver-textdocument": "^1.0.4"
+        "vls": "^0.8.2",
+        "vscode-html-languageservice": "^5.0.4"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "*"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vscode/l10n": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.10.tgz",
-      "integrity": "sha512-E1OCmDcDWa0Ya7vtSjp/XfHFGqYJfh+YPC1RkATU71fTac+j1JjCcB3qwSzmlKAighx2WxhLlfhS0RwAN++PFQ==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.13.tgz",
+      "integrity": "sha512-A3uY356uOU9nGa+TQIT/i3ziWUgJjVMUrGGXSrtRiTwklyCFjGVWIOHoEIHbJpiyhDkJd9kvIWUOfXK1IkK8XQ==",
       "dev": true
     },
     "node_modules/@vue/babel-helper-vue-jsx-merge-props": {
@@ -22008,34 +22004,15 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "node_modules/vscode-html-languageservice": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.3.tgz",
-      "integrity": "sha512-6rfrtcHhXDMXmC5pR2WXrx02HiNCzQDynOBMn+53zLxr2hvZrDzoc0QgC0FaFGfcglf7GeOsfhkWvJBFC/a70g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.5.tgz",
+      "integrity": "sha512-7788ZT+I7/UhFoI4+bzaAiGGZEW7X39kTeuytLtw6jJA6W7ez85bWKYoFDcwrPNmywj3n/IkU9Op9asaje44jg==",
       "dev": true,
       "dependencies": {
-        "@vscode/l10n": "^0.0.10",
-        "vscode-languageserver-textdocument": "^1.0.7",
-        "vscode-languageserver-types": "^3.17.2",
-        "vscode-uri": "^3.0.6"
-      }
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
-      "dev": true,
-      "dependencies": {
-        "vscode-jsonrpc": "8.0.2",
-        "vscode-languageserver-types": "3.17.2"
+        "@vscode/l10n": "^0.0.13",
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3",
+        "vscode-uri": "^3.0.7"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -22045,9 +22022,9 @@
       "dev": true
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
       "dev": true
     },
     "node_modules/vscode-uri": {
@@ -26547,31 +26524,19 @@
       }
     },
     "@volar-plugins/vetur": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@volar-plugins/vetur/-/vetur-0.1.0.tgz",
-      "integrity": "sha512-Qaws7TI8d/kkjihSQrW/3YGqiLeLZ1dMjfxDBe4vJKhzXw82sN4+Wr8NwGf2s15KyVDPQTjkPHv6ukn4vFD9Og==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@volar-plugins/vetur/-/vetur-2.0.0.tgz",
+      "integrity": "sha512-RsubwRwnv497I8Dtru8gE/C6P+nmvmMLNnQnyLU3njTqO5Dm4KaBr6cbVl8iQOXHOxfBXzI3lmQSPWdsp3dXRA==",
       "dev": true,
       "requires": {
-        "@volar/vue-language-service-types": "^0.34.0",
-        "vls": "^0.8.0",
-        "vscode-html-languageservice": "^5.0.0",
-        "vscode-uri": "^3.0.3"
-      }
-    },
-    "@volar/vue-language-service-types": {
-      "version": "0.34.17",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-service-types/-/vue-language-service-types-0.34.17.tgz",
-      "integrity": "sha512-skDO8ZS6Vs0M+zbnYeoBWk7JX8WbCeCohOwnkstqYxXtcqEU4HTeTShhVxrfyWGS0FLHVE79VAhicxjul2EnHw==",
-      "dev": true,
-      "requires": {
-        "vscode-languageserver-protocol": "^3.17.1",
-        "vscode-languageserver-textdocument": "^1.0.4"
+        "vls": "^0.8.2",
+        "vscode-html-languageservice": "^5.0.4"
       }
     },
     "@vscode/l10n": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.10.tgz",
-      "integrity": "sha512-E1OCmDcDWa0Ya7vtSjp/XfHFGqYJfh+YPC1RkATU71fTac+j1JjCcB3qwSzmlKAighx2WxhLlfhS0RwAN++PFQ==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.13.tgz",
+      "integrity": "sha512-A3uY356uOU9nGa+TQIT/i3ziWUgJjVMUrGGXSrtRiTwklyCFjGVWIOHoEIHbJpiyhDkJd9kvIWUOfXK1IkK8XQ==",
       "dev": true
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
@@ -41399,31 +41364,15 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "vscode-html-languageservice": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.3.tgz",
-      "integrity": "sha512-6rfrtcHhXDMXmC5pR2WXrx02HiNCzQDynOBMn+53zLxr2hvZrDzoc0QgC0FaFGfcglf7GeOsfhkWvJBFC/a70g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.5.tgz",
+      "integrity": "sha512-7788ZT+I7/UhFoI4+bzaAiGGZEW7X39kTeuytLtw6jJA6W7ez85bWKYoFDcwrPNmywj3n/IkU9Op9asaje44jg==",
       "dev": true,
       "requires": {
-        "@vscode/l10n": "^0.0.10",
-        "vscode-languageserver-textdocument": "^1.0.7",
-        "vscode-languageserver-types": "^3.17.2",
-        "vscode-uri": "^3.0.6"
-      }
-    },
-    "vscode-jsonrpc": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
-      "dev": true
-    },
-    "vscode-languageserver-protocol": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
-      "dev": true,
-      "requires": {
-        "vscode-jsonrpc": "8.0.2",
-        "vscode-languageserver-types": "3.17.2"
+        "@vscode/l10n": "^0.0.13",
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3",
+        "vscode-uri": "^3.0.7"
       }
     },
     "vscode-languageserver-textdocument": {
@@ -41433,9 +41382,9 @@
       "dev": true
     },
     "vscode-languageserver-types": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
       "dev": true
     },
     "vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.3.9",
+  "version": "6.3.10",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -146,7 +146,7 @@
             </v-list-item>
 
             <v-list-item
-              v-if="isBenBcCccUlc || isCoop"
+              v-if="!isHistorical && (isBenBcCccUlc || isCoop)"
               data-type="consent-continue-out"
               @click="goToConsentContinuationOutFiling()"
               :disabled="!isAllowed(AllowableActions.CONSENT_CONTINUATION_OUT)"


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
- app version = 6.3.10
- hide "Consent to Continuation Out" menu when historical

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).