### PR TITLE
16544 Update badge layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.14",
+  "version": "6.5.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.5.14",
+      "version": "6.5.15",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.12",
+  "version": "6.5.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.5.12",
+      "version": "6.5.14",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.14",
+  "version": "6.5.15",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.12",
+  "version": "6.5.14",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/filings/LimitedRestoration.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/LimitedRestoration.vue
@@ -1,17 +1,19 @@
 <template>
   <FilingTemplate class="limited-restoration" :filing="filing" :index="index">
     <template #body>
-      <h4>Limited Restoration Period</h4>
+      <div v-if="isFilingComplete">
+        <h4>Limited Restoration Period</h4>
 
-      <p class="mt-4">
-        The Company <strong>{{ legalName }}</strong> was successfully restored and is active
-        <strong>until {{ expiryDate }}</strong>. At the end of the limited restoration period,
-        the company will be automatically dissolved. If you require assistance to extend a
-        limited restoration/reinstatement or wish to convert your restoration from a limited
-        period to a full restoration, please contact BC Registries staff:
-      </p>
+        <p class="mt-4">
+          The Company <strong>{{ legalName }}</strong> was successfully restored and is active
+          <strong>until {{ expiryDate }}</strong>. At the end of the limited restoration period,
+          the company will be automatically dissolved. If you require assistance to extend a
+          limited restoration/reinstatement or wish to convert your restoration from a limited
+          period to a full restoration, please contact BC Registries staff:
+        </p>
 
-      <ContactInfo class="mt-4" />
+        <ContactInfo class="mt-4" />
+      </div>
     </template>
   </FilingTemplate>
 </template>
@@ -20,7 +22,7 @@
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import { ContactInfo } from '@/components/common'
 import { ApiFilingIF } from '@/interfaces'
