### PR TITLE
19823 Revert pre-set numbered option for regular amalgamation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.44",
+  "version": "7.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.0.44",
+      "version": "7.0.45",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.44",
+  "version": "7.0.45",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -128,9 +128,8 @@ export default class HeaderActions extends Mixins(AllowableActionsMixin) {
     conditions[3] = () => (EnumUtilities.isTypeIncorporationApplication(this.filing) &&
       !this.isBenBcCccUlc && !this.isCoop)
     conditions[4] = () => (EnumUtilities.isTypeChangeOfRegistration(this.filing) && !this.isFirm)
-    conditions[5] = () => (EnumUtilities.isTypeCorrection(this.filing) &&
-      !this.isFirm && !this.isBenBcCccUlc &&
-      !this.isCoop)
+    conditions[5] = () => (EnumUtilities.isTypeCorrection(this.filing) && !this.isFirm &&
+      !this.isBenBcCccUlc && !this.isCoop)
     conditions[6] = () => (EnumUtilities.isTypeRegistration(this.filing) && !this.isFirm)
     conditions[7] = () => (EnumUtilities.isTypeAmalgamation(this.filing) && !this.isBenBcCccUlc)
 

--- a/src/views/AmalgamationSelection.vue
+++ b/src/views/AmalgamationSelection.vue
@@ -226,9 +226,7 @@ export default class AmalgamationSelection extends Vue {
     const email = this.isShortFormAmalgamation(type) ? this.getBusinessEmail : ''
     const phone = this.isShortFormAmalgamation(type) ? this.getFullPhoneNumber : ''
     const legalName = this.isShortFormAmalgamation(type) ? this.getLegalName : ''
-    const correctNameOption = this.isShortFormAmalgamation(type)
-      ? CorrectNameOptions.CORRECT_AML_ADOPT
-      : CorrectNameOptions.CORRECT_AML_NUMBERED
+    const correctNameOption = this.isShortFormAmalgamation(type) ? CorrectNameOptions.CORRECT_AML_ADOPT : null
 
     const draftAmalgamationApplication = {
       filing: {


### PR DESCRIPTION
*Issue #:* bcgov/entity#19823

*Description of changes:*
- app version = 7.0.45
- removed numbered option for non-short-form (ie, regular) amalgamation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).