### PR TITLE
18469 Capitalize AGM in output titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.10",
+  "version": "7.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.0.10",
+      "version": "7.0.11",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.10",
+  "version": "7.0.11",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/services/enum-utilities.ts
+++ b/src/services/enum-utilities.ts
@@ -299,6 +299,8 @@ export default class EnumUtilities {
       case FilingTypes.ADMIN_FREEZE:
         // FUTURE: add freeze/unfreeze checks here
         return FilingNames.ADMIN_FREEZE
+      case FilingTypes.AGM_EXTENSION: return FilingNames.AGM_EXTENSION
+      case FilingTypes.AGM_LOCATION_CHANGE: return FilingNames.AGM_LOCATION_CHANGE
       case FilingTypes.ALTERATION: return FilingNames.ALTERATION
       case FilingTypes.ANNUAL_REPORT: return FilingNames.ANNUAL_REPORT + (agmYear ? ` (${agmYear})` : '')
       case FilingTypes.CHANGE_OF_ADDRESS: return FilingNames.CHANGE_OF_ADDRESS
@@ -332,13 +334,15 @@ export default class EnumUtilities {
   }
 
   /**
-   * Converts a string in "camelCase" (or "PascalCase") to separate, title-case words,
+   * Converts a string in "camelCase" (or "PascalCase") to a string of separate, title-case words,
    * suitable for a title or proper name.
    * @param s the string to convert
    * @returns the converted string
    */
   static camelCaseToWords (s: string): string {
-    return s?.split(/(?=[A-Z])/).join(' ').replace(/^\w/, c => c.toUpperCase()) || ''
+    const words = s?.split(/(?=[A-Z])/).join(' ').replace(/^\w/, c => c.toUpperCase()) || ''
+    // SPECIAL CASE: convert 'Agm' to uppercase
+    return words.replace('Agm', 'AGM')
   }
 
   /**

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -1,8 +1,8 @@
 // Libraries
 import axios from '@/axios-auth'
 import { AxiosResponse } from 'axios'
-import { ApiBusinessIF, ApiFilingIF, CommentIF, DocumentIF, FetchDocumentsIF, NameRequestIF,
-  PresignedUrlIF } from '@/interfaces'
+import { ApiBusinessIF, ApiFilingIF, CommentIF, DocumentIF, FetchDocumentsIF, PresignedUrlIF }
+  from '@/interfaces'
 import { DigitalCredentialTypes, FilingStatus, Roles } from '@/enums'
 import { StatusCodes } from 'http-status-codes'
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#18469

*Description of changes:*
- app version = 7.0.11
- added missing cases for AGM filings
- added special case to convert "Agm" to "AGM"
- fixed a lint warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).