### PR TITLE
16356 Update the light grey text to meet AA contrast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.20",
+  "version": "6.5.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.5.20",
+      "version": "6.5.21",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.5.20",
+  "version": "6.5.21",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -232,7 +232,7 @@ ul.list {
 }
 
 .list-item__subtitle {
-  color: $gray6;
+  color: $gray7;
 }
 
 .list-item__actions {
@@ -259,13 +259,9 @@ ul.list {
 
 .no-results__subtitle {
   margin-top: 0.25rem;
-  color: $gray6;
+  color: $gray7;
   @extend .font-14;
   font-weight: 500;
-}
-
-.gray6 {
-  color: $gray6;
 }
 
 .white-background {

--- a/src/components/Dashboard/AddressListSm.vue
+++ b/src/components/Dashboard/AddressListSm.vue
@@ -271,7 +271,7 @@ $icon-width: 2.75rem;
 
 // Complete filing required styling
 .complete-filing {
-  color: $gray6;
+  color: $gray7;
   font-size: $px-14;
   white-space: pre-wrap;
 }

--- a/src/components/Dashboard/CustodianListSm.vue
+++ b/src/components/Dashboard/CustodianListSm.vue
@@ -88,7 +88,7 @@ $avatar-width: 2.75rem;
 // Complete filing required styling
 .complete-filing {
   padding: 2rem;
-  color: $gray6;
+  color: $gray7;
   font-size: $px-14;
   white-space: pre-wrap;
   display: inline-block;

--- a/src/components/Dashboard/DirectorListSm.vue
+++ b/src/components/Dashboard/DirectorListSm.vue
@@ -116,7 +116,7 @@ $avatar-width: 2.75rem;
 // Complete filing required styling
 .complete-filing {
   padding: 2rem;
-  color: $gray6;
+  color: $gray7;
   font-size: $px-14;
   white-space: pre-wrap;
   display: inline-block;

--- a/src/components/Dashboard/FilingHistoryList/FilingTemplate.vue
+++ b/src/components/Dashboard/FilingHistoryList/FilingTemplate.vue
@@ -170,7 +170,7 @@ export default class FilingTemplate extends Vue {
 }
 
 .item-header-subtitle {
-  color: $gray6;
+  color: $gray7;
   margin-top: 0.5rem;
 }
 

--- a/src/components/Dashboard/FilingHistoryList/filings/AlterationFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/AlterationFiling.vue
@@ -141,7 +141,7 @@ export default class AlterationFiling extends Vue {
 @import "@/assets/styles/theme.scss";
 
 .item-header-subtitle {
-  color: $gray6;
+  color: $gray7;
   margin-top: 0.5rem;
 }
 

--- a/src/components/Dashboard/FilingHistoryList/filings/ChangeOfAddress.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/ChangeOfAddress.vue
@@ -53,7 +53,7 @@ export default class ChangeOfAddress extends Vue {
 @import "@/assets/styles/theme.scss";
 
 .item-header-subtitle {
-  color: $gray6;
+  color: $gray7;
   margin-top: 0.5rem;
 }
 

--- a/src/components/Dashboard/FilingHistoryList/filings/DissolutionVoluntary.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/DissolutionVoluntary.vue
@@ -148,7 +148,7 @@ export default class DissolutionVoluntary extends Vue {
 @import "@/assets/styles/theme.scss";
 
 .item-header-subtitle {
-  color: $gray6;
+  color: $gray7;
   margin-top: 0.5rem;
 }
 

--- a/src/components/Dashboard/FilingHistoryList/filings/IncorporationApplication.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/IncorporationApplication.vue
@@ -113,7 +113,7 @@ export default class IncorporationApplication extends Vue {
 @import "@/assets/styles/theme.scss";
 
 .item-header-subtitle {
-  color: $gray6;
+  color: $gray7;
   margin-top: 0.5rem;
 }
 

--- a/src/components/Dashboard/FilingHistoryList/filings/StaffFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/StaffFiling.vue
@@ -86,7 +86,7 @@ export default class StaffFiling extends Vue {
 @import "@/assets/styles/theme.scss";
 
 .item-header-subtitle {
-  color: $gray6;
+  color: $gray7;
   margin-top: 0.5rem;
 }
 

--- a/src/components/Dashboard/FilingHistoryList/subtitles/FiledAndPaid.vue
+++ b/src/components/Dashboard/FilingHistoryList/subtitles/FiledAndPaid.vue
@@ -22,6 +22,6 @@ export default class FiledAndPaid extends Vue {
 @import "@/assets/styles/theme.scss";
 
 .filed-and-paid {
-  color: $gray6;
+  color: $gray7;
 }
 </style>

--- a/src/components/Dashboard/FilingHistoryList/subtitles/FiledAndPendingPaid.vue
+++ b/src/components/Dashboard/FilingHistoryList/subtitles/FiledAndPendingPaid.vue
@@ -40,7 +40,7 @@ export default class FiledAndPendingPaid extends Vue {
 @import "@/assets/styles/theme.scss";
 
 .filed-and-pending-paid {
-  color: $gray6;
+  color: $gray7;
 }
 
 .details-btn {

--- a/src/components/Dashboard/FilingHistoryList/subtitles/FutureEffectiveFiledAndPendingCoa.vue
+++ b/src/components/Dashboard/FilingHistoryList/subtitles/FutureEffectiveFiledAndPendingCoa.vue
@@ -49,6 +49,6 @@ export default class FutureEffectiveFiledAndPendingCoa extends Vue {
 }
 
 .future-effective-filed-and-pending-coa {
-  color: $gray6;
+  color: $gray7;
 }
 </style>

--- a/src/components/Dashboard/FilingHistoryList/subtitles/FutureEffectivePaid.vue
+++ b/src/components/Dashboard/FilingHistoryList/subtitles/FutureEffectivePaid.vue
@@ -59,7 +59,7 @@ export default class FutureEffectivePaid extends Vue {
 @import "@/assets/styles/theme.scss";
 
 .future-effective-paid {
-  color: $gray6;
+  color: $gray7;
 }
 
 .details-btn {

--- a/src/components/Dashboard/FirmsAddressList.vue
+++ b/src/components/Dashboard/FirmsAddressList.vue
@@ -148,7 +148,7 @@ $icon-width: 2.75rem;
 
 // Complete filing required styling
 .complete-filing {
-  color: $gray6;
+  color: $gray7;
   font-size: $px-14;
   white-space: pre-wrap;
 }

--- a/src/components/Dashboard/ProprietorPartnersListSm.vue
+++ b/src/components/Dashboard/ProprietorPartnersListSm.vue
@@ -147,7 +147,7 @@ $avatar-width: 2.75rem;
 // Complete filing required styling
 .complete-filing {
   padding: 2rem;
-  color: $gray6;
+  color: $gray7;
   font-size: $px-14;
   white-space: pre-wrap;
   display: inline-block;

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -1484,7 +1484,7 @@ ul {
 // Director Display
 .director-info {
   display: flex;
-  color: $gray6;
+  color: $gray7;
 
   .status {
     flex: 1 1 auto;

--- a/src/components/common/SummaryDirectors.vue
+++ b/src/components/common/SummaryDirectors.vue
@@ -347,7 +347,7 @@ ul {
 // Director Display
 .director-info {
   display: flex;
-  color: $gray6;
+  color: $gray7;
 
   .status {
     flex: 1 1 auto;

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -1231,7 +1231,7 @@ article {
 
 header p,
 section p {
-  color: $gray6;
+  color: $gray7;
 }
 
 section + section {

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -941,7 +941,7 @@ article {
 
 header p,
 section p {
-  color: $gray6;
+  color: $gray7;
 }
 
 section + section {

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -916,7 +916,7 @@ article {
 
 header p,
 section p {
-  color: $gray6;
+  color: $gray7;
 }
 
 section + section {

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -837,7 +837,7 @@ article {
 
 header p,
 section p {
-  color: $gray6;
+  color: $gray7;
 }
 
 section + section {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -397,6 +397,6 @@ section header {
 
 .section-count {
   color: $gray9;
-  font-weight: 500;
+  font-weight: normal;
 }
 </style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -15,7 +15,7 @@
             <section v-if="alertCount > 0" id="dashboard-alerts-section" class="mb-n6">
               <header>
                 <h2 class="mb-3">
-                  <span>Alerts</span>&nbsp;<span class="gray6">({{ alertCount }})</span>
+                  <span>Alerts</span>&nbsp;<span class="section-count">({{ alertCount }})</span>
                 </h2>
               </header>
               <!-- FUTURE: move these to a new Alerts component and inside one expansion panel -->
@@ -29,7 +29,7 @@
             <section id="dashboard-todo-section">
               <header>
                 <h2 class="mb-3">
-                  <span>To Do</span>&nbsp;<span class="gray6">({{todoCount}})</span>
+                  <span>To Do</span>&nbsp;<span class="section-count">({{todoCount}})</span>
                 </h2>
               </header>
               <LegalObligation />
@@ -43,7 +43,7 @@
             <section id="dashboard-filing-history-section">
               <header>
                 <h2>
-                  <span>Recent Filing History</span>&nbsp;<span class="gray6">({{getHistoryCount}})</span>
+                  <span>Recent Filing History</span>&nbsp;<span class="section-count">({{getHistoryCount}})</span>
                 </h2>
                 <StaffNotation
                   v-if="isRoleStaff && !!businessId"
@@ -374,6 +374,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import "@/assets/styles/theme.scss";
+
 section header {
   display: flex;
   flex-direction: row;
@@ -391,5 +393,10 @@ section header {
 
 .pending-tooltip {
   max-width: 16.5rem;
+}
+
+.section-count {
+  color: $gray9;
+  font-weight: 500;
 }
 </style>

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -989,7 +989,7 @@ article {
 
 header p,
 section p {
-  color: $gray6;
+  color: $gray7;
 }
 
 section + section {

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -865,7 +865,7 @@ article {
 
 header p,
 section p {
-  color: $gray6;
+  color: $gray7;
 }
 
 section + section {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16356

*Description of changes:*

- Made the section numbers regular font weight and #212529 color
- Made the business detail ledger subtitles #495957 color
- Made other filing subtitles #495957 color

There are a couple places where the old gray color (gray6, #868E96) was used for UI elements (action button in `Directors.vue` and vertical bars in `base.scss`). I have held off on updating the gray in these places and have limited the changes to text only. If required, I can expand the changes to these UI elements as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
