### PR TITLE
17216 - add start date while building dissolution filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.8.1",
+  "version": "6.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.8.1",
+      "version": "6.8.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.8.1",
+  "version": "6.8.2",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/business-interfaces.ts
+++ b/src/interfaces/business-interfaces.ts
@@ -53,6 +53,7 @@ export interface ApiBusinessIF {
   nextAnnualReport: ApiDateTimeUtc // BCOMP only
   state: EntityState
   stateFiling: string // the state filing URL
+  startDate: ApiDateTimeUtc
   submitter?: string // not used
   taxId?: string // aka Business Number // may be absent
   warnings: Array<BusinessWarningIF>

--- a/src/interfaces/dissolution-interfaces.ts
+++ b/src/interfaces/dissolution-interfaces.ts
@@ -29,6 +29,7 @@ export interface DissolutionFilingIF {
     legalName: string
     identifier: string
     foundingDate: string
+    startDate: string
   }
   dissolution: DissolutionIF
 }

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -32,6 +32,7 @@ export default class FilingMixin extends DateMixin {
   @Getter(useBusinessStore) getIdentifier!: string
   @Getter(useBusinessStore) getLegalType!: CorpTypeCd
   @Getter(useRootStore) getRegisteredOfficeAddress!: OfficeAddressIF
+  @Getter(useBusinessStore) getStartDate!: Date
 
   /**
    * Adds/removes filing code and/or sets flags in the Filing Data object.
@@ -128,7 +129,9 @@ export default class FilingMixin extends DateMixin {
         foundingDate: this.dateToApi(this.getFoundingDate),
         identifier: this.getIdentifier,
         legalName: this.entityName,
-        legalType: this.getLegalType
+        legalType: this.getLegalType,
+        startDate: this.dateToApi(this.getStartDate)
+
       },
       dissolution: {
         custodialOffice: this.getRegisteredOfficeAddress,

--- a/src/mixins/filing-mixin.ts
+++ b/src/mixins/filing-mixin.ts
@@ -32,7 +32,7 @@ export default class FilingMixin extends DateMixin {
   @Getter(useBusinessStore) getIdentifier!: string
   @Getter(useBusinessStore) getLegalType!: CorpTypeCd
   @Getter(useRootStore) getRegisteredOfficeAddress!: OfficeAddressIF
-  @Getter(useBusinessStore) getStartDate!: Date
+  @Getter(useBusinessStore) getStartDate!: string
 
   /**
    * Adds/removes filing code and/or sets flags in the Filing Data object.
@@ -130,7 +130,7 @@ export default class FilingMixin extends DateMixin {
         identifier: this.getIdentifier,
         legalName: this.entityName,
         legalType: this.getLegalType,
-        startDate: this.dateToApi(this.getStartDate)
+        startDate: this.getStartDate
 
       },
       dissolution: {

--- a/src/stores/businessStore.ts
+++ b/src/stores/businessStore.ts
@@ -1,4 +1,4 @@
-import { AllowedActionsIF, ApiBusinessIF, BusinessStateIF, BusinessWarningIF } from '@/interfaces'
+import { AllowedActionsIF, ApiBusinessIF, ApiDateTimeUtc, BusinessStateIF, BusinessWarningIF } from '@/interfaces'
 import { defineStore } from 'pinia'
 import { CorpTypeCd, EntityState } from '@/enums'
 import { DateUtilities, LegalServices } from '@/services/'
@@ -59,8 +59,8 @@ export const useBusinessStore = defineStore('business', {
     },
 
     /** The start date. */
-    getStartDate (state: BusinessStateIF): Date {
-      return DateUtilities.apiToDate(state.businessInfo.startDate)
+    getStartDate (state: BusinessStateIF): string {
+      return state.businessInfo.startDate
     },
 
     /** The business identifier (aka Incorporation Number). */
@@ -224,7 +224,7 @@ export const useBusinessStore = defineStore('business', {
       this.businessInfo.foundingDate = val
     },
 
-    setStartDate (val: string) {
+    setStartDate (val: ApiDateTimeUtc) {
       this.businessInfo.startDate = val
     },
 

--- a/src/stores/businessStore.ts
+++ b/src/stores/businessStore.ts
@@ -27,6 +27,7 @@ export const useBusinessStore = defineStore('business', {
       nextAnnualReport: null,
       state: null,
       stateFiling: null,
+      startDate: null,
       warnings: []
     }
   }),
@@ -55,6 +56,11 @@ export const useBusinessStore = defineStore('business', {
     /** The founding date. */
     getFoundingDate (state: BusinessStateIF): Date {
       return DateUtilities.apiToDate(state.businessInfo.foundingDate)
+    },
+
+    /** The start date. */
+    getStartDate (state: BusinessStateIF): Date {
+      return DateUtilities.apiToDate(state.businessInfo.startDate)
     },
 
     /** The business identifier (aka Incorporation Number). */
@@ -216,6 +222,10 @@ export const useBusinessStore = defineStore('business', {
 
     setFoundingDate (val: string) {
       this.businessInfo.foundingDate = val
+    },
+
+    setStartDate (val: string) {
+      this.businessInfo.startDate = val
     },
 
     setGoodStanding (val: boolean) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17216

*Description of changes:*

Add start date while building dissolution filing. This is a cleaner solution and start date can be saved to and fetched from `draftFiling` when filing a Dissolution in Create UI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
