### PR TITLE
21846 Updated list of filings enabled/disabled for corrections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.5",
+  "version": "7.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.3.5",
+      "version": "7.3.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.5",
+  "version": "7.3.6",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -699,7 +699,7 @@ export default class App extends Mixins(
     const filingName = EnumUtilities.filingTypeToName(header.name, null, data.type)
 
     // save display name for later
-    filing.displayName = EnumUtilities.isTypeAmalgamation(header)
+    filing.displayName = EnumUtilities.isTypeAmalgamationApplication(header)
       ? filingName
       : `${description}${dba}${filingName}`
 
@@ -727,7 +727,7 @@ export default class App extends Mixins(
 
     const description = GetCorpFullDescription(data.nameRequest.legalType)
     const filingName = EnumUtilities.filingTypeToName(header.name, null, data.type)
-    const displayName = EnumUtilities.isTypeAmalgamation(header)
+    const displayName = EnumUtilities.isTypeAmalgamationApplication(header)
       ? filingName
       : `${description} ${filingName}`
 

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -144,7 +144,7 @@ export default class FilingHistoryList extends Mixins(FilingMixin) {
       case filing.availableOnPaperOnly: return 'paper-filing' // must come first
       case EnumUtilities.isTypeAgmExtension(filing): return 'agm-extension'
       case EnumUtilities.isTypeAlteration(filing): return 'alteration-filing'
-      case EnumUtilities.isTypeAmalgamation(filing): return 'amalgamation-filing'
+      case EnumUtilities.isTypeAmalgamationApplication(filing): return 'amalgamation-filing'
       case EnumUtilities.isTypeChangeOfAddress(filing): return 'change-of-address'
       case EnumUtilities.isTypeConsentContinuationOut(filing): return 'consent-continuation-out'
       case EnumUtilities.isTypeContinuationIn(filing): return 'continuation-in'

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -177,7 +177,7 @@ export default class HeaderActions extends Mixins(AllowableActionsMixin) {
       case EnumUtilities.isTypeRegistrarsNotation(this.filing): return true // staff filing not allowed
       case EnumUtilities.isTypeRegistrarsOrder(this.filing): return true // staff filing not allowed
       case EnumUtilities.isTypeRestoration(this.filing): return true // not supported
-      case EnumUtilities.isTypeSpecialResolution(this.filing): break
+      case EnumUtilities.isTypeSpecialResolution(this.filing): return true // not supported
       case EnumUtilities.isTypeTransition(this.filing): return true // not supported
     }
 

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -79,7 +79,7 @@
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
-import { AllowableActions, Routes } from '@/enums'
+import { AllowableActions } from '@/enums'
 import { FilingTypes } from '@bcrs-shared-components/enums'
 import { ApiFilingIF } from '@/interfaces'
 import { AllowableActionsMixin } from '@/mixins'
@@ -114,33 +114,75 @@ export default class HeaderActions extends Mixins(AllowableActionsMixin) {
 
   /**
    * Whether to disable correction for THIS filing.
-   * This is function instead of a getter so that we always query the realtime FF.
+   * (This is function instead of a getter so that we always query the realtime FF.)
    */
   disableCorrection (): boolean {
-    // first check allowable actions
+    // disable if not allowed
     if (!this.isAllowed(AllowableActions.CORRECTION)) return true
 
-    const conditions: Array<() => boolean> = []
-    // list of conditions to DISABLE correction
-    // (any condition not listed below is ALLOWED)
-    conditions[0] = () => this.filing.availableOnPaperOnly
-    conditions[1] = () => this.isTypeStaff
-    conditions[2] = () => (
+    // disable if filing is paper-only
+    if (this.filing.availableOnPaperOnly) return true
+
+    // disable if filing is future effective but is not completed or corrected
+    if (
       this.filing.isFutureEffective &&
       !EnumUtilities.isStatusCompleted(this.filing) &&
       !EnumUtilities.isStatusCorrected(this.filing)
-    )
-    conditions[3] = () => (EnumUtilities.isTypeIncorporationApplication(this.filing) &&
-      !this.isBaseCompany && !this.isCoop)
-    conditions[4] = () => (EnumUtilities.isTypeChangeOfRegistration(this.filing) && !this.isFirm)
-    conditions[5] = () => (EnumUtilities.isTypeCorrection(this.filing) && !this.isFirm &&
-      !this.isBaseCompany && !this.isCoop)
-    conditions[6] = () => (EnumUtilities.isTypeRegistration(this.filing) && !this.isFirm)
-    conditions[7] = () => (EnumUtilities.isTypeAmalgamation(this.filing) && !this.isBaseCompany)
-    conditions[8] = () => (EnumUtilities.isTypeContinuationIn(this.filing) && !this.isBaseCompany)
+    ) return true
 
-    // check if any condition is True
-    return conditions.some(condition => condition())
+    // disable for certain filing types
+    switch (true) {
+      case EnumUtilities.isTypeAdminFreeze(this.filing): return true // staff filing not allowed
+      case EnumUtilities.isTypeAlteration(this.filing): break
+      case EnumUtilities.isTypeAgmExtension(this.filing): return true // not supported
+      case EnumUtilities.isTypeAgmLocationChange(this.filing): return true // not supported
+      case EnumUtilities.isTypeAmalgamationApplication(this.filing):
+        // disable if not a base company (safety check for filing compatibility)
+        if (!this.isBaseCompany) return true
+        break
+      case EnumUtilities.isTypeAmalgamationOut(this.filing): return true // not supported
+      case EnumUtilities.isTypeAnnualReport(this.filing): return true // not supported
+      case EnumUtilities.isTypeChangeOfAddress(this.filing): break
+      case EnumUtilities.isTypeChangeOfCompanyInfo(this.filing): return true // not supported
+      case EnumUtilities.isTypeChangeOfDirectors(this.filing): break
+      case EnumUtilities.isTypeChangeOfName(this.filing): break
+      case EnumUtilities.isTypeChangeOfRegistration(this.filing):
+        // disable if not a firm (safety check for filing compatibility)
+        if (!this.isFirm) return true
+        break
+      case EnumUtilities.isTypeConsentAmalgamationOut(this.filing): return true // not supported
+      case EnumUtilities.isTypeConsentContinuationOut(this.filing): return true // not supported
+      case EnumUtilities.isTypeContinuationIn(this.filing):
+        // disable if not a base company (safety check for filing compatibility)
+        if (!this.isBaseCompany) return true
+        break
+      case EnumUtilities.isTypeContinuationOut(this.filing): return true // not supported
+      case EnumUtilities.isTypeConversion(this.filing): return true // not supported
+      case EnumUtilities.isTypeCorrection(this.filing):
+        // disable if not a firm, base company, or coop (safety check for filing compatibility)
+        if (!this.isFirm && !this.isBaseCompany && !this.isCoop) return true
+        break
+      case EnumUtilities.isTypeCourtOrder(this.filing): return true // staff filing not allowed
+      case EnumUtilities.isTypeDissolution(this.filing): return true // not supported
+      case EnumUtilities.isTypeDissolved(this.filing): return true // not supported
+      case EnumUtilities.isTypeIncorporationApplication(this.filing):
+        // disable if not a base company or coop (safety check for filing compatibility)
+        if (!this.isBaseCompany && !this.isCoop) return true
+        break
+      case EnumUtilities.isTypePutBackOn(this.filing): return true // staff filing not allowed
+      case EnumUtilities.isTypeRegistration(this.filing):
+        // disable if not a firm (safety check for filing compatibility)
+        if (!this.isFirm) return true
+        break
+      case EnumUtilities.isTypeRegistrarsNotation(this.filing): return true // staff filing not allowed
+      case EnumUtilities.isTypeRegistrarsOrder(this.filing): return true // staff filing not allowed
+      case EnumUtilities.isTypeRestoration(this.filing): return true // not supported
+      case EnumUtilities.isTypeSpecialResolution(this.filing): break
+      case EnumUtilities.isTypeTransition(this.filing): return true // not supported
+    }
+
+    // if we get this far then don't disable correction
+    return false
   }
 
   /** Called by File a Correction button to correct the subject filing. */
@@ -157,7 +199,7 @@ export default class HeaderActions extends Mixins(AllowableActionsMixin) {
         // correction via Edit UI
         this.setCurrentFiling(filing)
         this.setFileCorrectionDialog(true)
-        break
+        return
 
       case FilingTypes.CHANGE_OF_ADDRESS:
       case FilingTypes.CHANGE_OF_DIRECTORS:
@@ -165,26 +207,14 @@ export default class HeaderActions extends Mixins(AllowableActionsMixin) {
           // correction via Edit UI if current type is BEN/BC/CC/ULC/C/CBEN/CCC/CUL or CP
           this.setCurrentFiling(filing)
           this.setFileCorrectionDialog(true)
-          break
-        } else {
-          // Local correction otherwise
-          this.$router.push({
-            name: Routes.CORRECTION,
-            params: { correctedFilingId: filing.filingId.toString() }
-          })
-          break
+          return
         }
-
-      case FilingTypes.ANNUAL_REPORT:
-      case FilingTypes.CONVERSION:
-      default:
-        // local correction for all other filings
-        this.$router.push({
-          name: Routes.CORRECTION,
-          params: { correctedFilingId: filing.filingId.toString() }
-        })
         break
     }
+
+    // correction is not supported for all other filings
+    // eslint-disable-next-line no-console
+    console.log('correctThisFiling(), invalid correction type for filing =', this.filing)
   }
 }
 </script>

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -130,50 +130,50 @@ export default class HeaderActions extends Mixins(AllowableActionsMixin) {
       !EnumUtilities.isStatusCorrected(this.filing)
     ) return true
 
-    // disable for certain filing types
+    // disable/allow according to filing type
     switch (true) {
       case EnumUtilities.isTypeAdminFreeze(this.filing): return true // staff filing not allowed
-      case EnumUtilities.isTypeAlteration(this.filing): break
+      case EnumUtilities.isTypeAlteration(this.filing): return false
       case EnumUtilities.isTypeAgmExtension(this.filing): return true // not supported
       case EnumUtilities.isTypeAgmLocationChange(this.filing): return true // not supported
       case EnumUtilities.isTypeAmalgamationApplication(this.filing):
         // disable if not a base company (safety check for filing compatibility)
         if (!this.isBaseCompany) return true
-        break
+        return false
       case EnumUtilities.isTypeAmalgamationOut(this.filing): return true // not supported
       case EnumUtilities.isTypeAnnualReport(this.filing): return true // not supported
-      case EnumUtilities.isTypeChangeOfAddress(this.filing): break
+      case EnumUtilities.isTypeChangeOfAddress(this.filing): return false
       case EnumUtilities.isTypeChangeOfCompanyInfo(this.filing): return true // not supported
-      case EnumUtilities.isTypeChangeOfDirectors(this.filing): break
-      case EnumUtilities.isTypeChangeOfName(this.filing): break
+      case EnumUtilities.isTypeChangeOfDirectors(this.filing): return false
+      case EnumUtilities.isTypeChangeOfName(this.filing): return false
       case EnumUtilities.isTypeChangeOfRegistration(this.filing):
         // disable if not a firm (safety check for filing compatibility)
         if (!this.isFirm) return true
-        break
+        return false
       case EnumUtilities.isTypeConsentAmalgamationOut(this.filing): return true // not supported
       case EnumUtilities.isTypeConsentContinuationOut(this.filing): return true // not supported
       case EnumUtilities.isTypeContinuationIn(this.filing):
         // disable if not a base company (safety check for filing compatibility)
         if (!this.isBaseCompany) return true
-        break
+        return false
       case EnumUtilities.isTypeContinuationOut(this.filing): return true // not supported
       case EnumUtilities.isTypeConversion(this.filing): return true // not supported
       case EnumUtilities.isTypeCorrection(this.filing):
         // disable if not a firm, base company, or coop (safety check for filing compatibility)
         if (!this.isFirm && !this.isBaseCompany && !this.isCoop) return true
-        break
+        return false
       case EnumUtilities.isTypeCourtOrder(this.filing): return true // staff filing not allowed
       case EnumUtilities.isTypeDissolution(this.filing): return true // not supported
       case EnumUtilities.isTypeDissolved(this.filing): return true // not supported
       case EnumUtilities.isTypeIncorporationApplication(this.filing):
         // disable if not a base company or coop (safety check for filing compatibility)
         if (!this.isBaseCompany && !this.isCoop) return true
-        break
+        return false
       case EnumUtilities.isTypePutBackOn(this.filing): return true // staff filing not allowed
       case EnumUtilities.isTypeRegistration(this.filing):
         // disable if not a firm (safety check for filing compatibility)
         if (!this.isFirm) return true
-        break
+        return false
       case EnumUtilities.isTypeRegistrarsNotation(this.filing): return true // staff filing not allowed
       case EnumUtilities.isTypeRegistrarsOrder(this.filing): return true // staff filing not allowed
       case EnumUtilities.isTypeRestoration(this.filing): return true // not supported
@@ -181,8 +181,10 @@ export default class HeaderActions extends Mixins(AllowableActionsMixin) {
       case EnumUtilities.isTypeTransition(this.filing): return true // not supported
     }
 
-    // if we get this far then don't disable correction
-    return false
+    // eslint-disable-next-line no-console
+    console.log('disableCorrection(), unhandled filing =', this.filing)
+
+    return true // safe fallback
   }
 
   /** Called by File a Correction button to correct the subject filing. */

--- a/src/mixins/enum-mixin.ts
+++ b/src/mixins/enum-mixin.ts
@@ -46,8 +46,8 @@ export default class EnumMixin extends Vue {
     return (item.name === FilingTypes.ALTERATION)
   }
 
-  /** DEPRECATED Returns True if filing is an Amalgamation. */
-  isTypeAmalgamation (item: any): boolean {
+  /** DEPRECATED Returns True if filing is an Amalgamation Application. */
+  isTypeAmalgamationApplication (item: any): boolean {
     return (item.name === FilingTypes.AMALGAMATION_APPLICATION)
   }
 

--- a/src/services/enum-utilities.ts
+++ b/src/services/enum-utilities.ts
@@ -91,6 +91,11 @@ export default class EnumUtilities {
     return (item.name === FilingTypes.CHANGE_OF_ADDRESS)
   }
 
+  /** Returns True if filing is a Change of of Company Info. */
+  static isTypeChangeOfCompanyInfo (item: any): boolean {
+    return (item.name === FilingTypes.CHANGE_OF_COMPANY_INFO)
+  }
+
   /** Returns True if filing is a Change of Directors. */
   static isTypeChangeOfDirectors (item: any): boolean {
     return (item.name === FilingTypes.CHANGE_OF_DIRECTORS)
@@ -106,7 +111,17 @@ export default class EnumUtilities {
     return (item.name === FilingTypes.CHANGE_OF_REGISTRATION)
   }
 
-  /** Returns True if filing is a Consent to Continuation Out. */
+  /** Returns True if filing is an Amalgamation Out. */
+  static isTypeAmalgamationOut (item: any): boolean {
+    return (item.name === FilingTypes.AMALGAMATION_OUT)
+  }
+
+  /** Returns True if filing is a Consent for Amalgamation Out. */
+  static isTypeConsentAmalgamationOut (item: any): boolean {
+    return (item.name === FilingTypes.CONSENT_AMALGAMATION_OUT)
+  }
+
+  /** Returns True if filing is a Consent for Continuation Out. */
   static isTypeConsentContinuationOut (item: any): boolean {
     return (item.name === FilingTypes.CONSENT_CONTINUATION_OUT)
   }
@@ -136,8 +151,13 @@ export default class EnumUtilities {
     return (item.name === FilingTypes.DISSOLUTION)
   }
 
-  /** Returns True if filing is an Amalgamation. */
-  static isTypeAmalgamation (item: any): boolean {
+  /** Returns True if filing is a Dissolved. */
+  static isTypeDissolved (item: any): boolean {
+    return (item.name === FilingTypes.DISSOLVED)
+  }
+
+  /** Returns True if filing is an Amalgamation Application. */
+  static isTypeAmalgamationApplication (item: any): boolean {
     return (item.name === FilingTypes.AMALGAMATION_APPLICATION)
   }
 
@@ -181,7 +201,7 @@ export default class EnumUtilities {
     return (item.name === FilingTypes.REGISTRATION)
   }
 
-  /** Returns True if filing is a Restoration. */
+  /** Returns True if filing is a Restoration (of any subtype). */
   static isTypeRestoration (item: any): boolean {
     return (item.name === FilingTypes.RESTORATION)
   }
@@ -227,7 +247,7 @@ export default class EnumUtilities {
   }
 
   /** Returns True if filing is a Registrar's Order. */
-  static isTypeRegistarsOrder (item: any): boolean {
+  static isTypeRegistrarsOrder (item: any): boolean {
     return (item.name === FilingTypes.REGISTRARS_ORDER)
   }
 
@@ -298,8 +318,8 @@ export default class EnumUtilities {
       this.isTypeCourtOrder(item) ||
       this.isTypeDissolutionAdministrative(item) ||
       this.isTypePutBackOn(item) ||
-      this.isTypeRegistarsOrder(item) ||
-      this.isTypeRegistrarsNotation(item)
+      this.isTypeRegistrarsNotation(item) ||
+      this.isTypeRegistrarsOrder(item)
     )
   }
 

--- a/src/stores/rootStore.ts
+++ b/src/stores/rootStore.ts
@@ -188,7 +188,7 @@ export const useRootStore = defineStore('root', {
         (state.tasks.length === 0) &&
         // only the Amalgamation or IA or Registration filing history item
         (filingHistoryListStore.getFilings.length === 1) && (
-          EnumUtilities.isTypeAmalgamation(filingHistoryListStore.getFilings[0]) ||
+          EnumUtilities.isTypeAmalgamationApplication(filingHistoryListStore.getFilings[0]) ||
           EnumUtilities.isTypeIncorporationApplication(filingHistoryListStore.getFilings[0]) ||
           EnumUtilities.isTypeRegistration(filingHistoryListStore.getFilings[0])
         )

--- a/tests/unit/HeaderActions.spec.ts
+++ b/tests/unit/HeaderActions.spec.ts
@@ -39,7 +39,7 @@ describe('Header Actions component - disableCorrection()', () => {
     wrapper.destroy()
   })
 
-  it('returns allowed (disabled=false) when no conditions', async () => {
+  it('returns allowed (disabled=false) when no conditions are met', async () => {
     // no conditions
     vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
     await wrapper.setProps({ filing })

--- a/tests/unit/HeaderActions.spec.ts
+++ b/tests/unit/HeaderActions.spec.ts
@@ -59,6 +59,7 @@ describe('Header Actions component - disableCorrection()', () => {
     FilingTypes.DISSOLUTION,
     FilingTypes.DISSOLVED,
     FilingTypes.RESTORATION,
+    FilingTypes.SPECIAL_RESOLUTION,
     FilingTypes.TRANSITION
   ]
 

--- a/tests/unit/HeaderActions.spec.ts
+++ b/tests/unit/HeaderActions.spec.ts
@@ -9,17 +9,6 @@ import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 setActivePinia(createPinia())
 const businessStore = useBusinessStore()
 
-const baseCompanies = [
-  CorpTypeCd.BC_COMPANY,
-  CorpTypeCd.BENEFIT_COMPANY,
-  CorpTypeCd.CONTINUE_IN,
-  CorpTypeCd.BEN_CONTINUE_IN,
-  CorpTypeCd.BC_CCC,
-  CorpTypeCd.CCC_CONTINUE_IN,
-  CorpTypeCd.ULC_CONTINUE_IN,
-  CorpTypeCd.BC_ULC_COMPANY
-]
-
 const filing = {
   availableOnPaperOnly: false,
   isFutureEffectiveIa: false,
@@ -39,168 +28,181 @@ describe('Header Actions component - disableCorrection()', () => {
     wrapper.destroy()
   })
 
-  it('returns allowed (disabled=false) when no conditions are met', async () => {
-    // no conditions
-    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+  it('correction is disabled when corrections are not allowed', async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(false)
     await wrapper.setProps({ filing })
-    expect(vm.disableCorrection()).toBe(false)
+    expect(vm.disableCorrection()).toBe(true)
   })
 
-  it('returns allowed (disabled=false) when conditions[2]', async () => {
-    // conditions[2]: FE filing that is Completed or Corrected
-    for (const status of [FilingStatus.COMPLETED, FilingStatus.CORRECTED]) {
-      await wrapper.setProps({ filing: { ...filing, isFutureEffective: true, status } })
-      expect(vm.disableCorrection()).toBe(false)
-    }
-  })
-
-  it('returns allowed (disabled=false) when conditions[3]', async () => {
-    // conditions[3]: IA as a BC/BEN/C/CBEN/CC/CCC/CUL/ULC
-    for (const entityType of baseCompanies) {
-      businessStore.setLegalType(entityType as any)
-      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.INCORPORATION_APPLICATION } })
-      expect(vm.disableCorrection()).toBe(false)
-    }
-  })
-
-  it('returns allowed (disabled=false) when conditions[4]', async () => {
-    // conditions[4]: Change of Registration as a firm
-    for (const entityType of [CorpTypeCd.SOLE_PROP, CorpTypeCd.PARTNERSHIP]) {
-      businessStore.setLegalType(entityType as any)
-      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CHANGE_OF_REGISTRATION } })
-      expect(vm.disableCorrection({ ...filing, name: FilingTypes.CHANGE_OF_REGISTRATION })).toBe(false)
-    }
-  })
-
-  it('returns allowed (disabled=false) when conditions[5]', async () => {
-    // conditions[5]: Correction as a firm or BC/BEN/C/CBEN/CC/CCC/CUL/ULC
-    for (const entityType of [CorpTypeCd.SOLE_PROP, CorpTypeCd.PARTNERSHIP, ...baseCompanies]) {
-      businessStore.setLegalType(entityType as any)
-      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CORRECTION } })
-      expect(vm.disableCorrection({ ...filing, name: FilingTypes.CORRECTION })).toBe(false)
-    }
-  })
-
-  it('returns allowed (disabled=false) when conditions[6]', async () => {
-    // conditions[6]: Registration as a firm
-    for (const entityType of [CorpTypeCd.SOLE_PROP, CorpTypeCd.PARTNERSHIP]) {
-      businessStore.setLegalType(entityType as any)
-      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.REGISTRATION } })
-      expect(vm.disableCorrection({ ...filing, name: FilingTypes.REGISTRATION })).toBe(false)
-    }
-  })
-
-  it('returns allowed (disabled=false) when conditions[7]', async () => {
-    // conditions[7]: Amalgamation as a BC/BEN/C/CBEN/CC/CCC/CUL/ULC
-    for (const entityType of baseCompanies) {
-      businessStore.setLegalType(entityType as any)
-      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.AMALGAMATION_APPLICATION } })
-      expect(vm.disableCorrection({ ...filing, name: FilingTypes.AMALGAMATION_APPLICATION })).toBe(false)
-    }
-  })
-
-  it('returns allowed (disabled=false) when conditions[8]', async () => {
-    // conditions[8]: Continuation In as a BC/BEN/C/CBEN/CC/CCC/CUL/ULC
-    for (const entityType of baseCompanies) {
-      businessStore.setLegalType(entityType as any)
-      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CONTINUATION_IN } })
-      expect(vm.disableCorrection({ ...filing, name: FilingTypes.CONTINUATION_IN })).toBe(false)
-    }
-  })
-
-  it('returns allowed (disabled=false) when misc filings', async () => {
-    // Annual Report, Alteration, Change of Address, Change of Directors, Conversion
-    const names = [
-      FilingTypes.ANNUAL_REPORT,
-      FilingTypes.ALTERATION,
-      FilingTypes.CHANGE_OF_ADDRESS,
-      FilingTypes.CHANGE_OF_DIRECTORS,
-      FilingTypes.CONVERSION
-    ]
-    for (const name of names) {
-      await wrapper.setProps({ filing: { ...filing } })
-      expect(vm.disableCorrection({ ...filing, name })).toBe(false)
-    }
-  })
-
-  it('returns not allowed (disabled=true) when conditions[0]', async () => {
-    // only conditions[0]
+  it('correction is disabled when filing is available on paper only', async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
     await wrapper.setProps({ filing: { ...filing, availableOnPaperOnly: true } })
     expect(vm.disableCorrection()).toBe(true)
   })
 
-  it('returns not allowed (disabled=true) when conditions[1]', async () => {
-    const names = [
-      FilingTypes.ADMIN_FREEZE,
-      FilingTypes.COURT_ORDER,
-      FilingTypes.PUT_BACK_ON,
-      FilingTypes.REGISTRARS_ORDER,
-      FilingTypes.REGISTRARS_NOTATION
-    ]
-    // only conditions[1]
-    for (const name of names) {
+  it('correction is disabled when filing is future effective and not completed or corrected', async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+    await wrapper.setProps({ filing: { ...filing, isFutureEffective: true, status: FilingStatus.PENDING } })
+    expect(vm.disableCorrection()).toBe(true)
+  })
+
+  const NOT_SUPPORTED = [
+    FilingTypes.AGM_EXTENSION,
+    FilingTypes.AGM_LOCATION_CHANGE,
+    FilingTypes.AMALGAMATION_OUT,
+    FilingTypes.ANNUAL_REPORT,
+    FilingTypes.CHANGE_OF_COMPANY_INFO,
+    FilingTypes.CONSENT_AMALGAMATION_OUT,
+    FilingTypes.CONSENT_CONTINUATION_OUT,
+    FilingTypes.CONTINUATION_OUT,
+    FilingTypes.CONVERSION,
+    FilingTypes.DISSOLUTION,
+    FilingTypes.DISSOLVED,
+    FilingTypes.RESTORATION,
+    FilingTypes.TRANSITION
+  ]
+
+  for (const name of NOT_SUPPORTED) {
+    it(`correction is disabled when filing is an unsupported type '${name}''`, async () => {
+      vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
       await wrapper.setProps({ filing: { ...filing, name } })
       expect(vm.disableCorrection()).toBe(true)
-    }
-  })
+    })
+  }
 
