### PR TITLE
16048 Fix broken styling for detail component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.17",
+  "version": "6.5.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.5.17",
+      "version": "6.5.18",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.17",
+  "version": "6.5.18",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/DetailComment.vue
+++ b/src/components/common/DetailComment.vue
@@ -1,17 +1,19 @@
 <template>
   <v-card flat id="detail-comment-container">
-    <v-textarea
-      ref="textarea"
-      auto-grow
-      rows="5"
-      id="detail-comment-textarea"
-      :counter="maxLength"
-      :rules="rules"
-      :value="value"
-      :placeholder="placeholder"
-      :autofocus="autofocus"
-      @input="emitInput($event)"
-    />
+    <v-row no-gutters class="pl-4 pr-4 pt-2 pb-2">
+      <v-textarea
+        ref="textarea"
+        auto-grow
+        rows="5"
+        id="detail-comment-textarea"
+        :counter="maxLength"
+        :rules="rules"
+        :value="value"
+        :placeholder="placeholder"
+        :autofocus="autofocus"
+        @input="emitInput($event)"
+      />
+    </v-row>
   </v-card>
 </template>
 

--- a/src/components/common/DetailComment.vue
+++ b/src/components/common/DetailComment.vue
@@ -1,19 +1,17 @@
 <template>
   <v-card flat id="detail-comment-container">
-    <v-row no-gutters class="pl-4 pr-4 pt-2 pb-2">
-      <v-textarea
-        ref="textarea"
-        auto-grow
-        rows="5"
-        id="detail-comment-textarea"
-        :counter="maxLength"
-        :rules="rules"
-        :value="value"
-        :placeholder="placeholder"
-        :autofocus="autofocus"
-        @input="emitInput($event)"
-      />
-    </v-row>
+    <v-textarea
+      ref="textarea"
+      auto-grow
+      rows="5"
+      id="detail-comment-textarea"
+      :counter="maxLength"
+      :rules="rules"
+      :value="value"
+      :placeholder="placeholder"
+      :autofocus="autofocus"
+      @input="emitInput($event)"
+    />
   </v-card>
 </template>
 

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -75,12 +75,16 @@
                 <p>Enter a detail that will appear on the ledger for this entity.</p>
                 <p class="black--text mb-0">{{defaultComment}}</p>
               </header>
-              <DetailComment
-                v-model="detailComment"
-                placeholder="Add a Detail that will appear on the ledger for this entity."
-                :maxLength="maxDetailCommentLength"
-                @valid="detailCommentValid=$event"
-              />
+              <v-card flat>
+                <div no-gutters class="px-4 py-2">
+                  <DetailComment
+                    v-model="detailComment"
+                    placeholder="Add a Detail that will appear on the ledger for this entity."
+                    :maxLength="maxDetailCommentLength"
+                    @valid="detailCommentValid=$event"
+                  />
+                </div>
+              </v-card>
             </section>
 
             <!-- Certify -->

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -76,14 +76,13 @@
                 <p class="black--text mb-0">{{defaultComment}}</p>
               </header>
               <v-card flat>
-                <div class="px-4 py-2">
-                  <DetailComment
-                    v-model="detailComment"
-                    placeholder="Add a Detail that will appear on the ledger for this entity."
-                    :maxLength="maxDetailCommentLength"
-                    @valid="detailCommentValid=$event"
-                  />
-                </div>
+                <DetailComment
+                  class="px-4 py-2"
+                  v-model="detailComment"
+                  placeholder="Add a Detail that will appear on the ledger for this entity."
+                  :maxLength="maxDetailCommentLength"
+                  @valid="detailCommentValid=$event"
+                />
               </v-card>
             </section>
 

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -76,7 +76,7 @@
                 <p class="black--text mb-0">{{defaultComment}}</p>
               </header>
               <v-card flat>
-                <div no-gutters class="px-4 py-2">
+                <div class="px-4 py-2">
                   <DetailComment
                     v-model="detailComment"
                     placeholder="Add a Detail that will appear on the ledger for this entity."


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16048

*Description of changes:*

I set the padding of the `v-textarea` to match the padding of the content inside the src/components/common/Certify.vue component (included in the screenshots). In that component, the content is wrapped with a `v-row` with `class` attributes to add padding. I did the same for the `v-textarea`, however it also works if it is wrapped in a plain old `div` with the same `class` attributes. I went with the `v-row` for consistency, however I also get if it doesn't make the most sense semantically and would be open to using a `div` instead.

I'll get UX to have a look after reviews to see if they have any preferences on the padding amount.

*Screenshot of changes:*

![fix](https://github.com/bcgov/business-filings-ui/assets/122323255/9ecc9cab-474f-44eb-9849-4f6156950e36)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
