### PR TITLE
16344 Fix pending consent ledger item blurb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.7",
+  "version": "6.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.5.7",
+      "version": "6.5.8",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.7",
+  "version": "6.5.8",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
@@ -50,7 +50,7 @@ export default class ConsentContinuationOut extends Vue {
 
   /** Whether the filing is complete. */
   get isFilingComplete (): boolean {
-    return !EnumUtilities.isStatusPending(this.filing) && Boolean(this.filing.data)
+    return EnumUtilities.isStatusCompleted(this.filing)
   }
 }
 </script>

--- a/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
@@ -48,7 +48,7 @@ export default class ConsentContinuationOut extends Vue {
     return Boolean(this.filing.data?.order?.effectOfOrder)
   }
 
-  /** Whether the filing is pending. */
+  /** Whether the filing is complete. */
   get isFilingComplete (): boolean {
     return !EnumUtilities.isStatusPending(this.filing) && Boolean(this.filing.data)
   }

--- a/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
@@ -1,12 +1,14 @@
 <template>
   <FilingTemplate class="consent-continuation-out" :filing="filing" :index="index">
     <template #body>
-      <p class="mt-4">
-        This consent is valid <strong>until {{ expiry }} at 12:01 am Pacific time</strong>.
-      </p>
-      <p v-if="orderDetails" class="mt-4" v-html="orderDetails" />
-      <p v-if="fileNumber" class="mt-4 mb-0">Court Order Number: {{ fileNumber }}</p>
-      <p v-if="hasEffectOfOrder" class="mt-0">Pursuant to a Plan of Arrangement</p>
+      <div v-if="isFilingComplete">
+        <p class="mt-4">
+          This consent is valid <strong>until {{ expiry }} at 12:01 am Pacific time</strong>.
+        </p>
+        <p v-if="orderDetails" class="mt-4" v-html="orderDetails" />
+        <p v-if="fileNumber" class="mt-4 mb-0">Court Order Number: {{ fileNumber }}</p>
+        <p v-if="hasEffectOfOrder" class="mt-0">Pursuant to a Plan of Arrangement</p>
+      </div>
     </template>
   </FilingTemplate>
 </template>
@@ -15,7 +17,7 @@
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import { ApiFilingIF } from '@/interfaces'
 import FilingTemplate from '../FilingTemplate.vue'
-import { DateUtilities } from '@/services'
+import { DateUtilities, EnumUtilities } from '@/services'
 
 @Component({
   components: { FilingTemplate }
@@ -44,6 +46,11 @@ export default class ConsentContinuationOut extends Vue {
   /** Whether the court order has an effect of order. */
   get hasEffectOfOrder (): boolean {
     return Boolean(this.filing.data?.order?.effectOfOrder)
+  }
+
+  /** Whether the filing is pending. */
+  get isFilingComplete (): boolean {
+    return !EnumUtilities.isStatusPending(this.filing) && Boolean(this.filing.data)
   }
 }
 </script>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16344

*Description of changes:*

- Ensure that the filing object is not pending before showing the item details. If it is pending or it does not contain a `data` object, use the default template.

*Reproducing the issue manually in the code:*

1. Add the following code into the `getFilings` return filter in the file `filingHistoryListStore.ts`:
```
filing.status = FilingStatus.PENDING
delete filing.data
```

2. Make sure `isStatusPaid` in the file `FilingTemplate.vue` always returns `true`.
3. Expand the details on the web app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
