### PR TITLE
20534-remove-details-field-for-users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.2.1",
+      "version": "7.2.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/DetailComment.vue
+++ b/src/components/common/DetailComment.vue
@@ -41,12 +41,6 @@ export default class DetailComment extends Vue {
   /** Max Length passed into this component (optional). */
   @Prop({ default: 4096 }) readonly maxLength!: number
 
-  /** Role passed into this component. */
-  @Prop({ default: false }) readonly isRoleStaff: boolean
-
-  /** Comment is for continuationOut (optional) */
-  @Prop({ default: false }) readonly isContinuationOutDetailComment!: boolean
-
   /** Autofocus passed into this component (optional). */
   @Prop({ default: false }) readonly autofocus!: boolean
 
@@ -60,11 +54,6 @@ export default class DetailComment extends Vue {
 
   /** Array of validations rules for the textarea. */
   get rules (): Array<(val) => boolean | string> {
-    // Check if it should bypass rules based on specific conditions
-    if (!this.isRoleStaff && this.isContinuationOutDetailComment) {
-      return [() => true] // Always returns true under these conditions
-    }
-
     // include whitespace in maximum length check
     return [
       val => (val && val.trim().length > 0) || this.textRequiredErrorMsg,

--- a/src/components/common/DetailComment.vue
+++ b/src/components/common/DetailComment.vue
@@ -41,6 +41,12 @@ export default class DetailComment extends Vue {
   /** Max Length passed into this component (optional). */
   @Prop({ default: 4096 }) readonly maxLength!: number
 
+  /** Role passed into this component. */
+  @Prop({ default: false }) readonly isRoleStaff: boolean
+
+  /** Comment is for continuationOut (optional) */
+  @Prop({ default: false }) readonly isContinuationOutDetailComment!: boolean
+
   /** Autofocus passed into this component (optional). */
   @Prop({ default: false }) readonly autofocus!: boolean
 
@@ -54,6 +60,11 @@ export default class DetailComment extends Vue {
 
   /** Array of validations rules for the textarea. */
   get rules (): Array<(val) => boolean | string> {
+    // Check if it should bypass rules based on specific conditions
+    if (!this.isRoleStaff && this.isContinuationOutDetailComment) {
+      return [() => true] // Always returns true under these conditions
+    }
+
     // include whitespace in maximum length check
     return [
       val => (val && val.trim().length > 0) || this.textRequiredErrorMsg,

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -886,7 +886,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
 
   @Watch('certifyFormValid')
   @Watch('courtOrderValid')
-  @Watch('detailCommentValid')
   @Watch('documentDeliveryValid')
   onHaveChanges (): void {
     this.haveChanges = true

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -61,50 +61,6 @@
               </h1>
             </header>
 
-            <!-- Ledger Detail -->
-            <section v-if="isRoleStaff">
-              <header>
-                <h2>Ledger Detail</h2>
-                <p class="grey-text">
-                  Enter a detail that will appear on the ledger for this entity.
-                </p>
-              </header>
-              <div
-                id="detail-comment-section"
-                :class="{ 'invalid-section': !detailCommentValid && showErrors }"
-              >
-                <v-card
-                  flat
-                  class="py-8 px-5"
-                >
-                  <v-row no-gutters>
-                    <v-col
-                      cols="12"
-                      sm="3"
-                      class="pr-4"
-                    >
-                      <strong :class="{ 'app-red': !detailCommentValid && showErrors }">Detail</strong>
-                    </v-col>
-                    <v-col
-                      cols="12"
-                      sm="9"
-                    >
-                      <p class="grey-text font-weight-bold">
-                        {{ defaultComment }}
-                      </p>
-                      <DetailComment
-                        ref="detailCommentRef"
-                        v-model="detailComment"
-                        placeholder="Add a Detail that will appear on the ledger for this entity."
-                        :maxLength="maxDetailCommentLength"
-                        @valid="detailCommentValid=$event"
-                      />
-                    </v-col>
-                  </v-row>
-                </v-card>
-              </div>
-            </section>
-
             <!-- Effective Date of Continuation -->
             <section>
               <header>
@@ -347,7 +303,7 @@ import { Getter } from 'pinia-class'
 import { StatusCodes } from 'http-status-codes'
 import { navigate } from '@/utils'
 import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
-import { BusinessNameForeign, Certify, DetailComment, EffectiveDate, ForeignJurisdiction } from '@/components/common'
+import { BusinessNameForeign, Certify, EffectiveDate, ForeignJurisdiction } from '@/components/common'
 import { ConfirmDialog, ResumeErrorDialog, SaveErrorDialog }
   from '@/components/dialogs'
 import { CommonMixin, DateMixin, EnumMixin, FilingMixin, ResourceLookupMixin } from '@/mixins'
@@ -365,7 +321,6 @@ import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
     Certify,
     ConfirmDialog,
     CourtOrderPoa,
-    DetailComment,
     DocumentDelivery,
     EffectiveDate,
     ForeignJurisdiction,
@@ -381,7 +336,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
     businessNameForeignRef: BusinessNameForeign,
     confirm: ConfirmDialogType,
     certifyRef: Certify,
-    detailCommentRef: DetailComment,
     effectiveDateRef: EffectiveDate,
     foreignJurisdictionRef: ForeignJurisdiction,
   }
@@ -394,10 +348,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
 
   // enum for template
   readonly FilingCodes = FilingCodes
-
-  // variables for DetailComment component
-  detailComment = null
-  detailCommentValid = false
 
   // variables for EffectiveDate component
   initialEffectiveDate = ''
@@ -455,17 +405,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
     return (!this.dataLoaded && !this.saveErrorReason)
   }
 
-  /** Default comment (ie, the first line of the detail comment). */
-  get defaultComment (): string {
-    return 'Continuation Out'
-  }
-
-  /** Maximum length of detail comment. */
-  get maxDetailCommentLength (): number {
-    // = (max size in db) - (default comment length) - (Carriage Return)
-    return 2000 - this.defaultComment.length - 1
-  }
-
   /** The Base URL string. */
   get baseUrl (): string {
     return sessionStorage.getItem('BASE_URL')
@@ -473,10 +412,9 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
 
   /** True if page is valid, else False. */
   get isPageValid (): boolean {
-    return (this.detailCommentValid && this.effectiveDateValid &&
+    return (this.effectiveDateValid && this.certifyFormValid &&
       this.foreignJurisdictionValid && this.businessNameValid &&
-      this.documentDeliveryValid && this.courtOrderValid &&
-      this.certifyFormValid)
+      this.documentDeliveryValid && this.courtOrderValid)
   }
 
   /** True when saving, saving and resuming, or filing and paying. */
@@ -568,10 +506,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
 
       // load Certified By (but not Date)
       this.certifiedBy = filing.header.certifiedBy
-
-      // load Detail Comment, removing the first line (default comment)
-      const comment: string = filing.continuationOut.details || ''
-      this.detailComment = comment.split('\n').slice(1).join('\n')
 
       const courtOrder = filing.continuationOut.courtOrder
       if (courtOrder) {
@@ -700,10 +634,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
     if (!this.isPageValid) {
       this.showErrors = true
 
-      // Show error messages of components if invalid
-      if (!this.detailCommentValid) {
-        this.$refs.detailCommentRef.$refs.textarea.error = true
-      }
       if (!this.certifyFormValid) {
         this.$refs.certifyRef.$refs.certifyTextfieldRef.error = true
       }
@@ -816,7 +746,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
 
     const data: any = {
       [FilingTypes.CONTINUATION_OUT]: {
-        details: `${this.defaultComment}\n${this.detailComment}`,
         continuationOutDate: this.effectiveDate,
         foreignJurisdiction: {
           country: this.selectedCountry,
@@ -935,7 +864,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
 
   /** Array of valid components. Must match validFlags. */
   readonly validComponents = [
-    'detail-comment-section',
     'effective-date-section',
     'jurisdiction-information-section',
     'business-information-section',
@@ -947,7 +875,6 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
   /** Object of valid flags. Must match validComponents. */
   get validFlags (): object {
     return {
-      detailComment: this.detailCommentValid,
       effectiveDate: this.effectiveDateValid,
       foreignJurisdiction: this.foreignJurisdictionValid,
       businessInformation: this.businessNameValid,

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -62,7 +62,7 @@
             </header>
 
             <!-- Ledger Detail -->
-            <section>
+            <section v-if="isRoleStaff">
               <header>
                 <h2>Ledger Detail</h2>
                 <p class="grey-text">
@@ -97,6 +97,8 @@
                         v-model="detailComment"
                         placeholder="Add a Detail that will appear on the ledger for this entity."
                         :maxLength="maxDetailCommentLength"
+                        :isRoleStaff="isRoleStaff"
+                        :isContinuationOutDetailComment="true"
                         @valid="detailCommentValid=$event"
                       />
                     </v-col>
@@ -396,7 +398,7 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin,
   readonly FilingCodes = FilingCodes
 
   // variables for DetailComment component
-  detailComment = ''
+  detailComment = null
   detailCommentValid = false
 
   // variables for EffectiveDate component

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -97,8 +97,6 @@
                         v-model="detailComment"
                         placeholder="Add a Detail that will appear on the ledger for this entity."
                         :maxLength="maxDetailCommentLength"
-                        :isRoleStaff="isRoleStaff"
-                        :isContinuationOutDetailComment="true"
                         @valid="detailCommentValid=$event"
                       />
                     </v-col>

--- a/tests/unit/ContinuationOut.spec.ts
+++ b/tests/unit/ContinuationOut.spec.ts
@@ -59,7 +59,6 @@ describe('Continuation Out view', () => {
     expect(wrapper.findComponent(Certify).exists()).toBe(true)
     expect(wrapper.findComponent(ConfirmDialog).exists()).toBe(true)
     expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(true)
-    expect(wrapper.findComponent(DetailComment).exists()).toBe(true)
     expect(wrapper.findComponent(DocumentDelivery).exists()).toBe(true)
     expect(wrapper.findComponent(EffectiveDate).exists()).toBe(true)
     expect(wrapper.findComponent(ForeignJurisdiction).exists()).toBe(true)
@@ -122,16 +121,6 @@ describe('Continuation Out view', () => {
     vm.effectiveDateValid = true
     vm.foreignJurisdictionValid = true
     expect(!!vm.isPageValid).toBe(true)
-
-    // verify "validated" - invalid Detail Comment form
-    vm.businessNameValid = true
-    vm.certifyFormValid = true
-    vm.courtOrderValid = true
-    vm.detailCommentValid = false
-    vm.documentDeliveryValid = true
-    vm.effectiveDateValid = true
-    vm.foreignJurisdictionValid = true
-    expect(!!vm.isPageValid).toBe(false)
 
     // verify "validated" - invalid Certify form
     vm.businessNameValid = true
@@ -314,7 +303,6 @@ describe('Continuation Out view', () => {
 
     expect(vm.certifiedBy).toBe('Johnny Certifier')
     // NB: line 1 (default comment) should be removed
-    expect(vm.detailComment).toBe('Line 2\nLine 3')
     expect(vm.initialEffectiveDate).toBe('2023-06-10')
     expect(vm.initialBusinessName).toBe('North Shore Toys LTD.')
     expect(vm.initialCountry).toBe('CA')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20534

Updated the details field for continue out so it's required for Staff filings but not for regular users. 

Set the default value to null


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