-  it('returns not allowed (disabled=true) when conditions[2]', async () => {
-    const statuses = [
-      FilingStatus.CANCELLED,
-      FilingStatus.DELETED,
-      FilingStatus.DRAFT,
-      FilingStatus.ERROR,
-      FilingStatus.NEW,
-      FilingStatus.PAID,
-      FilingStatus.PENDING,
-      FilingStatus.WITHDRAWN
-    ]
-    // only conditions[2]
-    for (const status of statuses) {
-      await wrapper.setProps({ filing: { ...filing, isFutureEffective: true, status } })
+  const STAFF_FILINGS = [
+    FilingTypes.ADMIN_FREEZE,
+    FilingTypes.COURT_ORDER,
+    FilingTypes.PUT_BACK_ON,
+    FilingTypes.REGISTRARS_ORDER,
+    FilingTypes.REGISTRARS_NOTATION
+  ]
+
+  for (const name of STAFF_FILINGS) {
+    it(`correction is disabled when filing is a staff type '${name}''`, async () => {
+      vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+      await wrapper.setProps({ filing: { ...filing, name } })
       expect(vm.disableCorrection()).toBe(true)
+    })
+  }
+
+  const ALLOWED = [
+    FilingTypes.ALTERATION,
+    FilingTypes.CHANGE_OF_ADDRESS,
+    FilingTypes.CHANGE_OF_DIRECTORS,
+    FilingTypes.CHANGE_OF_NAME
+  ]
+
+  for (const name of ALLOWED) {
+    it(`correction is enabled when filing is type '${name}''`, async () => {
+      vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+      await wrapper.setProps({ filing: { ...filing, name } })
+      expect(vm.disableCorrection()).toBe(false)
+    })
+  }
+
+  const baseCompanies = [
+    CorpTypeCd.BC_COMPANY,
+    CorpTypeCd.BENEFIT_COMPANY,
+    CorpTypeCd.CONTINUE_IN,
+    CorpTypeCd.BEN_CONTINUE_IN,
+    CorpTypeCd.BC_CCC,
+    CorpTypeCd.CCC_CONTINUE_IN,
+    CorpTypeCd.ULC_CONTINUE_IN,
+    CorpTypeCd.BC_ULC_COMPANY
+  ]
+
+  const firms = [
+    CorpTypeCd.PARTNERSHIP,
+    CorpTypeCd.SOLE_PROP
+  ]
+
+  it(`correction is enabled for an 'amalgamationApplication' depending on legal type`, async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+    // enabled
+    for (const legalType of baseCompanies) {
+      businessStore.setLegalType(legalType)
+      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.AMALGAMATION_APPLICATION } })
+      expect(vm.disableCorrection()).toBe(false)
     }
-  })
-
-  it('returns not allowed (disabled=true) when conditions[3]', async () => {
-    // only conditions[3]: IA as not a CP nor BC/BEN/C/CBEN/CC/CCC/CUL/ULC
-    businessStore.setLegalType(CorpTypeCd.SOLE_PROP)
-    await wrapper.setProps({ filing: { ...filing, name: FilingTypes.INCORPORATION_APPLICATION } })
+    // disabled
+    businessStore.setLegalType(null)
+    await wrapper.setProps({ filing: { ...filing, name: FilingTypes.AMALGAMATION_APPLICATION } })
     expect(vm.disableCorrection()).toBe(true)
   })
 
