### PR TITLE
21439 - Fixed unknown name when firm is filed and pending

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.2.11",
+  "version": "7.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.2.11",
+      "version": "7.2.12",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.2.11",
+  "version": "7.2.12",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/stores/businessStore.ts
+++ b/src/stores/businessStore.ts
@@ -98,7 +98,7 @@ export const useBusinessStore = defineStore('business', {
       if (!GetFeatureFlag('enable-legal-name-fix')) {
         return state.businessInfo.legalName
       }
-      if (this.isFirm && !rootStore.isDraftRegistration) {
+      if (this.isFirm && !rootStore.isDraftRegistration  && !rootStore.isFiledRegistration) {
         return this.getAlternateName
       } else {
         return state.businessInfo.legalName

--- a/src/stores/businessStore.ts
+++ b/src/stores/businessStore.ts
@@ -98,7 +98,7 @@ export const useBusinessStore = defineStore('business', {
       if (!GetFeatureFlag('enable-legal-name-fix')) {
         return state.businessInfo.legalName
       }
-      if (this.isFirm && !rootStore.isDraftRegistration  && !rootStore.isFiledRegistration) {
+      if (this.isFirm && !rootStore.isDraftRegistration && !rootStore.isFiledRegistration) {
         return this.getAlternateName
       } else {
         return state.businessInfo.legalName


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21439

*Description of changes:*
In my last PR, i missed the case when the firm is filed but still not completed. Basically what I had before `isDraftRegistration` was not enough.

When the SP or GP is filed and pending, it's not draft anymore but at the same time it's not completed. So, the alternate names array is not found.


Before:
![before unknown](https://github.com/bcgov/business-filings-ui/assets/122301442/f93f3bb9-ace8-401d-841d-9c78b2f9d4cf)

After:
![after sp unknown](https://github.com/bcgov/business-filings-ui/assets/122301442/133a8c91-c118-4113-b157-4b9831c211b6)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
