### PR TITLE
16756 Added special Court Order / POA handling in Consent for Continuation Out filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.47",
+  "version": "7.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.0.47",
+      "version": "7.0.48",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.47",
+  "version": "7.0.48",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -5,7 +5,7 @@
       attach="#todo-list"
     />
 
-    <GenericErrorDialog
+    <AffiliationErrorDialog
       :dialog="fetchAffiliationInvitationsErrorDialog"
       attach="#todo-list"
       icon-color="error"
@@ -18,9 +18,9 @@
           <br> Please try again later.
         </div>
       </template>
-    </GenericErrorDialog>
+    </AffiliationErrorDialog>
 
-    <GenericErrorDialog
+    <AffiliationErrorDialog
       :dialog="authorizeAffiliationInvitationErrorDialog"
       attach="#todo-list"
       icon-color="error"
@@ -33,7 +33,7 @@
           <br> Please try again later.
         </div>
       </template>
-    </GenericErrorDialog>
+    </AffiliationErrorDialog>
 
     <DeleteErrorDialog
       :dialog="deleteErrorDialog"
@@ -584,7 +584,8 @@ import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import axios from '@/axios-auth'
 import { GetFeatureFlag, navigate } from '@/utils'
-import { CancelPaymentErrorDialog, ConfirmDialog, DeleteErrorDialog } from '@/components/dialogs'
+import { AffiliationErrorDialog, CancelPaymentErrorDialog, ConfirmDialog, DeleteErrorDialog }
+  from '@/components/dialogs'
 import { ContactInfo, NameRequestInfo } from '@/components/common'
 import AffiliationInvitationDetails from './TodoList/AffiliationInvitationDetails.vue'
 import ConversionDetails from './TodoList/ConversionDetails.vue'
