### PR TITLE
19204 Fixed whitespace between sub-title and body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.36",
+  "version": "7.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.0.36",
+      "version": "7.0.37",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.36",
+  "version": "7.0.37",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -233,7 +233,9 @@ export default class FilingHistoryList extends Mixins(FilingMixin) {
 }
 
 :deep(.v-expansion-panel-header) {
+  min-height: auto !important;
   padding: 0;
+  margin-top: 0.25rem;
 
   .v-expansion-panel-header__icon {
     display: none;

--- a/src/components/Dashboard/FilingHistoryList/FilingTemplate.vue
+++ b/src/components/Dashboard/FilingHistoryList/FilingTemplate.vue
@@ -53,7 +53,7 @@
       </div>
     </v-expansion-panel-header>
 
-    <v-expansion-panel-content>
+    <v-expansion-panel-content class="pt-5">
       <slot name="body">
         <!-- is this a generic paid (not yet completed) filing? -->
         <div


### PR DESCRIPTION
*Issue #:* bcgov/entity#19204

*Description of changes:*
- app version = 7.0.37
- removed min-height (which simulated padding when it's a single line)
- added top margin (whitespace whether it's a single or wrapped line)
- added top padding to body for all filings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).