-import { DateUtilities } from '@/services'
+import { DateUtilities, EnumUtilities } from '@/services'
 import FilingTemplate from '../FilingTemplate.vue'
 
 @Component({
@@ -43,6 +45,11 @@ export default class LimitedRestoration extends Vue {
     const expiry = this.filing.data?.restoration?.expiry
     const date = DateUtilities.yyyyMmDdToDate(expiry)
     return (DateUtilities.dateToPacificDate(date, true) || '[unknown]')
+  }
+
+  /** Whether the filing is complete. */
+  get isFilingComplete (): boolean {
+    return EnumUtilities.isStatusCompleted(this.filing)
   }
 }
 </script>

--- a/src/components/EntityInfo.vue
+++ b/src/components/EntityInfo.vue
@@ -21,6 +21,7 @@
         <v-col cols="12" md="3">
           <EntityDefinitions
             :businessId="businessId"
+            class="mt-3"
           />
         </v-col>
       </v-row>

--- a/src/components/EntityInfo.vue
+++ b/src/components/EntityInfo.vue
@@ -8,7 +8,7 @@
             :tempRegNumber="tempRegNumber"
           />
           <EntityMenu
-            class="mt-4 ml-n4"
+            class="mt-2 ml-n3"
             v-if="!isInLocalFilingPage"
             :businessId="businessId"
             @confirmDissolution="emitConfirmDissolution()"
@@ -120,16 +120,6 @@ menu > span + span {
 :deep(.v-btn.v-btn--disabled, .v-btn.v-btn--disabled .v-icon) {
   opacity: 0.4 !important;
   color: $app-blue !important;
-}
-
-:deep(#staff-comments .v-btn) {
-  margin-top: -4px; // for vertical alignment
-}
-
-#company-information-button,
-#dissolution-button,
-#download-summary-button {
-  margin-top: -4px; // for vertical alignment
 }
 
 :deep(.v-chip__content) {

--- a/src/components/EntityInfo/EntityDefinitions.vue
+++ b/src/components/EntityInfo/EntityDefinitions.vue
@@ -153,7 +153,6 @@ export default class EntityDefinitions extends Vue {
 dl {
   font-size: $px-14;
   line-height: 1.5rem;
-  margin-top: 0.2rem;
 }
 
 dt {

--- a/src/components/EntityInfo/EntityDefinitions.vue
+++ b/src/components/EntityInfo/EntityDefinitions.vue
@@ -53,6 +53,16 @@
         </v-btn>
       </dd>
     </template>
+
+    <!-- Test - to be deleted -->
+    <template>
+      <div>
+        <dt class="mr-2">Test:</dt>
+        <dd id="test">
+          <span>TEST</span>
+        </dd>
+      </div>
+    </template>
   </dl>
 </template>
 
@@ -143,6 +153,7 @@ export default class EntityDefinitions extends Vue {
 dl {
   font-size: $px-14;
   line-height: 1.5rem;
+  margin-top: 0.2rem;
 }
 
 dt {

--- a/src/components/EntityInfo/EntityDefinitions.vue
+++ b/src/components/EntityInfo/EntityDefinitions.vue
@@ -53,16 +53,6 @@
         </v-btn>
       </dd>
     </template>
-
-    <!-- Test - to be deleted -->
-    <template>
-      <div>
-        <dt class="mr-2">Test:</dt>
-        <dd id="test">
-          <span>TEST</span>
-        </dd>
-      </div>
-    </template>
   </dl>
 </template>
 

--- a/src/components/EntityInfo/EntityHeader.vue
+++ b/src/components/EntityInfo/EntityHeader.vue
@@ -9,8 +9,8 @@
       <!-- Subtitle -->
       <div>
         <span id="business-description">{{ businessDescription }} </span>
-        <span id="limited-restoration-badge-wrap" class="ml-3"  v-if="isInLimitedRestoration">
-          <span id="limited-restoration-badge" class="ml-3">Active until {{ getLimitedRestorationActiveUntil || 'Unknown' }}</span>
+        <span id="active-util-wrap" class="ml-3"  v-if="isInLimitedRestoration">
+          <span id="active-util" class="ml-3">Active until {{ getLimitedRestorationActiveUntil || 'Unknown' }}</span>
         </span>
       </div>
 
@@ -112,14 +112,14 @@ export default class EntityHeader extends Vue {
 
 #business-description,
 #limited-restoration,
-#limited-restoration-badge,
+#active-util,
 #ia-reg-description {
   font-size: $px-14;
   color: $gray7;
 }
 
 // vertical lines between items:
-#limited-restoration-badge-wrap {
+#active-util-wrap {
   border-left: 1px solid $gray3;
 }
 </style>

--- a/src/components/EntityInfo/EntityHeader.vue
+++ b/src/components/EntityInfo/EntityHeader.vue
@@ -18,7 +18,7 @@
         <v-chip
           id="historical-chip"
           class="primary mt-n1 pointer-events-none font-weight-bold"
-            small label text-color="white">HISTORICAL</v-chip>
+          small label text-color="white">HISTORICAL</v-chip>
         <span class="font-14 mx-3">{{ getReasonText || 'Unknown Reason' }}</span>
       </div>
       <div id="multiple-badges" class="mt-2" v-else>

--- a/src/components/EntityInfo/EntityHeader.vue
+++ b/src/components/EntityInfo/EntityHeader.vue
@@ -8,10 +8,8 @@
 
       <!-- Subtitle -->
       <div>
-        <span id="business-description">{{ businessDescription }} </span>
-        <span id="active-util-wrap" class="ml-3"  v-if="isInLimitedRestoration">
-          <span id="active-util" class="ml-3">Active until {{ getLimitedRestorationActiveUntil || 'Unknown' }}</span>
-        </span>
+        <span id="business-description">{{ businessDescription }}</span>
+        <span id="active-util" class="ml-3 pl-3" v-if="isInLimitedRestoration">Active until {{ getLimitedRestorationActiveUntil || 'Unknown' }}</span>
       </div>
 
       <div id="historical" class="mt-2" v-if="isHistorical">
@@ -28,7 +26,7 @@
         </span>
 
         <span id="authorized-to-continue-out" v-if="isAuthorizedToContinueOut">
-          <v-chip :class="dynamicClassForBadges"
+          <v-chip class="primary mt-n1 pointer-events-none font-weight-bold" :class="{ 'ml-3': isInLimitedRestoration }"
             small label text-color="white">AUTHORIZED TO CONTINUE OUT</v-chip>
         </span>
       </div>
@@ -79,12 +77,6 @@ export default class EntityHeader extends Vue {
     }
   }
 
-  get dynamicClassForBadges (): string {
-    const singleBadge = 'primary mt-n1 pointer-events-none font-weight-bold'
-    const multipleBadges = 'primary mt-n1 ml-3 pointer-events-none font-weight-bold'
-    return this.isInLimitedRestoration ? multipleBadges : singleBadge
-  }
-
   /** The incorporation application or registration description. */
   get iaRegDescription (): string {
     const filingName = [CorpTypeCd.SOLE_PROP, CorpTypeCd.PARTNERSHIP].includes(this.getLegalType)
@@ -119,7 +111,7 @@ export default class EntityHeader extends Vue {
 }
 
 // vertical lines between items:
-#active-util-wrap {
+#active-util {
   border-left: 1px solid $gray3;
 }
 </style>

--- a/src/components/EntityInfo/EntityHeader.vue
+++ b/src/components/EntityInfo/EntityHeader.vue
@@ -9,7 +9,9 @@
       <!-- Subtitle -->
       <div>
         <span id="business-description">{{ businessDescription }}</span>
-        <span id="active-util" class="ml-3 pl-3" v-if="isInLimitedRestoration">Active until {{ getLimitedRestorationActiveUntil || 'Unknown' }}</span>
+        <span id="active-util" class="ml-3 pl-3" v-if="isInLimitedRestoration">
+          Active until {{ getLimitedRestorationActiveUntil || 'Unknown' }}
+        </span>
       </div>
 
       <div id="historical" class="mt-2" v-if="isHistorical">

--- a/src/components/EntityInfo/EntityHeader.vue
+++ b/src/components/EntityInfo/EntityHeader.vue
@@ -8,16 +8,27 @@
 
       <!-- Subtitle -->
       <div>
-        <span id="business-description">{{ businessDescription }}</span>
+        <span id="business-description">{{ businessDescription }} </span>
+        <span id="limited-restoration-badge-wrap" class="ml-3"  v-if="isInLimitedRestoration">
+          <span id="limited-restoration-badge" class="ml-3">Active until {{ getLimitedRestorationActiveUntil || 'Unknown' }}</span>
+        </span>
+      </div>
 
-        <span id="limited-restoration" class="ml-3" v-if="isInLimitedRestoration">
-          <span class="ml-3">Active until {{ getLimitedRestorationActiveUntil || 'Unknown' }}</span>
-          <v-chip class="primary mt-n1 ml-3 pointer-events-none font-weight-bold"
+      <div id="historical" class="mt-2" v-if="isHistorical">
+          <v-chip
+            id="historical-chip"
+            class="primary mt-n1 pointer-events-none font-weight-bold"
+             small label text-color="white">HISTORICAL</v-chip>
+          <span class="font-14 mx-3">{{ getReasonText || 'Unknown Reason' }}</span>
+      </div>
+      <div id="multiple-badges" class="mt-2" v-else>
+        <span id="limited-restoration" v-if="isInLimitedRestoration">
+          <v-chip class="primary mt-n1 pointer-events-none font-weight-bold"
             small label text-color="white">LIMITED RESTORATION</v-chip>
         </span>
 
         <span id="authorized-to-continue-out" v-if="isAuthorizedToContinueOut">
-          <v-chip class="primary mt-n1 ml-3 pointer-events-none font-weight-bold"
+          <v-chip :class="dynamicClassForBadges"
             small label text-color="white">AUTHORIZED TO CONTINUE OUT</v-chip>
         </span>
       </div>
@@ -52,7 +63,9 @@ export default class EntityHeader extends Vue {
   @Getter(useBusinessStore) getEntityName!: string
   @Getter(useBusinessStore) getLegalType!: CorpTypeCd
   @Getter(useRootStore) getLimitedRestorationActiveUntil!: string
+  @Getter(useRootStore) getReasonText!: string
   @Getter(useFilingHistoryListStore) isAuthorizedToContinueOut!: boolean
+  @Getter(useBusinessStore) isHistorical!: boolean
   @Getter(useRootStore) isInLimitedRestoration!: boolean
   @Getter(useBusinessStore) isSoleProp!: boolean
 
@@ -64,6 +77,12 @@ export default class EntityHeader extends Vue {
     } else {
       return corpFullDescription
     }
+  }
+
+  get dynamicClassForBadges (): string {
+    const singleBadge = 'primary mt-n1 pointer-events-none font-weight-bold'
+    const multipleBadges = 'primary mt-n1 ml-3 pointer-events-none font-weight-bold'
+    return this.isInLimitedRestoration ? multipleBadges : singleBadge
   }
 
   /** The incorporation application or registration description. */
@@ -93,13 +112,14 @@ export default class EntityHeader extends Vue {
 
 #business-description,
 #limited-restoration,
+#limited-restoration-badge,
 #ia-reg-description {
   font-size: $px-14;
   color: $gray7;
 }
 
 // vertical lines between items:
-#limited-restoration {
+#limited-restoration-badge-wrap {
   border-left: 1px solid $gray3;
 }
 </style>

--- a/src/components/EntityInfo/EntityHeader.vue
+++ b/src/components/EntityInfo/EntityHeader.vue
@@ -15,11 +15,11 @@
       </div>
 
       <div id="historical" class="mt-2" v-if="isHistorical">
-          <v-chip
-            id="historical-chip"
-            class="primary mt-n1 pointer-events-none font-weight-bold"
-             small label text-color="white">HISTORICAL</v-chip>
-          <span class="font-14 mx-3">{{ getReasonText || 'Unknown Reason' }}</span>
+        <v-chip
+          id="historical-chip"
+          class="primary mt-n1 pointer-events-none font-weight-bold"
+            small label text-color="white">HISTORICAL</v-chip>
+        <span class="font-14 mx-3">{{ getReasonText || 'Unknown Reason' }}</span>
       </div>
       <div id="multiple-badges" class="mt-2" v-else>
         <span id="limited-restoration" v-if="isInLimitedRestoration">

--- a/src/components/EntityInfo/EntityMenu.vue
+++ b/src/components/EntityInfo/EntityMenu.vue
@@ -9,16 +9,6 @@
       />
     </span>
 
-    <span v-if="isHistorical">
-      <v-chip
-        id="historical-chip"
-        class="primary mt-n1 ml-4 pointer-events-none" small label text-color="white"
-      >
-        <strong>HISTORICAL</strong>
-      </v-chip>
-      <span class="font-14 mx-3">{{ getReasonText || 'Unknown Reason' }}</span>
-    </span>
-
     <!-- View and Change Business Information -->
     <span v-if="isBusiness && !isHistorical">
       <v-btn
@@ -148,7 +138,6 @@ export default class EntityMenu extends Mixins(AllowableActionsMixin) {
 
   @Getter(useConfigurationStore) getEditUrl!: string
   @Getter(useBusinessStore) getIdentifier!: string
-  @Getter(useRootStore) getReasonText!: string
   @Getter(useBusinessStore) isBenBcCccUlc!: boolean
   @Getter(useBusinessStore) isHistorical!: boolean
   @Getter(useRootStore) isPendingDissolution!: boolean

--- a/src/stores/rootStore.ts
+++ b/src/stores/rootStore.ts
@@ -217,8 +217,9 @@ export const useRootStore = defineStore('root', {
         if (!dissolutionDate) throw new Error('Invalid dissolution date')
         date = DateUtilities.dateToPacificDate(dissolutionDate, true)
       } else {
-        name = filingType === FilingTypes.CONTINUATION_OUT
-          ? 'Continued Out' : EnumUtilities.filingTypeToName(filingType)
+        name = (filingType === FilingTypes.CONTINUATION_OUT)
+          ? 'Continued Out'
+          : EnumUtilities.filingTypeToName(filingType)
         const effectiveDate = DateUtilities.apiToDate(stateFiling.header.effectiveDate)
         if (!effectiveDate) throw new Error('Invalid effective date')
         date = DateUtilities.dateToPacificDateTime(effectiveDate)

--- a/src/stores/rootStore.ts
+++ b/src/stores/rootStore.ts
@@ -217,7 +217,8 @@ export const useRootStore = defineStore('root', {
         if (!dissolutionDate) throw new Error('Invalid dissolution date')
         date = DateUtilities.dateToPacificDate(dissolutionDate, true)
       } else {
-        name = EnumUtilities.filingTypeToName(filingType)
+        name = filingType === FilingTypes.CONTINUATION_OUT
+          ? 'Continued Out' : EnumUtilities.filingTypeToName(filingType)
         const effectiveDate = DateUtilities.apiToDate(stateFiling.header.effectiveDate)
         if (!effectiveDate) throw new Error('Invalid effective date')
         date = DateUtilities.dateToPacificDateTime(effectiveDate)

--- a/tests/unit/EntityHeader.spec.ts
+++ b/tests/unit/EntityHeader.spec.ts
@@ -207,7 +207,7 @@ describe('Entity Header - LIMITED RESTORATION badge', () => {
 
       expect(wrapper.find('#limited-restoration').exists()).toBe(_.exists)
       if (_.exists) {
-        expect(wrapper.find('#active-util-wrap').text()).toContain('Active until')
+        expect(wrapper.find('#active-util').text()).toContain('Active until')
         expect(wrapper.find('#limited-restoration').text()).toContain('LIMITED RESTORATION')
       }
 

--- a/tests/unit/EntityHeader.spec.ts
+++ b/tests/unit/EntityHeader.spec.ts
@@ -109,6 +109,72 @@ describe('Entity Header - data', () => {
   })
 })
 
+describe('Entity Header - HISTORICAL badge', () => {
+  const router = mockRouter.mock()
+
+  const variations = [
+    { // 0
+      entityState: 'ACTIVE',
+      exists: false
+    },
+    { // 1
+      entityState: 'LIQUIDATION',
+      exists: false
+    },
+    { // 2
+      entityState: 'HISTORICAL',
+      stateFiling: null,
+      exists: true,
+      text: 'Unknown Reason'
+    },
+    { // 3
+      entityState: 'HISTORICAL',
+      stateFiling: {
+        header: { name: 'dissolution' },
+        dissolution: {
+          dissolutionDate: '2020-01-01',
+          dissolutionType: 'voluntary'
+        }
+      },
+      exists: true,
+      text: 'Voluntary Dissolution – January 1, 2020'
+    },
+    { // 4
+      entityState: 'HISTORICAL',
+      stateFiling: {
+        header: {
+          name: 'involuntaryDissolution',
+          effectiveDate: '2020-01-01T08:01:00+00:00'
+        }
+      },
+      exists: true,
+      text: 'Involuntary Dissolution – January 1, 2020 at 12:01 am Pacific time'
+    }
+  ]
+
+  variations.forEach((_, index) => {
+    it(`conditionally displays historical badge - variation #${index}`, async () => {
+      // init store
+      businessStore.setState(_.entityState as any)
+      rootStore.setStateFiling(_.stateFiling as any || null)
+
+      const wrapper = shallowMount(EntityHeader, { vuetify, router, propsData: { businessId: 'BC1234567', tempRegNumber: null } })
+      await Vue.nextTick()
+
+      expect(wrapper.find('#historical-chip').exists()).toBe(_.exists)
+      if (_.exists) {
+        expect(wrapper.find('#historical-chip').text()).toBe('HISTORICAL')
+        expect(wrapper.find('#historical-chip + span').text()).toBe(_.text)
+      }
+
+      // cleanup
+      businessStore.setState(null)
+      rootStore.setStateFiling(null)
+      wrapper.destroy()
+    })
+  })
+})
+
 describe('Entity Header - LIMITED RESTORATION badge', () => {
   const router = mockRouter.mock()
 
@@ -141,7 +207,7 @@ describe('Entity Header - LIMITED RESTORATION badge', () => {
 
       expect(wrapper.find('#limited-restoration').exists()).toBe(_.exists)
       if (_.exists) {
-        expect(wrapper.find('#limited-restoration').text()).toContain('Active until')
+        expect(wrapper.find('#active-util-wrap').text()).toContain('Active until')
         expect(wrapper.find('#limited-restoration').text()).toContain('LIMITED RESTORATION')
       }
 

--- a/tests/unit/EntityHeader.spec.ts
+++ b/tests/unit/EntityHeader.spec.ts
@@ -158,7 +158,11 @@ describe('Entity Header - HISTORICAL badge', () => {
       businessStore.setState(_.entityState as any)
       rootStore.setStateFiling(_.stateFiling as any || null)
 
-      const wrapper = shallowMount(EntityHeader, { vuetify, router, propsData: { businessId: 'BC1234567', tempRegNumber: null } })
+      const wrapper = shallowMount(EntityHeader, {
+        vuetify,
+        router,
+        propsData: { businessId: 'BC1234567', tempRegNumber: null }
+      })
       await Vue.nextTick()
 
       expect(wrapper.find('#historical-chip').exists()).toBe(_.exists)

--- a/tests/unit/EntityMenu.spec.ts
+++ b/tests/unit/EntityMenu.spec.ts
@@ -158,69 +158,6 @@ describe('Entity Menu - entities', () => {
   })
 })
 
-describe('Entity Menu - HISTORICAL badge', () => {
-  const router = mockRouter.mock()
-
-  const variations = [
-    { // 0
-      entityState: 'ACTIVE',
-      exists: false
-    },
-    { // 1
-      entityState: 'LIQUIDATION',
-      exists: false
-    },
-    { // 2
-      entityState: 'HISTORICAL',
-      stateFiling: null,
-      exists: true,
-      text: 'Unknown Reason'
-    },
-    { // 3
-      entityState: 'HISTORICAL',
-      stateFiling: {
-        header: { name: 'dissolution' },
-        dissolution: {
-          dissolutionDate: '2020-01-01',
-          dissolutionType: 'voluntary'
-        }
-      },
-      exists: true,
-      text: 'Voluntary Dissolution – January 1, 2020'
-    },
-    { // 4
-      entityState: 'HISTORICAL',
-      stateFiling: {
-        header: {
-          name: 'involuntaryDissolution',
-          effectiveDate: '2020-01-01T08:01:00+00:00'
-        }
-      },
-      exists: true,
-      text: 'Involuntary Dissolution – January 1, 2020 at 12:01 am Pacific time'
-    }
-  ]
-
-  variations.forEach((_, index) => {
-    it(`conditionally displays historical badge - variation #${index}`, async () => {
-      // init store
-      businessStore.setState(_.entityState as any)
-      rootStore.setStateFiling(_.stateFiling as any || null)
-
-      const wrapper = mount(EntityMenu, { vuetify, router, propsData: { businessId: null } })
-      await Vue.nextTick()
-
-      expect(wrapper.find('#historical-chip').exists()).toBe(_.exists)
-      if (_.exists) {
-        expect(wrapper.find('#historical-chip').text()).toBe('HISTORICAL')
-        expect(wrapper.find('#historical-chip + span').text()).toBe(_.text)
-      }
-
-      wrapper.destroy()
-    })
-  })
-})
-
 describe('Entity Menu - View and Change Business Information button', () => {
   const router = mockRouter.mock()
 

--- a/tests/unit/EntityMenu.spec.ts
+++ b/tests/unit/EntityMenu.spec.ts
@@ -42,7 +42,6 @@ describe('Entity Menu - entities', () => {
     await Vue.nextTick()
 
     expect(wrapper.findComponent(StaffComments).exists()).toBe(false)
-    expect(wrapper.find('#historical-chip').exists()).toBe(false)
     expect(wrapper.find('#company-information-button').exists()).toBe(false)
     expect(wrapper.find('.menu-btn').exists()).toBe(false)
     expect(wrapper.find('#download-summary-button').exists()).toBe(false)
@@ -78,7 +77,6 @@ describe('Entity Menu - entities', () => {
     await Vue.nextTick()
 
     expect(wrapper.findComponent(StaffComments).exists()).toBe(true)
-    expect(wrapper.find('#historical-chip').exists()).toBe(false)
     expect(wrapper.find('#company-information-button').exists()).toBe(true)
     expect(wrapper.find('.menu-btn').exists()).toBe(true)
     expect(wrapper.find('#download-summary-button').exists()).toBe(true)
@@ -113,7 +111,6 @@ describe('Entity Menu - entities', () => {
     await Vue.nextTick()
 
     expect(wrapper.findComponent(StaffComments).exists()).toBe(false)
-    expect(wrapper.find('#historical-chip').exists()).toBe(false)
     expect(wrapper.find('#company-information-button').exists()).toBe(false)
     expect(wrapper.find('.menu-btn').exists()).toBe(false)
     expect(wrapper.find('#download-summary-button').exists()).toBe(false)
@@ -148,7 +145,6 @@ describe('Entity Menu - entities', () => {
     await Vue.nextTick()
 
     expect(wrapper.findComponent(StaffComments).exists()).toBe(false)
-    expect(wrapper.find('#historical-chip').exists()).toBe(false)
     expect(wrapper.find('#company-information-button').exists()).toBe(false)
     expect(wrapper.find('#dissolution-button').exists()).toBe(false)
     expect(wrapper.find('#download-summary-button').exists()).toBe(false)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16544

*Description of changes:*
- Move badges to their own line
- Put `active until` beside entity type
- Align top & bottom texts for entity info bar
- Show `HISTORICAL` badge only when business is historical (confirmed with Yui)
- Update unit tests

### Badge layout 1:
*Before:*
![image](https://github.com/bcgov/business-filings-ui/assets/60866283/8d62261f-3f82-487c-b2c6-110530a6f733)
*After:*
![image](https://github.com/bcgov/business-filings-ui/assets/60866283/f5cdb871-7f64-4c54-a98b-acf039bb4b33)

### Badge layout 2:
*Before:*
![image](https://github.com/bcgov/business-filings-ui/assets/60866283/940b014c-ddb8-47bd-b138-0f8d605cedf2)
*After:*
![image](https://github.com/bcgov/business-filings-ui/assets/60866283/0806db73-8924-44cf-9bcc-153039a23c5b)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
