### PR TITLE
16847 Removed ledger detail in consent continue out / consent amalgamation out filings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.1.5",
+  "version": "7.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.1.5",
+      "version": "7.1.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.1.5",
+  "version": "7.1.6",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/filings/AgmExtension.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/AgmExtension.vue
@@ -6,7 +6,7 @@
   >
     <template #body>
       <div v-if="isFilingComplete">
-        <p class="mt-4">
+        <p class="mt-0">
           The {{ agmYear }} AGM must be held by <strong>{{ agmDueDate }}</strong>.
         </p>
       </div>

--- a/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
@@ -29,12 +29,6 @@
         </p>
 
         <p
-          v-if="orderDetails"
-          class="mt-4"
-          v-html="orderDetails"
-        />
-
-        <p
           v-if="fileNumber"
           class="mt-4 mb-0"
         >
@@ -85,10 +79,6 @@ export default class ConsentContinuationOut extends Mixins(CountriesProvincesMix
       }
     }
     return false
-  }
-
-  get orderDetails (): string {
-    return this.filing.data?.order?.orderDetails?.replaceAll('\n', '<br/>')
   }
 
   /** The court order file number. */

--- a/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/ConsentContinuationOut.vue
@@ -8,10 +8,11 @@
       <div>
         <p
           v-if="expiry && !isConsentExpired"
-          class="mt-4"
+          class="mt-0"
         >
           This consent to continue out to {{ foreignJurisdiction }} is valid <strong>until {{ expiry }}</strong>.
         </p>
+
         <p
           v-if="expiry && isConsentExpired"
           class="mt-4"
@@ -26,17 +27,20 @@
           This consent is expired. Please resubmit the continue out application for authorization to become a foreign
           corporation.
         </p>
+
         <p
           v-if="orderDetails"
           class="mt-4"
           v-html="orderDetails"
         />
+
         <p
           v-if="fileNumber"
           class="mt-4 mb-0"
         >
           Court Order Number: {{ fileNumber }}
         </p>
+
         <p
           v-if="hasEffectOfOrder"
           class="mt-0"

--- a/src/components/Dashboard/FilingHistoryList/filings/ContinuationOut.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/ContinuationOut.vue
@@ -7,6 +7,7 @@
     <template #body>
       <div v-if="isFilingComplete">
         <h4>Continuation Out Complete</h4>
+
         <p class="mt-4">
           The Company {{ legalName }} was successfully
           <strong>
@@ -17,12 +18,14 @@
           incorporated company under the Business Corporations Act.
           You are required to retain a copy of all the Continuation Out documents in your records books.
         </p>
+
         <p
           v-if="fileNumber"
           class="mt-4 mb-0"
         >
           Court Order Number: {{ fileNumber }}
         </p>
+
         <p
           v-if="hasEffectOfOrder"
           class="mt-0"

--- a/src/components/common/ForeignJurisdiction.vue
+++ b/src/components/common/ForeignJurisdiction.vue
@@ -24,7 +24,7 @@
           placeholder="Jurisdiction Country"
           :rules="countryRules"
           menu-props="auto"
-          @input="emitChangedCountry($event)"
+          @input="emitChangedCountry()"
         />
         <v-select
           v-if="canadaUsaRegions.length > 0"
@@ -36,7 +36,7 @@
           filled
           placeholder="Jurisdiction Region"
           :rules="regionRules"
-          @input="emitChangedRegion($event)"
+          @input="emitChangedRegion()"
         />
       </v-col>
     </v-row>
