### PR TITLE
21439 - Fixed Unknown Name when registration is in draft

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.2.9",
+  "version": "7.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.2.9",
+      "version": "7.2.10",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.2.9",
+  "version": "7.2.10",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/stores/businessStore.ts
+++ b/src/stores/businessStore.ts
@@ -93,10 +93,12 @@ export const useBusinessStore = defineStore('business', {
 
     /** The legal name or alternate name if is firm. */
     getLegalName (state: BusinessStateIF): string {
+      const rootStore = useRootStore()
+
       if (!GetFeatureFlag('enable-legal-name-fix')) {
         return state.businessInfo.legalName
       }
-      if (this.isFirm) {
+      if (this.isFirm && !rootStore.isDraftRegistration) {
         return this.getAlternateName
       } else {
         return state.businessInfo.legalName


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21439

*Description of changes:*
When the registration is draft, the code was checking for the name from alternate names but that doesn't exist at that point. When that is the case, we need to use the legal name as before. So, I simply added that check.

Before:
![before sp](https://github.com/bcgov/business-filings-ui/assets/122301442/b6074446-cf31-4df0-9672-f5153d063564)

After:
![after sp](https://github.com/bcgov/business-filings-ui/assets/122301442/96841865-d63b-43b3-8a8b-e837eaaeb215)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
