### PR TITLE
Hotfix continuation out certify component after eslint update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.6.0",
+      "version": "6.6.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -212,8 +212,8 @@
               >
                 <Certify
                   ref="certifyRef"
-                  isCertified.sync="isCertified"
-                  certifiedBy.sync="certifiedBy"
+                  :isCertified.sync="isCertified"
+                  :certifiedBy.sync="certifiedBy"
                   :class="{ 'invalid-component': !certifyFormValid && showErrors }"
                   :entityDisplay="displayName()"
                   :message="certifyText(FilingCodes.CONTINUATION_OUT)"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16552

*Description of changes:*
- Certify component was broken after the eslint presets update. 
<img width="1440" alt="broken cont out" src="https://github.com/bcgov/business-filings-ui/assets/122301442/88775a86-c978-4696-abb2-c36ebf63af34">

This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
