### PR TITLE
18513 Fixed jerky expandable help transition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.0.6",
+      "version": "7.0.7",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",
@@ -17,7 +17,7 @@
         "@bcrs-shared-components/date-picker": "1.2.34",
         "@bcrs-shared-components/document-delivery": "1.2.1",
         "@bcrs-shared-components/enums": "1.0.51",
-        "@bcrs-shared-components/expandable-help": "^1.0.0",
+        "@bcrs-shared-components/expandable-help": "1.0.1",
         "@bcrs-shared-components/folio-number-input": "1.1.18",
         "@bcrs-shared-components/interfaces": "1.0.76",
         "@bcrs-shared-components/mixins": "1.1.27",
@@ -283,7 +283,9 @@
       "version": "1.0.13"
     },
     "node_modules/@bcrs-shared-components/expandable-help": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/expandable-help/-/expandable-help-1.0.1.tgz",
+      "integrity": "sha512-XhSYX1sSpoBUfCg5AoTe/1fKuOOtxuhhykhefRw8r+j34GK4hTJzeHYaUJBbXD87r2RkdITu3IFS4kA1yZm3OA==",
       "dependencies": {
         "vue": "^2.7.14"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",
@@ -22,7 +22,7 @@
     "@bcrs-shared-components/date-picker": "1.2.34",
     "@bcrs-shared-components/document-delivery": "1.2.1",
     "@bcrs-shared-components/enums": "1.0.51",
-    "@bcrs-shared-components/expandable-help": "^1.0.0",
+    "@bcrs-shared-components/expandable-help": "1.0.1",
     "@bcrs-shared-components/folio-number-input": "1.1.18",
     "@bcrs-shared-components/interfaces": "1.0.76",
     "@bcrs-shared-components/mixins": "1.1.27",


### PR DESCRIPTION
*Issue #:* bcgov/entity#18513

*Description of changes:*
- app version = 7.0.7
- imported latest ExpandableHelp component (to fix jerky transition)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).