-  it('returns not allowed (disabled=true) when conditions[4]', async () => {
-    // only conditions[4]: Change of Registration as not a firm
-    businessStore.setLegalType(CorpTypeCd.COOP)
-    await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CHANGE_OF_REGISTRATION } })
+  it(`correction is enabled for a 'registration' depending on legal type`, async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+    // enabled
+    for (const legalType of firms) {
+      businessStore.setLegalType(legalType)
+      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.REGISTRATION } })
+      expect(vm.disableCorrection()).toBe(false)
+    }
+    // disabled
+    businessStore.setLegalType(null)
+    await wrapper.setProps({ filing: { ...filing, name: FilingTypes.REGISTRATION } })
     expect(vm.disableCorrection()).toBe(true)
   })
 
-  it('returns not allowed (disabled=true) when conditions[5]', async () => {
-    // only conditions[5]: Correction as not a firm nor CP nor BC/BEN/C/CBEN/CC/CCC/CUL/ULC
+  it(`correction is enabled for a 'continuationIn' depending on legal type`, async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+    // enabled
+    for (const legalType of baseCompanies) {
+      businessStore.setLegalType(legalType)
+      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CONTINUATION_IN } })
+      expect(vm.disableCorrection()).toBe(false)
+    }
+    // disabled
+    businessStore.setLegalType(null)
+    await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CONTINUATION_IN } })
+    expect(vm.disableCorrection()).toBe(true)
+  })
+
+  it(`correction is enabled for a 'correction' depending on legal type`, async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+    // enabled
+    for (const legalType of [...firms, ...baseCompanies, CorpTypeCd.COOP]) {
+      businessStore.setLegalType(legalType)
+      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CORRECTION } })
+      expect(vm.disableCorrection()).toBe(false)
+    }
+    // disabled
     businessStore.setLegalType(null)
     await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CORRECTION } })
     expect(vm.disableCorrection()).toBe(true)
   })
 