@@ -82,7 +82,7 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
   /** Get the respective regions of the country selected as an array of objects. */
   get canadaUsaRegions (): Array<any> {
     if (this.selectedCountryName === 'Canada') {
-      let regions = this.getCountryRegions('CA')
+      let regions = this.getCountryRegions('CA') as any[]
       regions = regions.filter(province => province.short !== 'BC')
       regions.push({ name: 'Federal', short: 'FEDERAL' })
       return regions
@@ -108,7 +108,8 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
 
   /** Get the selected country's code. */
   get selectedCountryCode (): string {
-    const countryCode = this.getCountries().find(country => country.name === this.selectedCountryName)
+    const countries = this.getCountries() as any[]
+    const countryCode = countries.find(country => country.name === this.selectedCountryName)
     return countryCode?.code
   }
 
@@ -116,7 +117,8 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
    * @example ('CA') -> 'Canada'
    */
   private getCountryNameFromCode (code: string): string {
-    const country = this.getCountries().find(country => country.code === code)
+    const countries = this.getCountries() as any[]
+    const country = countries.find(country => country.code === code)
     return country?.name
   }
 

--- a/src/interfaces/api-filing-interface.ts
+++ b/src/interfaces/api-filing-interface.ts
@@ -110,7 +110,7 @@ export interface ApiFilingIF {
       effectOfOrder?: EffectOfOrderTypes
       fileNumber: string // may be null
       orderDate?: string // FUTURE: use date type here
-      orderDetails: string
+      orderDetails?: string
     }
 
     // dissolution filings only

--- a/src/interfaces/api-filing-interface.ts
+++ b/src/interfaces/api-filing-interface.ts
@@ -96,12 +96,10 @@ export interface ApiFilingIF {
     continuationOut?: {
       continuationOutDate: IsoDatePacific
       courtOrder?: any
-      details: string
-      foreignJurisdiction: {
-        country: string
-        region?: string
-      }
+      country: string
+      details?: string
       legalName: string
+      region: string // may be null
     }
 
     // conversion filings only

--- a/src/views/AgmExtension.vue
+++ b/src/views/AgmExtension.vue
@@ -298,6 +298,12 @@ export default class AgmExtension extends Mixins(CommonMixin, DateMixin,
     this.updateFilingData('add', FilingCodes.AGM_EXTENSION, undefined, undefined)
   }
 
+  /** Called just before this component is destroyed. */
+  beforeDestroy (): void {
+    // remove event handler
+    window.onbeforeunload = null
+  }
+
   /**
    * Called when user clicks File and Pay button
    * or when user retries from Save Error dialog.

--- a/src/views/AgmLocationChg.vue
+++ b/src/views/AgmLocationChg.vue
@@ -427,6 +427,12 @@ export default class AgmLocationChg extends Mixins(CommonMixin, DateMixin,
     this.updateFilingData('add', FilingCodes.AGM_LOCATION_CHANGE, undefined, undefined)
   }
 
+  /** Called just before this component is destroyed. */
+  beforeDestroy (): void {
+    // remove event handler
+    window.onbeforeunload = null
+  }
+
   /**
    * Called when user clicks File and Pay button
    * or when user retries from Save Error dialog.

--- a/src/views/AmalgamationOut.vue
+++ b/src/views/AmalgamationOut.vue
@@ -216,7 +216,7 @@
                   :certifiedBy.sync="certifiedBy"
                   :class="{ 'invalid-component': !certifyFormValid && showErrors }"
                   :entityDisplay="displayName()"
-                  :message="certifyText(FilingCodes.AMALGANATION_OUT)"
+                  :message="certifyText(FilingCodes.AMALGAMATION_OUT)"
                   @valid="certifyFormValid=$event"
                 />
               </div>
@@ -543,6 +543,12 @@ export default class AmalgamationOut extends Mixins(CommonMixin, DateMixin,
     // always include continue out code
     // clear Priority flag and set the Waive Fees flag to true
     this.updateFilingData('add', FilingCodes.AMALGAMATION_OUT, undefined, true)
+  }
+
+  /** Called just before this component is destroyed. */
+  beforeDestroy (): void {
+    // remove event handler
+    window.onbeforeunload = null
   }
 
   /** Fetches the draft amalgamation out filing. */

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -664,6 +664,9 @@ export default class AnnualReport extends Mixins(CommonMixin, DateMixin, FilingM
   beforeDestroy (): void {
     // stop listening for custom events
     this.$root.$off('fetch-error-event')
+
+    // remove event handler
+    window.onbeforeunload = null
   }
 
   async fetchDraftFiling (): Promise<void> {

--- a/src/views/ConsentAmalgamationOut.vue
+++ b/src/views/ConsentAmalgamationOut.vue
@@ -521,6 +521,12 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
       (this.staffPaymentData.option === StaffPaymentOptions.NO_FEE))
   }
 
+  /** Called just before this component is destroyed. */
+  beforeDestroy (): void {
+    // remove event handler
+    window.onbeforeunload = null
+  }
+
   /** Fetches the draft consent filing. */
   async fetchDraftFiling (): Promise<void> {
     const url = `businesses/${this.getIdentifier}/filings/${this.filingId}`

--- a/src/views/ConsentAmalgamationOut.vue
+++ b/src/views/ConsentAmalgamationOut.vue
@@ -78,50 +78,6 @@
               </h1>
             </header>
 
-            <!-- Ledger Detail -->
-            <section v-if="isRoleStaff">
-              <header>
-                <h2>Ledger Detail</h2>
-                <p class="grey-text">
-                  Enter a detail that will appear on the ledger for this entity.
-                </p>
-              </header>
-              <div
-                id="detail-comment-section"
-                :class="{ 'invalid-section': !detailCommentValid && showErrors }"
-              >
-                <v-card
-                  flat
-                  class="py-8 px-5"
-                >
-                  <v-row no-gutters>
-                    <v-col
-                      cols="12"
-                      sm="3"
-                      class="pr-4"
-                    >
-                      <strong :class="{ 'app-red': !detailCommentValid && showErrors }">Detail</strong>
-                    </v-col>
-                    <v-col
-                      cols="12"
-                      sm="9"
-                    >
-                      <p class="grey-text font-weight-bold">
-                        {{ defaultComment }}
-                      </p>
-                      <DetailComment
-                        ref="detailCommentRef"
-                        v-model="detailComment"
-                        placeholder="Add a Detail that will appear on the ledger for this entity."
-                        :maxLength="maxDetailCommentLength"
-                        @valid="detailCommentValid=$event"
-                      />
-                    </v-col>
-                  </v-row>
-                </v-card>
-              </div>
-            </section>
-
             <!-- Jurisdiction Information -->
             <section>
               <header>
@@ -326,7 +282,7 @@ import { Getter } from 'pinia-class'
 import { StatusCodes } from 'http-status-codes'
 import { navigate } from '@/utils'
 import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
-import { Certify, DetailComment, ForeignJurisdiction } from '@/components/common'
+import { Certify, ForeignJurisdiction } from '@/components/common'
 import { ConfirmDialog, PaymentErrorDialog, ResumeErrorDialog, SaveErrorDialog, StaffPaymentDialog }
   from '@/components/dialogs'
 import { CommonMixin, DateMixin, EnumMixin, FilingMixin, ResourceLookupMixin } from '@/mixins'
@@ -343,7 +299,6 @@ import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
     Certify,
     ConfirmDialog,
     CourtOrderPoa,
-    DetailComment,
     DocumentDelivery,
     ForeignJurisdiction,
     PaymentErrorDialog,
@@ -359,7 +314,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
   $refs!: {
     confirm: ConfirmDialogType,
     certifyRef: Certify,
-    detailCommentRef: DetailComment,
     foreignJurisdictionRef: ForeignJurisdiction
   }
 
@@ -372,10 +326,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
 
   // enum for template
   readonly FilingCodes = FilingCodes
-
-  // variables for DetailComment component
-  detailComment = ''
-  detailCommentValid = false
 
   // variables for Certify component
   certifiedBy = ''
@@ -428,17 +378,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
     return (!this.dataLoaded && !this.saveErrorReason && !this.paymentErrorDialog)
   }
 
-  /** Default comment (ie, the first line of the detail comment). */
-  get defaultComment (): string {
-    return 'Six Month Consent to Continue Out'
-  }
-
-  /** Maximum length of detail comment. */
-  get maxDetailCommentLength (): number {
-    // = (max size in db) - (default comment length) - (Carriage Return)
-    return 2000 - this.defaultComment.length - 1
-  }
-
   /** The Base URL string. */
   get baseUrl (): string {
     return sessionStorage.getItem('BASE_URL')
@@ -447,7 +386,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
   /** True if page is valid, else False. */
   get isPageValid (): boolean {
     return (
-      (this.detailCommentValid || !this.isRoleStaff) && // staff only
       this.certifyFormValid &&
       this.foreignJurisdictionValid &&
       this.documentDeliveryValid &&
@@ -569,10 +507,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
         } as StaffPaymentIF
       }
 
-      // load Detail Comment, removing the first line (default comment)
-      const comment: string = filing.consentAmalgamationOut.details || ''
-      this.detailComment = comment.split('\n').slice(1).join('\n')
-
       const courtOrder = filing.consentAmalgamationOut.courtOrder
       if (courtOrder) {
         this.fileNumber = courtOrder.fileNumber
@@ -686,10 +620,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
     // if there is an invalid component, scroll to it
     if (!this.isPageValid) {
       this.showErrors = true
-      if (!this.detailCommentValid) {
-        // Show error message of detail comment text area if invalid
-        this.$refs.detailCommentRef.$refs.textarea.error = true
-      }
       if (!this.certifyFormValid) {
         // Show error message of legal name text field if invalid
         this.$refs.certifyRef.$refs.certifyTextfieldRef.error = true
@@ -830,8 +760,7 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
     }
 
     const data: any = {
-      [FilingTypes.CONSENT_AMALGAMATION_OUT]: {
-        details: this.isRoleStaff ? `${this.defaultComment}\n${this.detailComment}` : null,
+      consentAmalgamationOut: {
         foreignJurisdiction: {
           country: this.selectedCountry,
           region: this.selectedRegion
@@ -840,7 +769,7 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
     }
 
     if (this.fileNumber !== '') {
-      data[FilingTypes.CONSENT_AMALGAMATION_OUT].courtOrder = {
+      data.consentAmalgamationOut.courtOrder = {
         fileNumber: this.fileNumber,
         effectOfOrder: (this.hasPlanOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : '') as string
       }
@@ -962,7 +891,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
 
   /** Array of valid components. Must match validFlags. */
   readonly validComponents = [
-    'detail-comment-section',
     'foreign-jurisdiction-section',
     'document-delivery-section',
     'certify-form-section',
@@ -972,7 +900,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
   /** Object of valid flags. Must match validComponents. */
   get validFlags (): object {
     return {
-      detailComment: this.detailCommentValid,
       foreignJurisdiction: this.foreignJurisdictionValid,
       documentDelivery: this.documentDeliveryValid,
       certifyForm: this.certifyFormValid,
@@ -982,7 +909,6 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
 
   @Watch('certifyFormValid')
   @Watch('courtOrderValid')
-  @Watch('detailCommentValid')
   @Watch('documentDeliveryValid')
   @Watch('foreignJurisdictionValid')
   onHaveChanges (): void {

--- a/src/views/ConsentAmalgamationOut.vue
+++ b/src/views/ConsentAmalgamationOut.vue
@@ -79,7 +79,7 @@
             </header>
 
             <!-- Ledger Detail -->
-            <section>
+            <section v-if="isRoleStaff">
               <header>
                 <h2>Ledger Detail</h2>
                 <p class="grey-text">
@@ -446,8 +446,13 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
 
   /** True if page is valid, else False. */
   get isPageValid (): boolean {
-    return (this.detailCommentValid && this.certifyFormValid && this.foreignJurisdictionValid &&
-      this.documentDeliveryValid && this.courtOrderValid)
+    return (
+      (this.detailCommentValid || !this.isRoleStaff) && // staff only
+      this.certifyFormValid &&
+      this.foreignJurisdictionValid &&
+      this.documentDeliveryValid &&
+      this.courtOrderValid
+    )
   }
 
   /** True when saving, saving and resuming, or filing and paying. */
@@ -820,7 +825,7 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
 
     const data: any = {
       [FilingTypes.CONSENT_AMALGAMATION_OUT]: {
-        details: `${this.defaultComment}\n${this.detailComment}`,
+        details: this.isRoleStaff ? `${this.defaultComment}\n${this.detailComment}` : null,
         foreignJurisdiction: {
           country: this.selectedCountry,
           region: this.selectedRegion

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -79,7 +79,7 @@
             </header>
 
             <!-- Ledger Detail -->
-            <section>
+            <section v-if="isRoleStaff">
               <header>
                 <h2>Ledger Detail</h2>
                 <p class="grey-text">
@@ -446,8 +446,13 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
 
   /** True if page is valid, else False. */
   get isPageValid (): boolean {
-    return (this.detailCommentValid && this.certifyFormValid && this.foreignJurisdictionValid &&
-      this.documentDeliveryValid && this.courtOrderValid)
+    return (
+      (this.detailCommentValid || !this.isRoleStaff) && // staff only
+      this.certifyFormValid &&
+      this.foreignJurisdictionValid &&
+      this.documentDeliveryValid &&
+      this.courtOrderValid
+    )
   }
 
   /** True when saving, saving and resuming, or filing and paying. */
@@ -820,7 +825,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
 
     const data: any = {
       [FilingTypes.CONSENT_CONTINUATION_OUT]: {
-        details: `${this.defaultComment}\n${this.detailComment}`,
+        details: this.isRoleStaff ? `${this.defaultComment}\n${this.detailComment}` : null,
         foreignJurisdiction: {
           country: this.selectedCountry,
           region: this.selectedRegion

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -521,6 +521,12 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
       (this.staffPaymentData.option === StaffPaymentOptions.NO_FEE))
   }
 
+  /** Called just before this component is destroyed. */
+  beforeDestroy (): void {
+    // remove event handler
+    window.onbeforeunload = null
+  }
+
   /** Fetches the draft consent filing. */
   async fetchDraftFiling (): Promise<void> {
     const url = `businesses/${this.getIdentifier}/filings/${this.filingId}`

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -78,50 +78,6 @@
               </h1>
             </header>
 
-            <!-- Ledger Detail -->
-            <section v-if="isRoleStaff">
-              <header>
-                <h2>Ledger Detail</h2>
-                <p class="grey-text">
-                  Enter a detail that will appear on the ledger for this entity.
-                </p>
-              </header>
-              <div
-                id="detail-comment-section"
-                :class="{ 'invalid-section': !detailCommentValid && showErrors }"
-              >
-                <v-card
-                  flat
-                  class="py-8 px-5"
-                >
-                  <v-row no-gutters>
-                    <v-col
-                      cols="12"
-                      sm="3"
-                      class="pr-4"
-                    >
-                      <strong :class="{ 'app-red': !detailCommentValid && showErrors }">Detail</strong>
-                    </v-col>
-                    <v-col
-                      cols="12"
-                      sm="9"
-                    >
-                      <p class="grey-text font-weight-bold">
-                        {{ defaultComment }}
-                      </p>
-                      <DetailComment
-                        ref="detailCommentRef"
-                        v-model="detailComment"
-                        placeholder="Add a Detail that will appear on the ledger for this entity."
-                        :maxLength="maxDetailCommentLength"
-                        @valid="detailCommentValid=$event"
-                      />
-                    </v-col>
-                  </v-row>
-                </v-card>
-              </div>
-            </section>
-
             <!-- Jurisdiction Information -->
             <section>
               <header>
@@ -326,7 +282,7 @@ import { Getter } from 'pinia-class'
 import { StatusCodes } from 'http-status-codes'
 import { navigate } from '@/utils'
 import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
-import { Certify, DetailComment, ForeignJurisdiction } from '@/components/common'
+import { Certify, ForeignJurisdiction } from '@/components/common'
 import { ConfirmDialog, PaymentErrorDialog, ResumeErrorDialog, SaveErrorDialog, StaffPaymentDialog }
   from '@/components/dialogs'
 import { CommonMixin, DateMixin, EnumMixin, FilingMixin, ResourceLookupMixin } from '@/mixins'
@@ -343,7 +299,6 @@ import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
     Certify,
     ConfirmDialog,
     CourtOrderPoa,
-    DetailComment,
     DocumentDelivery,
     ForeignJurisdiction,
     PaymentErrorDialog,
@@ -359,7 +314,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
   $refs!: {
     confirm: ConfirmDialogType,
     certifyRef: Certify,
-    detailCommentRef: DetailComment,
     foreignJurisdictionRef: ForeignJurisdiction
   }
 
@@ -372,10 +326,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
 
   // enum for template
   readonly FilingCodes = FilingCodes
-
-  // variables for DetailComment component
-  detailComment = ''
-  detailCommentValid = false
 
   // variables for Certify component
   certifiedBy = ''
@@ -428,17 +378,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
     return (!this.dataLoaded && !this.saveErrorReason && !this.paymentErrorDialog)
   }
 
-  /** Default comment (ie, the first line of the detail comment). */
-  get defaultComment (): string {
-    return 'Six Month Consent to Continue Out'
-  }
-
-  /** Maximum length of detail comment. */
-  get maxDetailCommentLength (): number {
-    // = (max size in db) - (default comment length) - (Carriage Return)
-    return 2000 - this.defaultComment.length - 1
-  }
-
   /** The Base URL string. */
   get baseUrl (): string {
     return sessionStorage.getItem('BASE_URL')
@@ -447,7 +386,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
   /** True if page is valid, else False. */
   get isPageValid (): boolean {
     return (
-      (this.detailCommentValid || !this.isRoleStaff) && // staff only
       this.certifyFormValid &&
       this.foreignJurisdictionValid &&
       this.documentDeliveryValid &&
@@ -569,10 +507,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
         } as StaffPaymentIF
       }
 
-      // load Detail Comment, removing the first line (default comment)
-      const comment: string = filing.consentContinuationOut.details || ''
-      this.detailComment = comment.split('\n').slice(1).join('\n')
-
       const courtOrder = filing.consentContinuationOut.courtOrder
       if (courtOrder) {
         this.fileNumber = courtOrder.fileNumber
@@ -686,10 +620,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
     // if there is an invalid component, scroll to it
     if (!this.isPageValid) {
       this.showErrors = true
-      if (!this.detailCommentValid) {
-        // Show error message of detail comment text area if invalid
-        this.$refs.detailCommentRef.$refs.textarea.error = true
-      }
       if (!this.certifyFormValid) {
         // Show error message of legal name text field if invalid
         this.$refs.certifyRef.$refs.certifyTextfieldRef.error = true
@@ -830,8 +760,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
     }
 
     const data: any = {
-      [FilingTypes.CONSENT_CONTINUATION_OUT]: {
-        details: this.isRoleStaff ? `${this.defaultComment}\n${this.detailComment}` : null,
+      consentContinuationOut: {
         foreignJurisdiction: {
           country: this.selectedCountry,
           region: this.selectedRegion
@@ -840,7 +769,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
     }
 
     if (this.fileNumber !== '') {
-      data[FilingTypes.CONSENT_CONTINUATION_OUT].courtOrder = {
+      data.consentContinuationOut.courtOrder = {
         fileNumber: this.fileNumber,
         effectOfOrder: (this.hasPlanOfArrangement ? EffectOfOrderTypes.PLAN_OF_ARRANGEMENT : '') as string
       }
@@ -962,7 +891,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
 
   /** Array of valid components. Must match validFlags. */
   readonly validComponents = [
-    'detail-comment-section',
     'foreign-jurisdiction-section',
     'document-delivery-section',
     'certify-form-section',
@@ -972,7 +900,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
   /** Object of valid flags. Must match validComponents. */
   get validFlags (): object {
     return {
-      detailComment: this.detailCommentValid,
       foreignJurisdiction: this.foreignJurisdictionValid,
       documentDelivery: this.documentDeliveryValid,
       certifyForm: this.certifyFormValid,
@@ -982,7 +909,6 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
 
   @Watch('certifyFormValid')
   @Watch('courtOrderValid')
-  @Watch('detailCommentValid')
   @Watch('documentDeliveryValid')
   @Watch('foreignJurisdictionValid')
   onHaveChanges (): void {

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -545,6 +545,12 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
     this.updateFilingData('add', FilingCodes.CONTINUATION_OUT, undefined, true)
   }
 
+  /** Called just before this component is destroyed. */
+  beforeDestroy (): void {
+    // remove event handler
+    window.onbeforeunload = null
+  }
+
   /** Fetches the draft continuation out filing. */
   async fetchDraftFiling (): Promise<void> {
     const url = `businesses/${this.getIdentifier}/filings/${this.filingId}`

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -434,6 +434,12 @@ export default class Correction extends Mixins(CommonMixin, DateMixin, EnumMixin
       (this.staffPaymentData.option === StaffPaymentOptions.NO_FEE))
   }
 
+  /** Called just before this component is destroyed. */
+  beforeDestroy (): void {
+    // remove event handler
+    window.onbeforeunload = null
+  }
+
   /** Fetches the draft correction filing. */
   async fetchDraftFiling (): Promise<void> {
     const url = `businesses/${this.getIdentifier}/filings/${this.filingId}`

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -552,6 +552,9 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
   beforeDestroy (): void {
     // stop listening for custom events
     this.$root.$off('fetch-error-event')
+
+    // remove event handler
+    window.onbeforeunload = null
   }
 
   async fetchDraftFiling (): Promise<void> {

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -414,6 +414,9 @@ export default class StandaloneOfficeAddressFiling extends Mixins(CommonMixin, D
   beforeDestroy (): void {
     // stop listening for custom events
     this.$root.$off('fetch-error-event')
+
+    // remove event handler
+    window.onbeforeunload = null
   }
 
   async fetchDraftFiling (): Promise<void> {

--- a/tests/unit/ConsentAmalgamationOut.spec.ts
+++ b/tests/unit/ConsentAmalgamationOut.spec.ts
@@ -217,6 +217,9 @@ describe('Consent to Amalgamation Out view', () => {
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
 
+    // verify that detail comment is not empty
+    expect(vm.detailComment).not.toBe('')
+
     vi.restoreAllMocks()
     wrapper.destroy()
   })
@@ -385,7 +388,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
     expect(wrapper.findComponent(Certify).exists()).toBe(true)
     expect(wrapper.findComponent(ConfirmDialog).exists()).toBe(true)
     expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(false) // staff only
-    expect(wrapper.findComponent(DetailComment).exists()).toBe(true)
     expect(wrapper.findComponent(DocumentDelivery).exists()).toBe(true)
     expect(wrapper.findComponent(ForeignJurisdiction).exists()).toBe(true)
     expect(wrapper.findComponent(PaymentErrorDialog).exists()).toBe(true)
@@ -408,7 +410,7 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       return Promise.resolve({
         business: {},
         header: { filingId: 456 },
-        consentAmalgamationOut: { details: 'test' },
+        consentAmalgamationOut: { details: null },
         annualReport: {}
       })
     })
@@ -443,6 +445,9 @@ describe('Consent to Continue Out for general user and IAs only', () => {
 
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
+
+    // verify that detail comment is empty
+    expect(vm.detailComment).toBe('')
 
     vi.restoreAllMocks()
     wrapper.destroy()

--- a/tests/unit/ConsentAmalgamationOut.spec.ts
+++ b/tests/unit/ConsentAmalgamationOut.spec.ts
@@ -217,8 +217,8 @@ describe('Consent to Amalgamation Out view', () => {
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
 
-    // verify that detail comment is not empty
-    expect(vm.detailComment).not.toBe('')
+    // verify that detail comment from Legal API is not null
+    expect(vm.savedFiling.consentAmalgamationOut.details).toBe('test')
 
     vi.restoreAllMocks()
     wrapper.destroy()
@@ -446,8 +446,8 @@ describe('Consent to Continue Out for general user and IAs only', () => {
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
 
-    // verify that detail comment is empty
-    expect(vm.detailComment).toBe('')
+    // verify that detail comment from Legal API is null
+    expect(vm.savedFiling.consentAmalgamationOut.details).toBeNull()
 
     vi.restoreAllMocks()
     wrapper.destroy()

--- a/tests/unit/ConsentAmalgamationOut.spec.ts
+++ b/tests/unit/ConsentAmalgamationOut.spec.ts
@@ -167,7 +167,7 @@ describe('Consent to Amalgamation Out view', () => {
       return Promise.resolve({
         business: {},
         header: { filingId: 456 },
-        consentAmalgamationOut: { details: 'test' },
+        consentAmalgamationOut: {},
         annualReport: {}
       })
     })
@@ -202,9 +202,6 @@ describe('Consent to Amalgamation Out view', () => {
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
 
-    // verify that detail comment from Legal API is not null
-    expect(vm.savedFiling.consentAmalgamationOut.details).toBe('test')
-
     vi.restoreAllMocks()
     wrapper.destroy()
   })
@@ -225,7 +222,6 @@ describe('Consent to Amalgamation Out view', () => {
           priority: true
         },
         consentAmalgamationOut: {
-          details: 'Line 1\nLine 2\nLine 3',
           foreignJurisdiction: {
             country: 'CA',
             region: 'AB'
@@ -393,7 +389,7 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       return Promise.resolve({
         business: {},
         header: { filingId: 456 },
-        consentAmalgamationOut: { details: null },
+        consentAmalgamationOut: {},
         annualReport: {}
       })
     })
@@ -427,9 +423,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
 
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
-
-    // verify that detail comment from Legal API is null
-    expect(vm.savedFiling.consentAmalgamationOut.details).toBeNull()
 
     vi.restoreAllMocks()
     wrapper.destroy()

--- a/tests/unit/ConsentAmalgamationOut.spec.ts
+++ b/tests/unit/ConsentAmalgamationOut.spec.ts
@@ -8,7 +8,7 @@ import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
 import ConsentAmalgamationOut from '@/views/ConsentAmalgamationOut.vue'
 import { ConfirmDialog, PaymentErrorDialog, ResumeErrorDialog, SaveErrorDialog, StaffPaymentDialog }
   from '@/components/dialogs'
-import { Certify, DetailComment, ForeignJurisdiction } from '@/components/common'
+import { Certify, ForeignJurisdiction } from '@/components/common'
 import { CourtOrderPoa } from '@bcrs-shared-components/court-order-poa'
 import { DocumentDelivery } from '@bcrs-shared-components/document-delivery'
 import { LegalServices } from '@/services'
@@ -64,7 +64,6 @@ describe('Consent to Amalgamation Out view', () => {
     expect(wrapper.findComponent(Certify).exists()).toBe(true)
     expect(wrapper.findComponent(ConfirmDialog).exists()).toBe(true)
     expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(true)
-    expect(wrapper.findComponent(DetailComment).exists()).toBe(true)
     expect(wrapper.findComponent(DocumentDelivery).exists()).toBe(true)
     expect(wrapper.findComponent(PaymentErrorDialog).exists()).toBe(true)
     expect(wrapper.findComponent(ResumeErrorDialog).exists()).toBe(true)
@@ -121,23 +120,13 @@ describe('Consent to Amalgamation Out view', () => {
     // verify "validated" - all true
     vm.certifyFormValid = true
     vm.courtOrderValid = true
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = true
     vm.foreignJurisdictionValid = true
     expect(vm.isPageValid).toBe(true)
 
-    // verify "validated" - invalid Detail Comment form
-    vm.certifyFormValid = true
-    vm.courtOrderValid = true
-    vm.detailCommentValid = false
-    vm.documentDeliveryValid = true
-    vm.foreignJurisdictionValid = true
-    expect(vm.isPageValid).toBe(false)
-
     // verify "validated" - invalid Certify form
     vm.certifyFormValid = false
     vm.courtOrderValid = true
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = true
     vm.foreignJurisdictionValid = true
     expect(vm.isPageValid).toBe(false)
@@ -145,7 +134,6 @@ describe('Consent to Amalgamation Out view', () => {
     // verify "validated" - invalid Court Order form
     vm.certifyFormValid = true
     vm.courtOrderValid = false
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = true
     vm.foreignJurisdictionValid = true
     expect(vm.isPageValid).toBe(false)
@@ -153,7 +141,6 @@ describe('Consent to Amalgamation Out view', () => {
     // verify "validated" - invalid Document Delivery form
     vm.certifyFormValid = true
     vm.courtOrderValid = true
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = false
     vm.foreignJurisdictionValid = true
     expect(vm.isPageValid).toBe(false)
@@ -161,7 +148,6 @@ describe('Consent to Amalgamation Out view', () => {
     // verify "validated" - invalid Foreign Jurisdiction form
     vm.certifyFormValid = true
     vm.courtOrderValid = true
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = true
     vm.foreignJurisdictionValid = false
     expect(vm.isPageValid).toBe(false)
@@ -198,7 +184,6 @@ describe('Consent to Amalgamation Out view', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
-        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -262,7 +247,6 @@ describe('Consent to Amalgamation Out view', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
-        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -280,7 +264,6 @@ describe('Consent to Amalgamation Out view', () => {
     expect(vm.staffPaymentData.routingSlipNumber).toBe('123456789')
     expect(vm.staffPaymentData.isPriority).toBe(true)
     // NB: line 1 (default comment) should be removed
-    expect(vm.detailComment).toBe('Line 2\nLine 3')
     expect(vm.draftCountry).toBe('CA')
     expect(vm.draftRegion).toBe('AB')
 
@@ -427,7 +410,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
-        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -464,7 +446,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
-        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -476,7 +457,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
 
     // make sure form is validated
     await wrapper.setData({
-      detailCommentValid: true,
       documentDeliveryValid: true,
       certifyFormValid: true,
       courtOrderValid: true,

--- a/tests/unit/ConsentContinuationOut.spec.ts
+++ b/tests/unit/ConsentContinuationOut.spec.ts
@@ -217,6 +217,9 @@ describe('Consent to Continuation Out view', () => {
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
 
+    // verify that detail comment is not empty
+    expect(vm.detailComment).not.toBe('')
+
     vi.restoreAllMocks()
     wrapper.destroy()
   })
@@ -385,7 +388,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
     expect(wrapper.findComponent(Certify).exists()).toBe(true)
     expect(wrapper.findComponent(ConfirmDialog).exists()).toBe(true)
     expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(false) // staff only
-    expect(wrapper.findComponent(DetailComment).exists()).toBe(true)
     expect(wrapper.findComponent(DocumentDelivery).exists()).toBe(true)
     expect(wrapper.findComponent(ForeignJurisdiction).exists()).toBe(true)
     expect(wrapper.findComponent(PaymentErrorDialog).exists()).toBe(true)
@@ -408,7 +410,7 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       return Promise.resolve({
         business: {},
         header: { filingId: 456 },
-        consentContinuationOut: { details: 'test' },
+        consentContinuationOut: { details: null },
         annualReport: {}
       })
     })
@@ -443,6 +445,9 @@ describe('Consent to Continue Out for general user and IAs only', () => {
 
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
+
+    // verify that detail comment is empty
+    expect(vm.detailComment).toBe('')
 
     vi.restoreAllMocks()
     wrapper.destroy()

--- a/tests/unit/ConsentContinuationOut.spec.ts
+++ b/tests/unit/ConsentContinuationOut.spec.ts
@@ -8,7 +8,7 @@ import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
 import ConsentContinuationOut from '@/views/ConsentContinuationOut.vue'
 import { ConfirmDialog, PaymentErrorDialog, ResumeErrorDialog, SaveErrorDialog, StaffPaymentDialog }
   from '@/components/dialogs'
-import { Certify, DetailComment, ForeignJurisdiction } from '@/components/common'
+import { Certify, ForeignJurisdiction } from '@/components/common'
 import { CourtOrderPoa } from '@bcrs-shared-components/court-order-poa'
 import { DocumentDelivery } from '@bcrs-shared-components/document-delivery'
 import { LegalServices } from '@/services'
@@ -64,7 +64,6 @@ describe('Consent to Continuation Out view', () => {
     expect(wrapper.findComponent(Certify).exists()).toBe(true)
     expect(wrapper.findComponent(ConfirmDialog).exists()).toBe(true)
     expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(true)
-    expect(wrapper.findComponent(DetailComment).exists()).toBe(true)
     expect(wrapper.findComponent(DocumentDelivery).exists()).toBe(true)
     expect(wrapper.findComponent(PaymentErrorDialog).exists()).toBe(true)
     expect(wrapper.findComponent(ResumeErrorDialog).exists()).toBe(true)
@@ -121,23 +120,13 @@ describe('Consent to Continuation Out view', () => {
     // verify "validated" - all true
     vm.certifyFormValid = true
     vm.courtOrderValid = true
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = true
     vm.foreignJurisdictionValid = true
     expect(vm.isPageValid).toBe(true)
 
-    // verify "validated" - invalid Detail Comment form
-    vm.certifyFormValid = true
-    vm.courtOrderValid = true
-    vm.detailCommentValid = false
-    vm.documentDeliveryValid = true
-    vm.foreignJurisdictionValid = true
-    expect(vm.isPageValid).toBe(false)
-
     // verify "validated" - invalid Certify form
     vm.certifyFormValid = false
     vm.courtOrderValid = true
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = true
     vm.foreignJurisdictionValid = true
     expect(vm.isPageValid).toBe(false)
@@ -145,7 +134,6 @@ describe('Consent to Continuation Out view', () => {
     // verify "validated" - invalid Court Order form
     vm.certifyFormValid = true
     vm.courtOrderValid = false
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = true
     vm.foreignJurisdictionValid = true
     expect(vm.isPageValid).toBe(false)
@@ -153,7 +141,6 @@ describe('Consent to Continuation Out view', () => {
     // verify "validated" - invalid Document Delivery form
     vm.certifyFormValid = true
     vm.courtOrderValid = true
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = false
     vm.foreignJurisdictionValid = true
     expect(vm.isPageValid).toBe(false)
@@ -161,7 +148,6 @@ describe('Consent to Continuation Out view', () => {
     // verify "validated" - invalid Foreign Jurisdiction form
     vm.certifyFormValid = true
     vm.courtOrderValid = true
-    vm.detailCommentValid = true
     vm.documentDeliveryValid = true
     vm.foreignJurisdictionValid = false
     expect(vm.isPageValid).toBe(false)
@@ -198,7 +184,6 @@ describe('Consent to Continuation Out view', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
-        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -262,7 +247,6 @@ describe('Consent to Continuation Out view', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
-        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -280,7 +264,6 @@ describe('Consent to Continuation Out view', () => {
     expect(vm.staffPaymentData.routingSlipNumber).toBe('123456789')
     expect(vm.staffPaymentData.isPriority).toBe(true)
     // NB: line 1 (default comment) should be removed
-    expect(vm.detailComment).toBe('Line 2\nLine 3')
     expect(vm.draftCountry).toBe('CA')
     expect(vm.draftRegion).toBe('AB')
 
@@ -427,7 +410,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
-        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -464,7 +446,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
-        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -476,7 +457,6 @@ describe('Consent to Continue Out for general user and IAs only', () => {
 
     // make sure form is validated
     await wrapper.setData({
-      detailCommentValid: true,
       documentDeliveryValid: true,
       certifyFormValid: true,
       courtOrderValid: true,

--- a/tests/unit/ConsentContinuationOut.spec.ts
+++ b/tests/unit/ConsentContinuationOut.spec.ts
@@ -217,8 +217,8 @@ describe('Consent to Continuation Out view', () => {
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
 
-    // verify that detail comment is not empty
-    expect(vm.detailComment).not.toBe('')
+    // verify that detail comment from Legal API is not null
+    expect(vm.savedFiling.consentContinuationOut.details).toBe('test')
 
     vi.restoreAllMocks()
     wrapper.destroy()
@@ -446,8 +446,8 @@ describe('Consent to Continue Out for general user and IAs only', () => {
     // verify new Filing ID
     expect(vm.filingId).toBe(456)
 
-    // verify that detail comment is empty
-    expect(vm.detailComment).toBe('')
+    // verify that detail comment from Legal API is null
+    expect(vm.savedFiling.consentContinuationOut.details).toBeNull()
 
     vi.restoreAllMocks()
     wrapper.destroy()


### PR DESCRIPTION
*Issue #:* bcgov/entity#16847

*Description of changes:*
- app version = ~7.1.4~ 7.1.6
- removed ledger detail ~for non-staff user~ for all users
- updated validation logic
- updated saveFiling()
- updated unit tests

*Also:*
- removed windows event handler  when local filings views are destroyed

*Also:*
- fixed some filing body margins
- fixed ApiFilingIF.continuationOut object

*Also:*
- fixed some calls that didn't need parameters
- fixed some typings
- removed order details display from CCO ledger item
- removed ledger detail section from CCO and CAO sub-components + all supporting code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).