### PR TITLE
16481 Fixes to allowed actions/dialogs/NIGS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.1.8",
+  "version": "7.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.1.8",
+      "version": "7.1.9",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.1.8",
+  "version": "7.1.9",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/filings/DefaultFiling.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/DefaultFiling.vue
@@ -4,7 +4,7 @@
     :filing="filing"
     :index="index"
   >
-    <!-- just use all fallback slots -->
+    <!-- just use all fallback slots (see FilingTemplate.vue) -->
   </FilingTemplate>
 </template>
 

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -310,15 +310,8 @@
                   </v-btn>
                 </template>
 
-                <!-- non-staff see no buttons for these filings (these are staff-only filings) -->
-                <template
-                  v-else-if="!isRoleStaff && (
-                    EnumUtilities.isTypeCorrection(item) ||
-                    EnumUtilities.isTypeConversion(item) ||
-                    EnumUtilities.isTypeRestoration(item) ||
-                    EnumUtilities.isTypeContinuationOut(item)
-                  )"
-                >
+                <!-- non-staff see no buttons for staff filings -->
+                <template v-else-if="!isRoleStaff && isStaffFiling(item)">
                   <!-- no action button in this case -->
                 </template>
 
@@ -788,6 +781,16 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
     if (this.isStatusError(item) && (this.inProcessFiling !== item.filingId)) return true
     if (this.isStatusPaid(item) && (this.inProcessFiling !== item.filingId)) return true
     return false
+  }
+
+  /** Whether this is a staff-only filing. */
+  isStaffFiling (item: TodoItemIF): boolean {
+    return (
+      EnumUtilities.isTypeContinuationOut(item) ||
+      EnumUtilities.isTypeConversion(item) ||
+      EnumUtilities.isTypeCorrection(item) ||
+      EnumUtilities.isTypeRestoration(item)
+    )
   }
 
   /** Whether to show the Delete button only for a draft item. */

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -323,7 +323,7 @@
                 </template>
 
                 <!-- draft filing - show Delete only -->
-                <template v-else-if="isStatusDraft(item) && item.showDeleteOnly">
+                <template v-else-if="isStatusDraft(item) && showDeleteOnly(item)">
                   <v-btn
                     class="btn-draft-delete"
                     color="primary"
@@ -790,6 +790,19 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
     return false
   }
 