-  it('returns not allowed (disabled=true) when conditions[6]', async () => {
-    // only conditions[6]: Registration as not a firm
-    businessStore.setLegalType(CorpTypeCd.COOP)
+  it(`correction is enabled for an 'incorporationApplication' depending on legal type`, async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+    // enabled
+    for (const legalType of [...baseCompanies, CorpTypeCd.COOP]) {
+      businessStore.setLegalType(legalType)
+      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.INCORPORATION_APPLICATION } })
+      expect(vm.disableCorrection()).toBe(false)
+    }
+    // disabled
+    businessStore.setLegalType(null)
+    await wrapper.setProps({ filing: { ...filing, name: FilingTypes.INCORPORATION_APPLICATION } })
+    expect(vm.disableCorrection()).toBe(true)
+  })
+
+  it(`correction is enabled for a 'registration' depending on legal type`, async () => {
+    vi.spyOn(vm, 'isAllowed').mockReturnValue(true)
+    // enabled
+    for (const legalType of firms) {
+      businessStore.setLegalType(legalType)
+      await wrapper.setProps({ filing: { ...filing, name: FilingTypes.REGISTRATION } })
+      expect(vm.disableCorrection()).toBe(false)
+    }
+    // disabled
+    businessStore.setLegalType(null)
     await wrapper.setProps({ filing: { ...filing, name: FilingTypes.REGISTRATION } })
     expect(vm.disableCorrection()).toBe(true)
   })
 
