### PR TITLE
19005 Implemented historical - amalgamation reason text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.29",
+  "version": "7.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.0.29",
+      "version": "7.0.30",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.29",
+  "version": "7.0.30",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -528,7 +528,7 @@
             </div>
           </template>
 
-          <!-- is this a draft IA or Registration? -->
+          <!-- is this a draft Amalgamation or IA or Registration? -->
           <template
             v-else-if="isStatusDraft(item) && (isTypeAmalgamation(item) || isTypeIncorporationApplication(item) ||
               isTypeRegistration(item))"

--- a/src/interfaces/business-state-interfaces.ts
+++ b/src/interfaces/business-state-interfaces.ts
@@ -1,4 +1,5 @@
 import { EntityState, CorpTypeCd, FilingSubTypes, FilingTypes } from '@/enums'
+import { AmalgamationTypes } from '@bcrs-shared-components/enums'
 import { IsoDatePacific, ApiDateTimeUtc } from '@bcrs-shared-components/interfaces'
 
 export interface FilingTypeIF {
@@ -16,6 +17,13 @@ export interface AllowedActionsIF {
   }
 }
 
+export interface AmalgamatedIntoIF {
+  amalgamationDate: ApiDateTimeUtc
+  amalgamationType: AmalgamationTypes
+  identifier: string // eg, BC7654321
+  legalName: string
+}
+
 export interface BusinessWarningIF {
   code: string // FUTURE: use an enum
   filing?: string // not used
@@ -28,6 +36,7 @@ export interface BusinessWarningIF {
 export interface ApiBusinessIF {
   adminFreeze: boolean
   allowedActions: AllowedActionsIF
+  amalgamatedInto?: AmalgamatedIntoIF
   arMaxDate?: IsoDatePacific // not used
   arMinDate?: IsoDatePacific // not used
   associationType: string // COOP only

--- a/src/mixins/enum-mixin.ts
+++ b/src/mixins/enum-mixin.ts
@@ -70,6 +70,11 @@ export default class EnumMixin extends Vue {
     return (item.name === FilingTypes.CORRECTION)
   }
 
+  /** DEPRECATED Returns True if filing is a Dissolution. */
+  isTypeDissolution (item: any): boolean {
+    return (item.name === FilingTypes.DISSOLUTION)
+  }
+
   /** DEPRECATED Returns True if filing is an Incorporation Application. */
   isTypeIncorporationApplication (item: any): boolean {
     return (item.name === FilingTypes.INCORPORATION_APPLICATION)

--- a/src/services/enum-utilities.ts
+++ b/src/services/enum-utilities.ts
@@ -127,6 +127,11 @@ export default class EnumUtilities {
     return (item.name === FilingTypes.CORRECTION)
   }
 
+  /** Returns True if filing is a Dissolution. */
+  static isTypeDissolution (item: any): boolean {
+    return (item.name === FilingTypes.DISSOLUTION)
+  }
+
   /** Returns True if filing is an Amalgamation. */
   static isTypeAmalgamation (item: any): boolean {
     return (item.name === FilingTypes.AMALGAMATION_APPLICATION)

--- a/src/stores/businessStore.ts
+++ b/src/stores/businessStore.ts
@@ -1,4 +1,5 @@
-import { AllowedActionsIF, ApiBusinessIF, ApiDateTimeUtc, BusinessStateIF, BusinessWarningIF } from '@/interfaces'
+import { AllowedActionsIF, AmalgamatedIntoIF, ApiBusinessIF, ApiDateTimeUtc, BusinessStateIF, BusinessWarningIF }
+  from '@/interfaces'
 import { defineStore } from 'pinia'
 import { CorpTypeCd, EntityState } from '@/enums'
 import { DateUtilities, LegalServices } from '@/services/'
@@ -34,9 +35,14 @@ export const useBusinessStore = defineStore('business', {
   }),
 
   getters: {
-    /** The allowed actions object. */
+    /** The Allowed Actions object. */
     getAllowedActions (state: BusinessStateIF): AllowedActionsIF {
       return state.businessInfo.allowedActions
+    },
+
+    /** The Amalgamated Info object. */
+    getAmalgamatedInto (state: BusinessStateIF): AmalgamatedIntoIF {
+      return state.businessInfo.amalgamatedInto
     },
 
     /** The business number (aka Tax ID). */
@@ -49,7 +55,7 @@ export const useBusinessStore = defineStore('business', {
       return state.businessInfo.warnings
     },
 
-    /** The business state.businessInfo. */
+    /** The business state. */
     getBusinessState (state: BusinessStateIF): EntityState {
       return state.businessInfo.state
     },

--- a/src/stores/filingHistoryListStore.ts
+++ b/src/stores/filingHistoryListStore.ts
@@ -38,7 +38,7 @@ export const useFilingHistoryListStore = defineStore('filingHistoryList', {
       })
     },
 
-    /** Returns the total AGM extension duration requires argument for year */
+    /** The function to compute total AGM extension duration. Requires argument for AGM Year. */
     getTotalAgmExtensionDuration (state: FilingHistoryListStateIF): (year: number) => number {
       return (year: number) => {
         return state.filings.reduce((totalMonths, filing) => {
@@ -47,11 +47,11 @@ export const useFilingHistoryListStore = defineStore('filingHistoryList', {
             return totalMonths
           }
           const filingExtension = filing.data?.agmExtension
-          // Cast year as number
           // Skip if extension data is missing
           if (!filingExtension) {
             return totalMonths
           }
+          // Cast year as number
           // Skip if years don't match
           if (Number(filingExtension.year) !== year) {
             return totalMonths

--- a/src/views/AgmExtension.vue
+++ b/src/views/AgmExtension.vue
@@ -454,7 +454,7 @@ export default class AgmExtension extends Mixins(CommonMixin, DateMixin,
         ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
-    } catch (error) {
+    } catch (error: any) {
       // save errors or warnings, if any
       this.saveErrors = error?.response?.data?.errors || []
       this.saveWarnings = error?.response?.data?.warnings || []

--- a/src/views/AgmLocationChg.vue
+++ b/src/views/AgmLocationChg.vue
@@ -561,7 +561,7 @@ export default class AgmLocationChg extends Mixins(CommonMixin, DateMixin,
         ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
-    } catch (error) {
+    } catch (error: any) {
       // save errors or warnings, if any
       this.saveErrors = error?.response?.data?.errors || []
       this.saveWarnings = error?.response?.data?.warnings || []

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -1134,7 +1134,7 @@ export default class AnnualReport extends Mixins(CommonMixin, DateMixin, FilingM
         ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
-    } catch (error) {
+    } catch (error: any) {
       // save errors or warnings, if any
       this.saveErrors = error?.response?.data?.errors || []
       this.saveWarnings = error?.response?.data?.warnings || []

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -847,7 +847,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
         ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
-    } catch (error) {
+    } catch (error: any) {
       // save errors or warnings, if any
       this.saveErrors = error?.response?.data?.errors || []
       this.saveWarnings = error?.response?.data?.warnings || []

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -838,7 +838,7 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
         ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
-    } catch (error) {
+    } catch (error: any) {
       // save errors or warnings, if any
       this.saveErrors = error?.response?.data?.errors || []
       this.saveWarnings = error?.response?.data?.warnings || []

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -755,7 +755,7 @@ export default class Correction extends Mixins(CommonMixin, DateMixin, EnumMixin
         ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
-    } catch (error) {
+    } catch (error: any) {
       // save errors or warnings, if any
       this.saveErrors = error?.response?.data?.errors || []
       this.saveWarnings = error?.response?.data?.warnings || []

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -879,7 +879,7 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
         ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
-    } catch (error) {
+    } catch (error: any) {
       // save errors or warnings, if any
       this.saveErrors = error?.response?.data?.errors || []
       this.saveWarnings = error?.response?.data?.warnings || []

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -755,7 +755,7 @@ export default class StandaloneOfficeAddressFiling extends Mixins(CommonMixin, D
         ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
       }
       return ret
-    } catch (error) {
+    } catch (error: any) {
       // save errors or warnings, if any
       this.saveErrors = error?.response?.data?.errors || []
       this.saveWarnings = error?.response?.data?.warnings || []


### PR DESCRIPTION
*Issue #:* bcgov/entity#19005

*Description of changes:*
- app version = 7.0.30
- updated some code comments
- added AmalgamatedInto interface object
- added enum mixin and utility functions
- added some business store getters
- refactored getReasonText() and added case for amalgamation
- cast some parameters to pre-empt code errors
- added/updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).

**Note:** This cannot be tested "for real" until a business is made historical by an amalgamation. I tested locally using mocked data as per the RFC / ticket. I also wrote some unit tests that verify all cases, so you can check there for the expected output.