### PR TITLE
16153 - Use ccoExpiryDate for Consent ledger badge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.3.10",
+  "version": "6.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.3.10",
+      "version": "6.3.11",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.3.10",
+  "version": "6.3.11",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/EntityInfo/EntityHeader.vue
+++ b/src/components/EntityInfo/EntityHeader.vue
@@ -16,7 +16,7 @@
             small label text-color="white">LIMITED RESTORATION</v-chip>
         </span>
 
-        <span id="authorized-to-continue-out" v-if="isCcoExpired">
+        <span id="authorized-to-continue-out" v-if="isAuthorizedToContinueOut">
           <v-chip class="primary mt-n1 ml-3 pointer-events-none font-weight-bold"
             small label text-color="white">AUTHORIZED TO CONTINUE OUT</v-chip>
         </span>
@@ -55,7 +55,6 @@ export default class EntityHeader extends Vue {
   @Getter isAuthorizedToContinueOut!: boolean
   @Getter isInLimitedRestoration!: boolean
   @Getter isSoleProp!: boolean
-  @Getter isCcoExpired!: boolean
 
   /** The business description. */
   get businessDescription (): string {

--- a/src/components/EntityInfo/EntityHeader.vue
+++ b/src/components/EntityInfo/EntityHeader.vue
@@ -16,7 +16,7 @@
             small label text-color="white">LIMITED RESTORATION</v-chip>
         </span>
 
-        <span id="authorized-to-continue-out" v-if="isAuthorizedToContinueOut">
+        <span id="authorized-to-continue-out" v-if="isCcoExpired">
           <v-chip class="primary mt-n1 ml-3 pointer-events-none font-weight-bold"
             small label text-color="white">AUTHORIZED TO CONTINUE OUT</v-chip>
         </span>
@@ -55,6 +55,7 @@ export default class EntityHeader extends Vue {
   @Getter isAuthorizedToContinueOut!: boolean
   @Getter isInLimitedRestoration!: boolean
   @Getter isSoleProp!: boolean
+  @Getter isCcoExpired!: boolean
 
   /** The business description. */
   get businessDescription (): string {

--- a/src/store/FilingHistoryList/getters.ts
+++ b/src/store/FilingHistoryList/getters.ts
@@ -90,10 +90,8 @@ export default {
     })
     if (ccoFiling) {
       const exp = ccoFiling.data?.consentContinuationOut?.expiry
-      const ccoExpiryDate = DateUtilities.dateToYyyyMmDd(new Date(exp))
-      const currentDate = rootGetters.getCurrentDate
-      const diff = DateUtilities.daysFromToday(new Date(currentDate), new Date(ccoExpiryDate))
-      return diff >= 0
+      const ccoExpiryDate = DateUtilities.apiToDate(exp)
+      return ccoExpiryDate >= new Date()
     }
     return false
   }

--- a/src/store/FilingHistoryList/getters.ts
+++ b/src/store/FilingHistoryList/getters.ts
@@ -81,15 +81,15 @@ export default {
 
   /** Whether the business is authorized to continue out, i.e. true if cco expiry date is present or in the future. */
   isAuthorizedToContinueOut (state: FilingHistoryListStateIF, rootGetters: any): boolean {
-    const ccoFilings = state.filings.filter(val => {
+    const ccoFiling = state.filings.find(val => {
       const exp = val.data?.consentContinuationOut?.expiry
       if (exp) {
         return true
       }
       return false
     })
-    if (ccoFilings && ccoFilings.length > 0) {
-      const exp = ccoFilings[0].data?.consentContinuationOut?.expiry
+    if (ccoFiling) {
+      const exp = ccoFiling.data?.consentContinuationOut?.expiry
       const ccoExpiryDate = DateUtilities.dateToYyyyMmDd(new Date(exp))
       const currentDate = rootGetters.getCurrentDate
       const diff = DateUtilities.daysFromToday(new Date(currentDate), new Date(ccoExpiryDate))

--- a/src/store/FilingHistoryList/getters.ts
+++ b/src/store/FilingHistoryList/getters.ts
@@ -79,7 +79,7 @@ export default {
     return state.loadingOne
   },
 
-  isCcoExpired (state: FilingHistoryListStateIF, rootGetters: any): boolean {
+  isAuthorizedToContinueOut (state: FilingHistoryListStateIF, rootGetters: any): boolean {
     const ccoFilings = state.filings.filter(val => {
       const exp = val.data?.consentContinuationOut?.expiry
       if (exp) {

--- a/src/store/FilingHistoryList/getters.ts
+++ b/src/store/FilingHistoryList/getters.ts
@@ -79,6 +79,7 @@ export default {
     return state.loadingOne
   },
 
+  /** Whether the business is authorized to continue out, i.e. true if cco expiry date is present or in the future. */
   isAuthorizedToContinueOut (state: FilingHistoryListStateIF, rootGetters: any): boolean {
     const ccoFilings = state.filings.filter(val => {
       const exp = val.data?.consentContinuationOut?.expiry

--- a/src/store/FilingHistoryList/getters.ts
+++ b/src/store/FilingHistoryList/getters.ts
@@ -1,5 +1,7 @@
 import { ApiFilingIF, FilingHistoryListStateIF } from '@/interfaces'
 import { DateUtilities, EnumUtilities } from '@/services'
+import getters from '../getters'
+import { Store } from 'vuex'
 
 export default {
   getCurrentFiling (state: FilingHistoryListStateIF): ApiFilingIF {
@@ -77,5 +79,24 @@ export default {
   /** Whether one document is downloading. */
   isLoadingOne (state: FilingHistoryListStateIF): boolean {
     return state.loadingOne
+  },
+
+  isCcoExpired (state: FilingHistoryListStateIF, rootGetters: any): boolean {
+    const filings = rootGetters.getFilings
+    const ccoFilings = state.filings.filter(val => {
+      const exp = val.data?.consentContinuationOut?.expiry
+      if (exp) {
+        return true
+      }
+      return false
+    })
+    if (ccoFilings) {
+      const exp = ccoFilings[0].data?.consentContinuationOut?.expiry
+      const ccoExpiryDate = DateUtilities.dateToYyyyMmDd(new Date(exp))
+      const currentDate = rootGetters.getCurrentDate
+      const diff = DateUtilities.daysFromToday(new Date(currentDate), new Date(ccoExpiryDate))
+      return diff >= 0
+    }
+    return false
   }
 }

--- a/src/store/FilingHistoryList/getters.ts
+++ b/src/store/FilingHistoryList/getters.ts
@@ -1,7 +1,5 @@
 import { ApiFilingIF, FilingHistoryListStateIF } from '@/interfaces'
 import { DateUtilities, EnumUtilities } from '@/services'
-import getters from '../getters'
-import { Store } from 'vuex'
 
 export default {
   getCurrentFiling (state: FilingHistoryListStateIF): ApiFilingIF {
@@ -82,7 +80,6 @@ export default {
   },
 
   isCcoExpired (state: FilingHistoryListStateIF, rootGetters: any): boolean {
-    const filings = rootGetters.getFilings
     const ccoFilings = state.filings.filter(val => {
       const exp = val.data?.consentContinuationOut?.expiry
       if (exp) {

--- a/src/store/FilingHistoryList/getters.ts
+++ b/src/store/FilingHistoryList/getters.ts
@@ -87,7 +87,7 @@ export default {
       }
       return false
     })
-    if (ccoFilings) {
+    if (ccoFilings && ccoFilings.length > 0) {
       const exp = ccoFilings[0].data?.consentContinuationOut?.expiry
       const ccoExpiryDate = DateUtilities.dateToYyyyMmDd(new Date(exp))
       const currentDate = rootGetters.getCurrentDate

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -209,15 +209,5 @@ export default {
         EnumUtilities.isTypeRestorationLimitedExtension(stateFiling)
       )
     )
-  },
-
-  /**
-   * True if the business is authorized to continue out, ie, the state filing is a
-   * Consent to Continuation Out filing.
-   */
-  isAuthorizedToContinueOut (_state: StateIF, getters: any): boolean {
-    const stateFiling = getters.getStateFiling as StateFilingIF // may be null
-
-    return (stateFiling?.hasOwnProperty(FilingTypes.CONSENT_CONTINUATION_OUT) || false)
   }
 }

--- a/tests/unit/EntityHeader.spec.ts
+++ b/tests/unit/EntityHeader.spec.ts
@@ -157,29 +157,16 @@ describe('Entity Header - AUTHORIZED TO CONTINUE OUT badge', () => {
 
   const variations = [
     {
-      currentDate: '2023-11-09',
       filing: {
         data: {
           consentContinuationOut: {
-            expiry: '2023-11-09T08:00:00+00:00'
+            expiry: '2223-11-09T08:00:00+00:00'
           }
         }
       },
       exists: true
     },
     {
-      currentDate: '2023-05-09',
-      filing: {
-        data: {
-          consentContinuationOut: {
-            expiry: '2023-11-09T08:00:00+00:00'
-          }
-        }
-      },
-      exists: true
-    },
-    {
-      currentDate: '2023-05-09',
       filing: {
         data: {
           consentContinuationOut: {
@@ -194,7 +181,6 @@ describe('Entity Header - AUTHORIZED TO CONTINUE OUT badge', () => {
   variations.forEach((_, index) => {
     it(`conditionally displays continue out badge - variation #${index}`, async () => {
       // init store
-      store.state.currentDate = _.currentDate
       store.state.filingHistoryList.filings.push(_.filing)
 
       const wrapper = shallowMount(EntityHeader, {
@@ -211,7 +197,6 @@ describe('Entity Header - AUTHORIZED TO CONTINUE OUT badge', () => {
       }
 
       // cleanup
-      store.state.currentDate = null
       store.state.filingHistoryList.filings.pop()
       wrapper.destroy()
     })

--- a/tests/unit/EntityHeader.spec.ts
+++ b/tests/unit/EntityHeader.spec.ts
@@ -157,33 +157,33 @@ describe('Entity Header - AUTHORIZED TO CONTINUE OUT badge', () => {
 
   const variations = [
     {
-      currentDate: "2023-11-09",
+      currentDate: '2023-11-09',
       filing: {
         data: {
-          consentContinuationOut:{
-            expiry: "2023-11-09T08:00:00+00:00"
+          consentContinuationOut: {
+            expiry: '2023-11-09T08:00:00+00:00'
           }
         }
       },
       exists: true
     },
     {
-      currentDate: "2023-05-09",
+      currentDate: '2023-05-09',
       filing: {
         data: {
-          consentContinuationOut:{
-            expiry: "2023-11-09T08:00:00+00:00"
+          consentContinuationOut: {
+            expiry: '2023-11-09T08:00:00+00:00'
           }
         }
       },
       exists: true
     },
     {
-      currentDate: "2023-05-09",
-      filing:{
+      currentDate: '2023-05-09',
+      filing: {
         data: {
-          consentContinuationOut:{
-            expiry: "2022-11-09T08:00:00+00:00"
+          consentContinuationOut: {
+            expiry: '2022-11-09T08:00:00+00:00'
           }
         }
       },
@@ -216,5 +216,4 @@ describe('Entity Header - AUTHORIZED TO CONTINUE OUT badge', () => {
       wrapper.destroy()
     })
   })
-
 })

--- a/tests/unit/EntityHeader.spec.ts
+++ b/tests/unit/EntityHeader.spec.ts
@@ -156,20 +156,46 @@ describe('Entity Header - AUTHORIZED TO CONTINUE OUT badge', () => {
   const router = mockRouter.mock()
 
   const variations = [
-    { // 0
-      stateFiling: null,
-      exists: false
-    },
-    { // 1
-      stateFiling: { consentContinuationOut: {} },
+    {
+      currentDate: "2023-11-09",
+      filing: {
+        data: {
+          consentContinuationOut:{
+            expiry: "2023-11-09T08:00:00+00:00"
+          }
+        }
+      },
       exists: true
+    },
+    {
+      currentDate: "2023-05-09",
+      filing: {
+        data: {
+          consentContinuationOut:{
+            expiry: "2023-11-09T08:00:00+00:00"
+          }
+        }
+      },
+      exists: true
+    },
+    {
+      currentDate: "2023-05-09",
+      filing:{
+        data: {
+          consentContinuationOut:{
+            expiry: "2022-11-09T08:00:00+00:00"
+          }
+        }
+      },
+      exists: false
     }
   ]
 
   variations.forEach((_, index) => {
     it(`conditionally displays continue out badge - variation #${index}`, async () => {
       // init store
-      store.state.stateFiling = _.stateFiling
+      store.state.currentDate = _.currentDate
+      store.state.filingHistoryList.filings.push(_.filing)
 
       const wrapper = shallowMount(EntityHeader, {
         store,
@@ -185,8 +211,10 @@ describe('Entity Header - AUTHORIZED TO CONTINUE OUT badge', () => {
       }
 
       // cleanup
-      store.state.stateFiling = null
+      store.state.currentDate = null
+      store.state.filingHistoryList.filings.pop()
       wrapper.destroy()
     })
   })
+
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16153

*Description of changes:*

- Badge is shown when Consent to Continuation Out is valid

![image](https://github.com/bcgov/business-filings-ui/assets/60866283/ede6f892-8075-4c22-9cc4-724a10173489)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