@@ -619,15 +620,14 @@ import {
 } from '@/interfaces'
 import { GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module'
 import { useBusinessStore, useConfigurationStore, useFilingHistoryListStore, useRootStore } from '@/stores'
-import GenericErrorDialog from '@/components/dialogs/GenericErrorDialog.vue'
 
 @Component({
   components: {
     // dialogs
+    AffiliationErrorDialog,
     CancelPaymentErrorDialog,
     ConfirmDialog,
     DeleteErrorDialog,
-    GenericErrorDialog,
     // components
     AffiliationInvitationDetails,
     ConversionDetails,

--- a/src/components/common/ContactInfo.vue
+++ b/src/components/common/ContactInfo.vue
@@ -10,7 +10,7 @@
       >
         mdi-phone
       </v-icon>
-      <span class="px-2">Canada and U.S. Toll Free:</span>
+      <span class="px-2 font-weight-bold">Canada and U.S. Toll Free:</span>
       <a
         href="tel:+1-877-526-1526"
         class="contact-value"
@@ -26,7 +26,7 @@
       >
         mdi-phone
       </v-icon>
-      <span class="px-2">Victoria Office:</span>
+      <span class="px-2 font-weight-bold">Victoria Office:</span>
       <a
         href="tel:+1-250-387-7848"
         class="contact-value"
@@ -42,7 +42,7 @@
       >
         mdi-email
       </v-icon>
-      <span class="px-2">Email:</span>
+      <span class="px-2 font-weight-bold">Email:</span>
       <a
         href="mailto:BCRegistries@gov.bc.ca"
         class="contact-value"

--- a/src/components/dialogs/AffiliationErrorDialog.vue
+++ b/src/components/dialogs/AffiliationErrorDialog.vue
@@ -1,0 +1,95 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    width="45rem"
+    persistent
+    :attach="attach"
+    content-class="affiliation-error-dialog"
+  >
+    <v-card>
+      <v-container>
+        <v-row justify="center">
+          <v-col cols="2" />
+          <v-col
+            cols="8"
+            lg="8"
+            class="text-center"
+          >
+            <v-icon
+              size="48"
+              :color="iconColor"
+              class="mb-6"
+            >
+              {{ icon }}
+            </v-icon>
+          </v-col>
+          <v-col cols="2">
+            <v-icon
+              color="primary"
+              class="mb-6 float-right"
+              @click="okay()"
+            >
+              mdi-close
+            </v-icon>
+          </v-col>
+        </v-row>
+        <v-row justify="center">
+          <v-col
+            cols="12"
+            lg="8"
+            class="text-center"
+          >
+            <h1
+              class="mb-5"
+              style="font-size: 24px"
+            >
+              {{ summary }}
+            </h1>
+            <p
+              class="mb-9"
+              style="font-size: 16px"
+            >
+              <slot name="description">
+                {{ description }}
+              </slot>
+            </p>
+            <slot name="actions">
+              <v-btn
+                large
+                link
+                color="primary"
+                @click="okay()"
+              >
+                OK
+              </v-btn>
+            </slot>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Emit, Vue } from 'vue-property-decorator'
+
+@Component({
+  components: {}
+})
+export default class AffiliationErrorDialog extends Vue {
+  @Prop({ default: '' }) private summary: string
+  @Prop({ default: '' }) private description: string
+  @Prop({ default: 'mdi-information-outline' }) private icon: string
+  @Prop({ default: 'primary' }) private iconColor: string
+
+  /** Prop to display the dialog. */
+  @Prop({ default: false }) readonly dialog!: boolean
+
+  /** Prop to provide attachment selector. */
+  @Prop({ default: '' }) readonly attach!: string
+
+  // Pass click event to parent.
+  @Emit() okay () {
+  }
+}
+</script>

--- a/src/components/dialogs/GenericErrorDialog.vue
+++ b/src/components/dialogs/GenericErrorDialog.vue
@@ -5,91 +5,57 @@
     persistent
     :attach="attach"
     content-class="generic-error-dialog"
+    @keydown.esc="close()"
   >
     <v-card>
-      <v-container>
-        <v-row justify="center">
-          <v-col cols="2" />
-          <v-col
-            cols="8"
-            lg="8"
-            class="text-center"
-          >
-            <v-icon
-              size="48"
-              :color="iconColor"
-              class="mb-6"
-            >
-              {{ icon }}
-            </v-icon>
-          </v-col>
-          <v-col cols="2">
-            <v-icon
-              color="primary"
-              class="mb-6 float-right"
-              @click="okay()"
-            >
-              mdi-close
-            </v-icon>
-          </v-col>
-        </v-row>
-        <v-row justify="center">
-          <v-col
-            cols="12"
-            lg="8"
-            class="text-center"
-          >
-            <h1
-              class="mb-5"
-              style="font-size: 24px"
-            >
-              {{ summary }}
-            </h1>
-            <p
-              class="mb-9"
-              style="font-size: 16px"
-            >
-              <slot name="description">
-                {{ description }}
-              </slot>
-            </p>
-            <slot name="actions">
-              <v-btn
-                large
-                link
-                color="primary"
-                @click="okay()"
-              >
-                OK
-              </v-btn>
-            </slot>
-          </v-col>
-        </v-row>
-      </v-container>
+      <v-card-title>{{ title }}</v-card-title>
+
+      <v-card-text class="pre-wrap">
+        <div
+          v-show="!!text"
+          class="font-15"
+          v-html="text"
+        />
+
+        <ContactInfo class="mt-6" />
+      </v-card-text>
+
+      <v-card-actions class="justify-center pt-0 pb-9">
+        <v-btn
+          color="primary"
+          large
+          @click="close()"
+        >
+          Close
+        </v-btn>
+      </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Emit, Vue } from 'vue-property-decorator'
+import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
+import ContactInfo from '@/components/common/ContactInfo.vue'
 
 @Component({
-  components: {}
+  components: {
+    ContactInfo
+  }
 })
 export default class GenericErrorDialog extends Vue {
-  @Prop({ default: '' }) private summary: string
-  @Prop({ default: '' }) private description: string
-  @Prop({ default: 'mdi-information-outline' }) private icon: string
-  @Prop({ default: 'primary' }) private iconColor: string
-
-  /** Prop to display the dialog. */
-  @Prop({ default: false }) readonly dialog!: boolean
-
-  /** Prop to provide attachment selector. */
   @Prop({ default: '' }) readonly attach!: string
+  @Prop({ default: false }) readonly dialog!: boolean
+  @Prop({ default: 'Please contact us:' }) readonly text!: string
+  @Prop({ default: 'An error occurred' }) readonly title!: string
 
-  // Pass click event to parent.
-  @Emit() okay () {
-  }
+  @Emit() close (): void {}
 }
 </script>
+
+<style lang="scss" scoped>
+@import '@/assets/styles/theme.scss';
+
+.v-card__text {
+  color: $gray7 !important;
+}
+</style>

--- a/src/components/dialogs/index.ts
+++ b/src/components/dialogs/index.ts
@@ -1,5 +1,6 @@
 import AddCommentDialog from './AddCommentDialog.vue'
 import AddStaffNotationDialog from './AddStaffNotationDialog.vue'
+import AffiliationErrorDialog from './AffiliationErrorDialog.vue'
 import BusinessAuthErrorDialog from './BusinessAuthErrorDialog.vue'
 import CancelPaymentErrorDialog from './CancelPaymentErrorDialog.vue'
 import CoaWarningDialog from './CoaWarningDialog.vue'
@@ -10,6 +11,7 @@ import DeleteErrorDialog from './DeleteErrorDialog.vue'
 import DownloadErrorDialog from './DownloadErrorDialog.vue'
 import FetchErrorDialog from './FetchErrorDialog.vue'
 import FileCorrectionDialog from './FileCorrectionDialog.vue'
+import GenericErrorDialog from './GenericErrorDialog.vue'
 import LoadCorrectionDialog from './LoadCorrectionDialog.vue'
 import NameRequestAuthErrorDialog from './NameRequestAuthErrorDialog.vue'
 import NameRequestInvalidDialog from './NameRequestInvalidDialog.vue'
@@ -24,6 +26,7 @@ import TechnicalErrorDialog from './TechnicalErrorDialog.vue'
 export {
   AddCommentDialog,
   AddStaffNotationDialog,
+  AffiliationErrorDialog,
   BusinessAuthErrorDialog,
   CancelPaymentErrorDialog,
   CoaWarningDialog,
@@ -34,6 +37,7 @@ export {
   DownloadErrorDialog,
   FetchErrorDialog,
   FileCorrectionDialog,
+  GenericErrorDialog,
   LoadCorrectionDialog,
   NameRequestAuthErrorDialog,
   NameRequestInvalidDialog,

--- a/src/stores/businessStore.ts
+++ b/src/stores/businessStore.ts
@@ -116,7 +116,7 @@ export const useBusinessStore = defineStore('business', {
       return state.businessInfo.stateFiling
     },
 
-    /** Is true of the business has a court order filing */
+    /** Is true of the business has a court order filing. */
     hasCourtOrders (state: BusinessStateIF): boolean {
       return state.businessInfo.hasCourtOrders
     },

--- a/tests/unit/ConsentContinuationOut.spec.ts
+++ b/tests/unit/ConsentContinuationOut.spec.ts
@@ -45,7 +45,7 @@ describe('Consent to Continuation Out view', () => {
     businessStore.setIdentifier('CP1234567')
     businessStore.setFoundingDate('1971-05-12T00:00:00-00:00')
     rootStore.filingData = []
-    rootStore.keycloakRoles = ['staff'] // consent to continuation outs currently apply to staff only
+    rootStore.keycloakRoles = ['staff']
   })
 
   it('mounts the sub-components properly', async () => {
@@ -384,7 +384,7 @@ describe('Consent to Continue Out for general user and IAs only', () => {
     // verify sub-components
     expect(wrapper.findComponent(Certify).exists()).toBe(true)
     expect(wrapper.findComponent(ConfirmDialog).exists()).toBe(true)
-    expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(true)
+    expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(false) // staff only
     expect(wrapper.findComponent(DetailComment).exists()).toBe(true)
     expect(wrapper.findComponent(DocumentDelivery).exists()).toBe(true)
     expect(wrapper.findComponent(ForeignJurisdiction).exists()).toBe(true)

--- a/tests/unit/GenericErrorDialog.spec.ts
+++ b/tests/unit/GenericErrorDialog.spec.ts
@@ -1,0 +1,61 @@
+import { mount } from '@vue/test-utils'
+import Vuetify from 'vuetify'
+import GenericErrorDialog from '@/dialogs/GenericErrorDialog.vue'
+import RegistriesContactInfo from '@/components/common/RegistriesContactInfo.vue'
+
+const vuetify = new Vuetify({})
+
+describe('GenericErrorDialog.vue', () => {
+  it('does not render the dialog when disabled', () => {
+    const wrapper = mount(GenericErrorDialog, {
+      vuetify
+    })
+
+    expect(wrapper.find('div[role="dialog"]').exists()).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('renders the dialog with default text and title', () => {
+    const wrapper = mount(GenericErrorDialog, {
+      vuetify,
+      propsData: { dialog: true }
+    })
+
+    expect(wrapper.find('div[role="dialog"]').exists()).toBe(true)
+    expect(wrapper.find('.v-card__title').text()).toBe('An error occurred')
+    expect(wrapper.find('.v-card__text > div').text()).toBe('Please contact us:')
+    expect(wrapper.find('.v-card__text').findComponent(RegistriesContactInfo).exists()).toBe(true)
+    expect(wrapper.find('.v-card__actions').text()).toBe('Close')
+
+    wrapper.destroy()
+  })
+
+  it('renders the dialog with custom text and title', () => {
+    const wrapper = mount(GenericErrorDialog, {
+      vuetify,
+      propsData: { dialog: true, text: 'Custom text', title: 'Custom title' }
+    })
+
+    expect(wrapper.find('div[role="dialog"]').exists()).toBe(true)
+    expect(wrapper.find('.v-card__title').text()).toBe('Custom title')
+    expect(wrapper.find('.v-card__text > div').text()).toBe('Custom text')
+    expect(wrapper.find('.v-card__text').findComponent(RegistriesContactInfo).exists()).toBe(true)
+    expect(wrapper.find('.v-card__actions').text()).toBe('Close')
+
+    wrapper.destroy()
+  })
+
+  it('emits close event when the Close button is clicked', async () => {
+    const wrapper = mount(GenericErrorDialog, {
+      vuetify,
+      propsData: { dialog: true }
+    })
+
+    expect(wrapper.emitted('close')).toBeUndefined()
+    await wrapper.find('.v-btn').trigger('click')
+    expect(wrapper.emitted('close')).toEqual([[]])
+
+    wrapper.destroy()
+  })
+})

--- a/tests/unit/GenericErrorDialog.spec.ts
+++ b/tests/unit/GenericErrorDialog.spec.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils'
 import Vuetify from 'vuetify'
-import GenericErrorDialog from '@/dialogs/GenericErrorDialog.vue'
-import RegistriesContactInfo from '@/components/common/RegistriesContactInfo.vue'
+import GenericErrorDialog from '@/components/dialogs/GenericErrorDialog.vue'
+import ContactInfo from '@/components/common/ContactInfo.vue'
 
 const vuetify = new Vuetify({})
 
@@ -25,7 +25,7 @@ describe('GenericErrorDialog.vue', () => {
     expect(wrapper.find('div[role="dialog"]').exists()).toBe(true)
     expect(wrapper.find('.v-card__title').text()).toBe('An error occurred')
     expect(wrapper.find('.v-card__text > div').text()).toBe('Please contact us:')
-    expect(wrapper.find('.v-card__text').findComponent(RegistriesContactInfo).exists()).toBe(true)
+    expect(wrapper.find('.v-card__text').findComponent(ContactInfo).exists()).toBe(true)
     expect(wrapper.find('.v-card__actions').text()).toBe('Close')
 
     wrapper.destroy()
@@ -40,7 +40,7 @@ describe('GenericErrorDialog.vue', () => {
     expect(wrapper.find('div[role="dialog"]').exists()).toBe(true)
     expect(wrapper.find('.v-card__title').text()).toBe('Custom title')
     expect(wrapper.find('.v-card__text > div').text()).toBe('Custom text')
-    expect(wrapper.find('.v-card__text').findComponent(RegistriesContactInfo).exists()).toBe(true)
+    expect(wrapper.find('.v-card__text').findComponent(ContactInfo).exists()).toBe(true)
     expect(wrapper.find('.v-card__actions').text()).toBe('Close')
 
     wrapper.destroy()


### PR DESCRIPTION
*Issue #:* bcgov/entity#16756

*Description of changes:*
- app version = 7.0.48
- bolded contact info labels (per design)
- renamed GenericErrorDialog -> AffiliationErrorDialog
- created GenericErrorDialog (same as Create UI)
- added new dialog, properties and logic to ConsentContinuationOut view
- make Court Order / POA section render for staff only
- added test suite for new dialog

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).