-  it('returns not allowed (disabled=true) when conditions[7]', async () => {
-    // only conditions[7]: Amalgamation as not a BC/BEN/C/CBEN/CC/CCC/CUL/ULC
-    businessStore.setLegalType(CorpTypeCd.COOP)
-    await wrapper.setProps({ filing: { ...filing, name: FilingTypes.AMALGAMATION_APPLICATION } })
-    expect(vm.disableCorrection()).toBe(true)
-  })
-
-  it('returns not allowed (disabled=true) when conditions[8]', async () => {
-    // only conditions[8]: Continuation In as not a BC/BEN/C/CBEN/CC/CCC/CUL/ULC
-    businessStore.setLegalType(CorpTypeCd.COOP)
-    await wrapper.setProps({ filing: { ...filing, name: FilingTypes.CONTINUATION_IN } })
+  it('correction is disabled when filing is unhandled', async () => {
+    await wrapper.setProps({ filing })
     expect(vm.disableCorrection()).toBe(true)
   })
 })

--- a/tests/unit/TodoList1.spec.ts
+++ b/tests/unit/TodoList1.spec.ts
@@ -2722,69 +2722,6 @@ describe('TodoList - Click Tests - Corrections', () => {
       wrapper.destroy()
     })
   }
-
-  // courtOrder is not a valid filing for Corrections
-  const localTest = ['annualReport', 'changeOfAddress', 'changeOfDirectors', 'conversion', 'changeOfName',
-    'courtOrder', 'dissolution', 'dissolved', 'involuntaryDissolution', 'putBackOn', 'registrarsNotation',
-    'registrarsOrder', 'transition', 'voluntaryDissolution']
-
-  for (const test of localTest) {
-    it(`Router pushes locally to resume a draft ${test} correction`, async () => {
-      // init draft Correction filing task
-      rootStore.tasks = [
-        {
-          task: {
-            filing: {
-              header: {
-                name: FilingTypes.CORRECTION,
-                status: FilingStatus.DRAFT,
-                filingId: 123,
-                comments: []
-              },
-              business: {},
-              correction: {
-                correctedFilingType: test,
-                correctedFilingId: 456
-              }
-            } as any
-          },
-          enabled: true,
-          order: 1
-        }
-      ]
-      rootStore.keycloakRoles = ['staff'] // only staff may resume draft corrections
-
-      const localVue = createLocalVue()
-      localVue.use(VueRouter)
-      const router = mockRouter.mock()
-
-      const wrapper = mount(TodoList, { localVue, router, vuetify, mixins: [AllowableActionsMixin] })
-      const vm = wrapper.vm as any
-      await Vue.nextTick()
-
-      expect(vm.todoItems.length).toEqual(1)
-      expect(wrapper.find('.todo-subtitle span').text()).toBe('DRAFT')
-
-      await wrapper.find('.btn-draft-resume').trigger('click')
-
-      // wait for save to complete and everything to update
-      // await flushPromises()
-
-      // verify routing to Correction page with filing id = 123 and corrected filing id = 456
-      if (test !== 'changeOfAddress' && test !== 'changeOfDirectors') {
-        expect(vm.$route.name).toBe('correction')
-        expect(vm.$route.params.filingId).toBe('123')
-        expect(vm.$route.params.correctedFilingId).toBe('456')
-      } else {
-        // verify redirection if correction of change of Address/Directors
-        const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
-        const editUrl = 'https://edit.url/BC1234567/correction/?correction-id=123'
-        expect(window.location.assign).toHaveBeenCalledWith(editUrl + '&accountid=' + accountId)
-      }
-
-      wrapper.destroy()
-    })
-  }
 })
 
 describe('TodoList - Click Tests - Alterations', () => {

--- a/tests/unit/enum-utilities.spec.ts
+++ b/tests/unit/enum-utilities.spec.ts
@@ -36,7 +36,7 @@ describe('Enum Utilities', () => {
     expect(EnumUtilities.isTypeIncorporationApplication({ name: 'incorporationApplication' })).toBe(true)
     expect(EnumUtilities.isTypePutBackOn({ name: 'putBackOn' })).toBe(true)
     expect(EnumUtilities.isTypeRegistrarsNotation({ name: 'registrarsNotation' })).toBe(true)
-    expect(EnumUtilities.isTypeRegistarsOrder({ name: 'registrarsOrder' })).toBe(true)
+    expect(EnumUtilities.isTypeRegistrarsOrder({ name: 'registrarsOrder' })).toBe(true)
     expect(EnumUtilities.isTypeRegistration({ name: 'registration' })).toBe(true)
     expect(EnumUtilities.isTypeRestoration({ name: 'restoration' })).toBe(true)
     expect(EnumUtilities.isTypeRestorationFull({ name: 'restoration', filingSubType: 'fullRestoration' })).toBe(true)


### PR DESCRIPTION
*Issue #:* bcgov/entity#21846

*Description of changes:*
- app version = 7.3.6
- renamed isTypeAmalgamation() -> isTypeAmalgamationApplication()
- updated doResumeFiling() to remove local correction routing
- refactored disableCorrection() to clearly show what happens for all filing types
- added some store getters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).