### PR TITLE
20162 Fixed logic for showing (vs disabling) limited restoration staff actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.49",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.0.49",
+      "version": "7.1.0",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.0.49",
+  "version": "7.1.0",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/StaffNotation.vue
+++ b/src/components/Dashboard/StaffNotation.vue
@@ -187,8 +187,7 @@
             </v-list-item>
 
             <v-list-item
-              v-if="isHistorical"
-              :disabled="!isAllowed(AllowableActions.LIMITED_RESTORATION_EXTENSION)"
+              v-if="isAllowed(AllowableActions.LIMITED_RESTORATION_EXTENSION)"
               data-type="extend-limited-restoration"
               @click="goToRestorationFiling(ApplicationTypes.EDIT_UI, FilingSubTypes.LIMITED_RESTORATION_EXTENSION)"
             >
@@ -198,8 +197,7 @@
             </v-list-item>
 
             <v-list-item
-              v-if="isHistorical"
-              :disabled="!isAllowed(AllowableActions.LIMITED_RESTORATION_TO_FULL)"
+              v-if="isAllowed(AllowableActions.LIMITED_RESTORATION_TO_FULL)"
               data-type="convert-full-restoration"
               @click="goToRestorationFiling(ApplicationTypes.EDIT_UI, FilingSubTypes.LIMITED_RESTORATION_TO_FULL)"
             >

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -584,6 +584,7 @@ describe('StaffNotation', () => {
     businessStore.setLegalType(CorpTypeCd.BC_COMPANY) // corp
     businessStore.setIdentifier('BC1234567')
     businessStore.setState(EntityState.HISTORICAL)
+
     // stub "create draft" endpoint
     sinon.stub(axios, 'post').withArgs('businesses/BC1234567/filings?draft=true').returns(
       new Promise(resolve =>
@@ -620,10 +621,16 @@ describe('StaffNotation', () => {
   })
 
   it('goes to limited restoration extension filing', async () => {
+    vi.spyOn(utils, 'GetFeatureFlag').mockImplementation(flag => {
+      if (flag === 'supported-restoration-entities') return 'BC'
+      return null
+    })
+
     // set store specifically for this test
     businessStore.setLegalType(CorpTypeCd.BC_COMPANY)
     businessStore.setIdentifier('BC1234567')
-    businessStore.setState(EntityState.HISTORICAL)
+    businessStore.setState(EntityState.ACTIVE)
+
     // stub "create draft" endpoint
     sinon.stub(axios, 'post').withArgs('businesses/BC1234567/filings?draft=true').returns(
       new Promise(resolve =>
@@ -663,11 +670,16 @@ describe('StaffNotation', () => {
   })
 
   it('goes to limited restoration conversion filing', async () => {
+    vi.spyOn(utils, 'GetFeatureFlag').mockImplementation(flag => {
+      if (flag === 'supported-restoration-entities') return 'BEN'
+      return null
+    })
+
     // set store specifically for this test
     businessStore.setLegalType(CorpTypeCd.BENEFIT_COMPANY)
     businessStore.setIdentifier('BC1234567')
     rootStore.currentDate = '2022-12-31'
-    businessStore.setState(EntityState.HISTORICAL)
+    businessStore.setState(EntityState.ACTIVE)
     rootStore.setStateFiling({
       business: {
         state: 'ACTIVE'


### PR DESCRIPTION
*Issue #:* bcgov/entity#20162

*Description of changes:*
- app version = 7.1.0
- show limited restoration staff actions according to allowable actions
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).