### PR TITLE
20072 Deleted Court Order dialog + added fallbacks for null business email/phone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.48",
+  "version": "7.0.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.0.48",
+      "version": "7.0.49",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.48",
+  "version": "7.0.49",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/AmalgamationSelection.vue
+++ b/src/views/AmalgamationSelection.vue
@@ -245,8 +245,8 @@ export default class AmalgamationSelection extends Vue {
           },
           type,
           contactPoint: {
-            email,
-            phone
+            email: email || '',
+            phone: phone || ''
           }
         }
       }

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -779,7 +779,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
       header: {
         name: FilingTypes.CONSENT_CONTINUATION_OUT,
         certifiedBy: this.certifiedBy || '',
-        email: this.getBusinessEmail,
+        email: this.getBusinessEmail || '',
         date: this.getCurrentDate // NB: API will reassign this date according to its clock
       }
     }

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -5,14 +5,6 @@
       attach="#consent-continuation-out"
     />
 
-    <GenericErrorDialog
-      attach="#consent-continuation-out"
-      :dialog="courtOrderDialog"
-      :text="courtOrderDialogText"
-      :title="courtOrderDialogTitle"
-      @close="courtOrderDialog=false; goToDashboard()"
-    />
-
     <PaymentErrorDialog
       attach="#consent-continuation-out"
       filingName="Consent to Continuation Out"
@@ -335,8 +327,8 @@ import { StatusCodes } from 'http-status-codes'
 import { navigate } from '@/utils'
 import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
 import { Certify, DetailComment, ForeignJurisdiction } from '@/components/common'
-import { ConfirmDialog, GenericErrorDialog, PaymentErrorDialog, ResumeErrorDialog, SaveErrorDialog,
-  StaffPaymentDialog } from '@/components/dialogs'
+import { ConfirmDialog, PaymentErrorDialog, ResumeErrorDialog, SaveErrorDialog, StaffPaymentDialog }
+  from '@/components/dialogs'
 import { CommonMixin, DateMixin, EnumMixin, FilingMixin, ResourceLookupMixin } from '@/mixins'
 import { EnumUtilities, LegalServices } from '@/services/'
 import { EffectOfOrderTypes, FilingCodes, FilingStatus, FilingTypes, Routes, SaveErrorReasons,
@@ -354,7 +346,6 @@ import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
     DetailComment,
     DocumentDelivery,
     ForeignJurisdiction,
-    GenericErrorDialog,
     PaymentErrorDialog,
     ResumeErrorDialog,
     SaveErrorDialog,
@@ -377,7 +368,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
   @Getter(useBusinessStore) getLegalName!: string
   @Getter(useConfigurationStore) getPayApiUrl!: string
   @Getter(useRootStore) getUserInfo!: any
-  @Getter(useBusinessStore) hasCourtOrders!: boolean
   @Getter(useRootStore) isRoleStaff!: boolean
 
   // enum for template
@@ -413,13 +403,9 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
   staffPaymentDialog = false
 
   // variables for displaying dialogs
-  courtOrderDialog = false
   resumeErrorDialog = false
   saveErrorReason = null as SaveErrorReasons
   paymentErrorDialog = false
-  courtOrderDialogText = 'This business has a court order in its ledger. Please contact BC ' +
-    'Registries to submit a Consent to Continue Out.'
-  courtOrderDialogTitle = 'Please contact BC Registries'
 
   // other variables
   totalFee = 0
@@ -505,13 +491,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
     // wait until entire view is rendered (including all child components)
     // see https://v3.vuejs.org/api/options-lifecycle-hooks.html#mounted
     await this.$nextTick()
-
-    // block regular user if business has a court order filing
-    if (!this.isRoleStaff && this.hasCourtOrders) {
-      this.dataLoaded = true
-      this.courtOrderDialog = true
-      return
-    }
 
     if (this.filingId > 0) {
       this.loadingMessage = `Resuming Your Consent to Continuation Out`

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -787,7 +787,7 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
       header: {
         name: FilingTypes.CONTINUATION_OUT,
         certifiedBy: this.certifiedBy || '',
-        email: this.getBusinessEmail,
+        email: this.getBusinessEmail || '',
         date: this.getCurrentDate // NB: API will reassign this date according to its clock
       }
     }


### PR DESCRIPTION
*Issue #:* bcgov/entity#20072

*Description of changes:*
- app version = 7.0.49
- deleted Court Order Dialog from Consent Continuation Out view

*Also:*
- added fallback (to empty string) for business email and phone in draft amalgamation
- added fallback (to empty string) for business email in consent continuation out
- added fallback (to empty string) for business email in continuation out

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).