### PR TITLE
Make Certify block non-editable if non-staff user (AGM Filings)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "6.9.5",
+  "version": "6.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "6.9.5",
+      "version": "6.9.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "6.9.5",
+  "version": "6.9.6",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/AgmExtension.vue
+++ b/src/views/AgmExtension.vue
@@ -97,6 +97,7 @@
                   :isCertified.sync="isCertified"
                   :certifiedBy.sync="certifiedBy"
                   :class="{ 'invalid-certify': !certifyFormValid && showErrors }"
+                  :disableEdit="!isRoleStaff"
                   :entityDisplay="displayName()"
                   :message="certifyText(FilingCodes.AGM_EXTENSION)"
                   @valid="certifyFormValid=$event"

--- a/src/views/AgmLocationChg.vue
+++ b/src/views/AgmLocationChg.vue
@@ -192,6 +192,7 @@
                   :isCertified.sync="isCertified"
                   :certifiedBy.sync="certifiedBy"
                   :class="{ 'invalid-certify': !certifyFormValid && showErrors }"
+                  :disableEdit="!isRoleStaff"
                   :entityDisplay="displayName()"
                   :message="certifyText(FilingCodes.AGM_LOCATION_CHANGE)"
                   @valid="certifyFormValid=$event"
@@ -419,7 +420,7 @@ export default class AgmLocationChg extends Mixins(CommonMixin, DateMixin,
   mounted (): void {
     // Pre-populate the certified block with the logged in user's name (if not staff)
     if (!this.isRoleStaff && this.getUserInfo) {
-      this.certifiedBy = this.getUserInfo.firstname + ' ' + this.getUserInfo.lastName
+      this.certifiedBy = this.getUserInfo.firstname + ' ' + this.getUserInfo.lastname
     }
 
     // always include agm location change code

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -507,9 +507,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
 
     // Pre-populate the certified block with the logged in user's name (if not staff)
     if (!this.isRoleStaff && this.getUserInfo) {
-      const firstName = this.getUserInfo?.firstname
-      const lastName = this.getUserInfo?.lastname
-      this.certifiedBy = firstName + ' ' + lastName
+      this.certifiedBy = this.getUserInfo.firstname + ' ' + this.getUserInfo.lastname
     }
 
     // always include consent continue out code


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18161

*Description of changes:*
- Certify block is now not editable for non-staff users (AGM filings)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