+  /** Whether to show the Delete button only for a draft item. */
+  showDeleteOnly (item: TodoItemIF): boolean {
+    switch (item.name) {
+      case FilingTypes.ALTERATION:
+      case FilingTypes.DISSOLUTION:
+      case FilingTypes.SPECIAL_RESOLUTION:
+        // when NIGS, non-staff can only delete item (staff can resume, etc)
+        return (!this.isGoodStanding && !this.isRoleStaff)
+      default:
+        return false
+    }
+  }
+
   /** Loads list of tasks from the API into Todo Items array. */
   async loadData (): Promise<void> {
     this.todoItems = []
@@ -1104,16 +1117,12 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
     const header = filing.header
 
     if (dissolution && business && header) {
-      // non-staff can only delete item when NIGS
-      const showDeleteOnly = (!this.isRoleStaff && !this.isGoodStanding)
-
       const corpFullDescription = GetCorpFullDescription(business.legalType)
 
       const paymentStatusCode = header.paymentStatusCode
       const payErrorObj = paymentStatusCode && await PayServices.getPayErrorObj(this.getPayApiUrl, paymentStatusCode)
 
       const item: TodoItemIF = {
-        showDeleteOnly,
         name: FilingTypes.DISSOLUTION,
         filingId: header.filingId,
         legalType: corpFullDescription,
@@ -1147,9 +1156,6 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
         alteration.business?.legalType === CorpTypeCd.BENEFIT_COMPANY
       )
 
-      // non-staff can only delete item when NIGS
-      const showDeleteOnly = (!this.isRoleStaff && !this.isGoodStanding)
-
       const corpFullDescription = GetCorpFullDescription(business.legalType)
 
       let title = header.priority ? 'Priority ' : ''
@@ -1164,7 +1170,6 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
       const payErrorObj = paymentStatusCode && await PayServices.getPayErrorObj(this.getPayApiUrl, paymentStatusCode)
 
       const item: TodoItemIF = {
-        showDeleteOnly,
         name: FilingTypes.ALTERATION,
         filingId: header.filingId,
         legalType: corpFullDescription,
@@ -1666,16 +1671,12 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
     const specialResolution = filing.specialResolution
 
     if (header && specialResolution) {
-      // non-staff can only delete item when NIGS
-      const showDeleteOnly = (!this.isRoleStaff && !this.isGoodStanding)
-
       const corpFullDescription = GetCorpFullDescription(business.legalType)
 
       const paymentStatusCode = header.paymentStatusCode
       const payErrorObj = paymentStatusCode && await PayServices.getPayErrorObj(this.getPayApiUrl, paymentStatusCode)
 
       const item: TodoItemIF = {
-        showDeleteOnly,
         name: FilingTypes.SPECIAL_RESOLUTION,
         filingId: header.filingId,
         legalType: corpFullDescription,

--- a/src/interfaces/todo-item-interface.ts
+++ b/src/interfaces/todo-item-interface.ts
@@ -15,6 +15,9 @@ export interface TodoItemIF {
   title: string
   comments?: Array<any> // always [] and never used
 
+  // alterations, dissolutions and special resolutions only
+  showDeleteOnly?: boolean
+
   // Todo ARs and Draft IAs only
   subtitle?: string
 

--- a/src/interfaces/todo-item-interface.ts
+++ b/src/interfaces/todo-item-interface.ts
@@ -15,9 +15,6 @@ export interface TodoItemIF {
   title: string
   comments?: Array<any> // always [] and never used
 
-  // alterations, dissolutions and special resolutions only
-  showDeleteOnly?: boolean
-
   // Todo ARs and Draft IAs only
   subtitle?: string
 

--- a/tests/unit/AddStaffNotationDialog.spec.ts
+++ b/tests/unit/AddStaffNotationDialog.spec.ts
@@ -100,7 +100,6 @@ describe('AddStaffNotationDialog', () => {
           attach: '#parent-page'
         }
       })
-    console.log(wrapper.html())
 
     expect(wrapper.find('v-card-title-stub').text()).toBe('Freeze Business')
     expect(wrapper.find('v-card-text-stub').text()).toContain('You are about to freeze')

--- a/tests/unit/EntityMenu.spec.ts
+++ b/tests/unit/EntityMenu.spec.ts
@@ -37,7 +37,7 @@ describe('Entity Menu - entities', () => {
     await Vue.nextTick()
 
     expect(wrapper.findComponent(StaffComments).exists()).toBe(false)
-    expect(wrapper.find('#company-information-button').exists()).toBe(false)
+    expect(wrapper.find('#business-information-button').exists()).toBe(false)
     expect(wrapper.find('.menu-btn').exists()).toBe(false)
     expect(wrapper.find('#download-summary-button').exists()).toBe(false)
     expect(wrapper.find('#view-add-digital-credentials-button').exists()).toBe(false)
@@ -71,7 +71,7 @@ describe('Entity Menu - entities', () => {
     await Vue.nextTick()
 
     expect(wrapper.findComponent(StaffComments).exists()).toBe(true)
-    expect(wrapper.find('#company-information-button').exists()).toBe(true)
+    expect(wrapper.find('#business-information-button').exists()).toBe(true)
     expect(wrapper.find('.menu-btn').exists()).toBe(true)
     expect(wrapper.find('#download-summary-button').exists()).toBe(true)
     expect(wrapper.find('#view-add-digital-credentials-button').exists()).toBe(false)
@@ -104,7 +104,7 @@ describe('Entity Menu - entities', () => {
     await Vue.nextTick()
 
     expect(wrapper.findComponent(StaffComments).exists()).toBe(false)
-    expect(wrapper.find('#company-information-button').exists()).toBe(false)
+    expect(wrapper.find('#business-information-button').exists()).toBe(false)
     expect(wrapper.find('.menu-btn').exists()).toBe(false)
     expect(wrapper.find('#download-summary-button').exists()).toBe(false)
     expect(wrapper.find('#view-add-digital-credentials-button').exists()).toBe(false)
@@ -137,7 +137,7 @@ describe('Entity Menu - entities', () => {
     await Vue.nextTick()
 
     expect(wrapper.findComponent(StaffComments).exists()).toBe(false)
-    expect(wrapper.find('#company-information-button').exists()).toBe(false)
+    expect(wrapper.find('#business-information-button').exists()).toBe(false)
     expect(wrapper.find('#dissolution-button').exists()).toBe(false)
     expect(wrapper.find('#download-summary-button').exists()).toBe(false)
     expect(wrapper.find('#view-add-digital-credentials-button').exists()).toBe(false)
@@ -192,7 +192,7 @@ describe('Entity Menu - View and Change Business Information button', () => {
       })
 
       // verify button
-      const companyInformationButton = wrapper.find('#company-information-button')
+      const companyInformationButton = wrapper.find('#business-information-button')
       expect(companyInformationButton.exists()).toBe(_.buttonExists)
 
       wrapper.destroy()
@@ -238,7 +238,7 @@ describe('Entity Menu - View and Change Business Information click tests', () =>
     })
     await Vue.nextTick()
 
-    await wrapper.find('#company-information-button').trigger('click')
+    await wrapper.find('#business-information-button').trigger('click')
 
     // verify redirection
     const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
@@ -266,7 +266,7 @@ describe('Entity Menu - View and Change Business Information click tests', () =>
     })
     await Vue.nextTick()
 
-    await wrapper.find('#company-information-button').trigger('click')
+    await wrapper.find('#business-information-button').trigger('click')
 
     // verify redirection
     const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id

--- a/tests/unit/EntityMenu.spec.ts
+++ b/tests/unit/EntityMenu.spec.ts
@@ -344,7 +344,7 @@ describe('Entity Menu - Dissolve this Business click tests', () => {
     await wrapper.find('.menu-btn').trigger('click')
     expect(wrapper.find('#dissolution-list-item').exists()).toBe(true)
     expect(wrapper.find('#dissolution-list-item').text()).toBe('Dissolve this Business')
-    expect(wrapper.find('#dissolution-list-item').classes()).not.toContain('v-btn--disabled') // enabled
+    expect(wrapper.find('#dissolution-list-item').classes()).not.toContain('v-list-item--disabled') // enabled
 
     wrapper.destroy()
   })
@@ -372,6 +372,7 @@ describe('Entity Menu - Dissolve this Business click tests', () => {
   it('emits Not In Good Standing event if not in good standing', async () => {
     businessStore.setGoodStanding(false)
     businessStore.setState(EntityState.ACTIVE)
+    rootStore.keycloakRoles = [] // regular user
 
     // mount the component and wait for everything to stabilize
     const wrapper = mount(EntityMenu, {
@@ -424,7 +425,20 @@ describe('Entity Menu - Business Summary click tests', () => {
   })
 })
 
-describe('Entity Menu - Digital Business Cards click tests', () => {
+describe('Entity Menu - Digital Business Cards tests', () => {
+  it('renders More actions if historical and digital credential feature is allowed', async () => {
+    businessStore.setState(EntityState.HISTORICAL)
+
+    const wrapper = mount(EntityMenu, {
+      vuetify,
+      mixins: [{ methods: { isAllowed: () => true } }],
+      propsData: { businessId: 'BC1234567' }
+    })
+
+    expect(wrapper.find('.menu-btn').exists()).toBe(true)
+    wrapper.destroy()
+  })
+
   it('displays the Digital Business Cards button', async () => {
     // mount the component and wait for everything to stabilize
     const wrapper = mount(EntityMenu, {
@@ -499,19 +513,6 @@ describe('Entity Menu - More actions click tests', () => {
   })
 })
 
-it('renders More actions if historical and digital credential feature is allowed', async () => {
-  businessStore.setState(EntityState.HISTORICAL)
-
-  const wrapper = mount(EntityMenu, {
-    vuetify,
-    mixins: [{ methods: { isAllowed: () => true } }],
-    propsData: { businessId: 'BC1234567' }
-  })
-
-  expect(wrapper.find('.menu-btn').exists()).toBe(true)
-  wrapper.destroy()
-})
-
 describe('Entity Menu - Consent to Amalgamation Out click tests', () => {
   beforeAll(() => {
     // override feature flag
@@ -545,7 +546,8 @@ describe('Entity Menu - Consent to Amalgamation Out click tests', () => {
 
     expect(wrapper.find('#consent-amalgamate-out-list-item').exists()).toBe(true)
     expect(wrapper.find('#consent-amalgamate-out-list-item').text()).toBe('Consent to Amalgamate Out')
-    expect(wrapper.find('#consent-amalgamate-out-list-item').classes()).not.toContain('v-btn--disabled') // enabled
+    // eslint-disable-next-line max-len
+    expect(wrapper.find('#consent-amalgamate-out-list-item').classes()).not.toContain('v-list-item--disabled') // enabled
 
     wrapper.destroy()
   })
@@ -584,7 +586,7 @@ describe('Entity Menu - Consent to Continuation Out click tests', () => {
 
     expect(wrapper.find('#consent-continue-out-list-item').exists()).toBe(true)
     expect(wrapper.find('#consent-continue-out-list-item').text()).toBe('Consent to Continue Out')
-    expect(wrapper.find('#consent-continue-out-list-item').classes()).not.toContain('v-btn--disabled') // enabled
+    expect(wrapper.find('#consent-continue-out-list-item').classes()).not.toContain('v-list-item--disabled') // enabled
 
     wrapper.destroy()
   })
@@ -622,7 +624,7 @@ describe('Entity Menu - Request AGM Extension click tests', () => {
 
     expect(wrapper.find('#agm-ext-list-item').exists()).toBe(true)
     expect(wrapper.find('#agm-ext-list-item').text()).toBe('Request AGM Extension')
-    expect(wrapper.find('#agm-ext-list-item').classes()).not.toContain('v-btn--disabled') // enabled
+    expect(wrapper.find('#agm-ext-list-item').classes()).not.toContain('v-list-item--disabled') // enabled
 
     wrapper.destroy()
   })
@@ -660,7 +662,7 @@ describe('Entity Menu - Request AGM Location Change click tests', () => {
 
     expect(wrapper.find('#agm-loc-chg-list-item').exists()).toBe(true)
     expect(wrapper.find('#agm-loc-chg-list-item').text()).toBe('Request AGM Location Change')
-    expect(wrapper.find('#agm-loc-chg-list-item').classes()).not.toContain('v-btn--disabled') // enabled
+    expect(wrapper.find('#agm-loc-chg-list-item').classes()).not.toContain('v-list-item--disabled') // enabled
 
     wrapper.destroy()
   })

--- a/tests/unit/StaffNotation.spec.ts
+++ b/tests/unit/StaffNotation.spec.ts
@@ -136,7 +136,7 @@ describe('StaffNotation', () => {
           { name: FilingTypes.REGISTRARS_ORDER },
           { name: FilingTypes.COURT_ORDER },
           { name: FilingTypes.CONVERSION },
-          { name: FilingTypes.DISSOLUTION }, // FUTURE: add dissolution type
+          { name: FilingTypes.DISSOLUTION, type: FilingSubTypes.DISSOLUTION_ADMINISTRATIVE },
           { name: FilingTypes.RESTORATION, type: FilingSubTypes.FULL_RESTORATION },
           { name: FilingTypes.PUT_BACK_ON },
           { name: FilingTypes.ADMIN_FREEZE },
@@ -165,6 +165,12 @@ describe('StaffNotation', () => {
   })
 
   it('renders drop-down menu correctly - full list, all allowed actions', async () => {
+    vi.spyOn(utils, 'GetFeatureFlag').mockImplementation(flag => {
+      if (flag === 'supported-dissolution-entities') return 'SP'
+      if (flag === 'supported-put-back-on-entities') return 'SP'
+      return null
+    })
+
     const wrapper = mount(StaffNotation, { vuetify })
 
     // open menu
@@ -248,10 +254,11 @@ describe('StaffNotation', () => {
 
   it('renders drop-down menu correctly - not firm', async () => {
     vi.spyOn(utils, 'GetFeatureFlag').mockImplementation(flag => {
-      if (flag === 'supported-consent-amalgamation-out-entities') return 'BEN'
       if (flag === 'supported-amalgamation-out-entities') return 'BEN'
       if (flag === 'supported-consent-continuation-out-entities') return 'BEN'
+      if (flag === 'supported-consent-amalgamation-out-entities') return 'BEN'
       if (flag === 'supported-continuation-out-entities') return 'BEN'
+      if (flag === 'supported-dissolution-entities') return 'BEN'
       return null
     })
 
@@ -265,7 +272,6 @@ describe('StaffNotation', () => {
     await wrapper.find('.menu-btn').trigger('click')
     expect(wrapper.vm.$data.expand).toBe(true)
 
-    console.log(wrapper.html())
     // verify items
     expect(wrapper.find('[data-type="record-conversion"]').exists()).toBe(false) // firms only
     expect(wrapper.find('[data-type="consent-amalgamate-out"]').exists()).toBe(true)

--- a/tests/unit/TodoList1.spec.ts
+++ b/tests/unit/TodoList1.spec.ts
@@ -47,7 +47,7 @@ const AllowableActionsMixin: any = {
   }
 }
 
-describe('TodoList - UI', () => {
+describe('TodoList - UI - Coops', () => {
   beforeAll(() => {
     sessionStorage.clear()
     sessionStorage.setItem('BUSINESS_ID', 'CP0001191')
@@ -1846,7 +1846,7 @@ describe('TodoList - UI - Amalgamation Applications', () => {
   })
 })
 
-describe('TodoList - Click Tests', () => {
+describe('TodoList - Click Tests - Coops', () => {
   const { assign } = window.location
 
   beforeAll(() => {
@@ -2852,7 +2852,7 @@ describe('TodoList - Click Tests - Alterations', () => {
   })
 })
 
-describe('TodoList - Delete Draft', () => {
+describe('TodoList - Delete draft', () => {
   const { assign } = window.location
   let deleteCall: any
 
@@ -2874,10 +2874,98 @@ describe('TodoList - Delete Draft', () => {
     sinon.restore()
   })
 
-  it('shows confirmation popup when \'Delete Draft\' is clicked', async () => {
+  it('allows resuming a restoration draft if not in good standing (as staff)', async () => {
     // init session storage and store
     sessionStorage.clear()
-    sessionStorage.setItem('BUSINESS_ID', 'CP0001191')
+    sessionStorage.setItem('BUSINESS_ID', 'BC0007291')
+    businessStore.setLegalType(CorpTypeCd.BENEFIT_COMPANY)
+    businessStore.setGoodStanding(false)
+    rootStore.tasks = [
+      {
+        task: {
+          filing: {
+            header: {
+              name: FilingTypes.RESTORATION,
+              status: FilingStatus.DRAFT,
+              filingId: 789
+            },
+            business: {
+              legalType: CorpTypeCd.BENEFIT_COMPANY
+            },
+            restoration: {
+              type: 'limitedRestorationToFull'
+            }
+          } as any
+        },
+        enabled: true,
+        order: 1
+      }
+    ]
+    rootStore.keycloakRoles = ['staff'] // only staff may resume draft alterations
+
+    const wrapper = mount(TodoList, { vuetify, mixins: [AllowableActionsMixin] })
+    await Vue.nextTick()
+
+    // verify item title
+    expect(wrapper.find('.list-item__title').text()).toContain('Limited Restoration To Full')
+
+    // verify action buttons
+    expect(wrapper.find('.btn-draft-delete').exists()).toBe(false)
+    expect(wrapper.find('.btn-draft-resume').exists()).toBe(true)
+    expect(wrapper.find('.actions__more-actions__btn').exists()).toBe(true)
+
+    businessStore.setGoodStanding(true)
+    wrapper.destroy()
+  })
+
+  it('doesn\'t allow resuming an alteration draft if not in good standing (as reg user)', async () => {
+    // init session storage and store
+    sessionStorage.clear()
+    sessionStorage.setItem('BUSINESS_ID', 'BC0007291')
+    businessStore.setLegalType(CorpTypeCd.BENEFIT_COMPANY)
+    businessStore.setGoodStanding(false)
+    rootStore.tasks = [
+      {
+        task: {
+          filing: {
+            header: {
+              name: FilingTypes.ALTERATION,
+              status: FilingStatus.DRAFT,
+              filingId: 789
+            },
+            business: {
+              legalType: CorpTypeCd.BENEFIT_COMPANY
+            },
+            alteration: {
+            }
+          } as any
+        },
+        enabled: true,
+        order: 1
+      }
+    ]
+    rootStore.keycloakRoles = []
+
+    const wrapper = mount(TodoList, { vuetify, mixins: [AllowableActionsMixin] })
+    await Vue.nextTick()
+
+    // verify item title
+    expect(wrapper.find('.list-item__title').text()).toContain('Alteration')
+
+    // verify action buttons
+    expect(wrapper.find('.btn-draft-delete').exists()).toBe(true)
+    expect(wrapper.find('.btn-draft-resume').exists()).toBe(false)
+    expect(wrapper.find('.actions__more-actions__btn').exists()).toBe(false)
+
+    businessStore.setGoodStanding(true)
+    wrapper.destroy()
+  })
+
+  it('shows confirmation popup when \'Delete draft\' is clicked', async () => {
+    // init session storage and store
+    sessionStorage.clear()
+    sessionStorage.setItem('BUSINESS_ID', 'BC0007291')
+    businessStore.setLegalType(CorpTypeCd.BENEFIT_COMPANY)
     rootStore.tasks = [
       {
         task: {
@@ -2916,7 +3004,10 @@ describe('TodoList - Delete Draft', () => {
   })
 
   it('calls DELETE endpoint when user clicks confirmation OK', async () => {
-    // init store
+    // init session storage and store
+    sessionStorage.clear()
+    sessionStorage.setItem('BUSINESS_ID', 'BC0007291')
+    businessStore.setLegalType(CorpTypeCd.BENEFIT_COMPANY)
     rootStore.tasks = [
       {
         task: {
@@ -2962,7 +3053,10 @@ describe('TodoList - Delete Draft', () => {
   })
 
   it('does not call DELETE endpoint when user clicks confirmation Cancel', async () => {
-    // init store
+    // init session storage and store
+    sessionStorage.clear()
+    sessionStorage.setItem('BUSINESS_ID', 'BC0007291')
+    businessStore.setLegalType(CorpTypeCd.BENEFIT_COMPANY)
     rootStore.tasks = [
       {
         task: {
@@ -3285,7 +3379,7 @@ describe('TodoList - Click Tests - Full and Limited Restoration', () => {
   }
 })
 
-describe('TodoList - Click Tests - Extension and Coversion Restoration', () => {
+describe('TodoList - Click Tests - Restoration Extension and Conversion', () => {
   const { assign } = window.location
 
   beforeAll(() => {

--- a/tests/unit/allowable-actions-mixin.spec.ts
+++ b/tests/unit/allowable-actions-mixin.spec.ts
@@ -80,12 +80,21 @@ describe('Allowable Actions Mixin', () => {
   })
 
   it('identifies whether Administrative Dissolution is allowed', () => {
-    // verify no allowed filing type
+    vi.spyOn(vm, 'getLegalType', 'get').mockReturnValue(CorpTypeCd.BC_COMPANY)
+
+    // verify allowed filing type but no feature flag
+    setAllowedFilingType({ name: FilingTypes.DISSOLUTION, type: FilingSubTypes.DISSOLUTION_ADMINISTRATIVE })
+    setFeatureFlag([])
+    expect(vm.isAllowed(AllowableActions.ADMINISTRATIVE_DISSOLUTION)).toBe(false)
+
+    // verify feature flag but no allowed filing type
+    setFeatureFlag([CorpTypeCd.BC_COMPANY])
     setAllowedFilingType()
     expect(vm.isAllowed(AllowableActions.ADMINISTRATIVE_DISSOLUTION)).toBe(false)
 
-    // verify allowed filing type
-    setAllowedFilingType({ name: FilingTypes.DISSOLUTION })
+    // verify both feature flag and allowed filing type
+    setFeatureFlag([CorpTypeCd.BC_COMPANY])
+    setAllowedFilingType({ name: FilingTypes.DISSOLUTION, type: FilingSubTypes.DISSOLUTION_ADMINISTRATIVE })
     expect(vm.isAllowed(AllowableActions.ADMINISTRATIVE_DISSOLUTION)).toBe(true)
   })
 
@@ -403,7 +412,7 @@ describe('Allowable Actions Mixin', () => {
     vi.spyOn(vm, 'getLegalType', 'get').mockReturnValue(CorpTypeCd.BC_COMPANY)
 
     // verify allowed filing type but no feature flag
-    setAllowedFilingType({ name: FilingTypes.DISSOLUTION })
+    setAllowedFilingType({ name: FilingTypes.DISSOLUTION, type: FilingSubTypes.DISSOLUTION_VOLUNTARY })
     setFeatureFlag([])
     expect(vm.isAllowed(AllowableActions.VOLUNTARY_DISSOLUTION)).toBe(false)
 
@@ -414,7 +423,7 @@ describe('Allowable Actions Mixin', () => {
 
     // verify both feature flag and allowed filing type
     setFeatureFlag([CorpTypeCd.BC_COMPANY])
-    setAllowedFilingType({ name: FilingTypes.DISSOLUTION })
+    setAllowedFilingType({ name: FilingTypes.DISSOLUTION, type: FilingSubTypes.DISSOLUTION_VOLUNTARY })
     expect(vm.isAllowed(AllowableActions.VOLUNTARY_DISSOLUTION)).toBe(true)
   })
 })


### PR DESCRIPTION
*Issue #:* bcgov/entity#16481

*Description of changes:*
- app version = 7.1.9
- disabled AR checkbox when filing is not allowed
- added template block for "show delete only"
- implemented "show delete only" for dissolution
- implemented "show delete only" for alteration
- implemented "show delete only" for special resolution
- allowed resuming draft restoration even when NIGS
- added getters for Change Business Info button and Voluntary Dissolution list item
- added special case to enable button/item even if not allowed
- updated (simplified) logic for changing business info or showing dialog
- updated logic for confirming Voluntary Dissolution or showing dialog
- added missing subtype checks when computing whether Dissolutions are allowed
- added missing Admin Dissolution feature flag check
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).