### PR TITLE
21928 Allow corrections for missing types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.6",
+  "version": "7.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.3.6",
+      "version": "7.3.7",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.6",
+  "version": "7.3.7",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
+++ b/src/components/Dashboard/FilingHistoryList/HeaderActions.vue
@@ -80,7 +80,6 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { AllowableActions } from '@/enums'
-import { FilingTypes } from '@bcrs-shared-components/enums'
 import { ApiFilingIF } from '@/interfaces'
 import { AllowableActionsMixin } from '@/mixins'
 import { EnumUtilities } from '@/services'
@@ -189,34 +188,9 @@ export default class HeaderActions extends Mixins(AllowableActionsMixin) {
 
   /** Called by File a Correction button to correct the subject filing. */
   async correctThisFiling (filing: ApiFilingIF): Promise<void> {
-    // see also TodoList.vue:doResumeFiling()
-    switch (filing?.name) {
-      case FilingTypes.ALTERATION:
-      case FilingTypes.AMALGAMATION_APPLICATION:
-      case FilingTypes.CHANGE_OF_REGISTRATION:
-      case FilingTypes.CORRECTION:
-      case FilingTypes.INCORPORATION_APPLICATION:
-      case FilingTypes.REGISTRATION:
-      case FilingTypes.SPECIAL_RESOLUTION:
-        // correction via Edit UI
-        this.setCurrentFiling(filing)
-        this.setFileCorrectionDialog(true)
-        return
-
-      case FilingTypes.CHANGE_OF_ADDRESS:
-      case FilingTypes.CHANGE_OF_DIRECTORS:
-        if (this.isBaseCompany || this.isCoop) {
-          // correction via Edit UI if current type is BEN/BC/CC/ULC/C/CBEN/CCC/CUL or CP
-          this.setCurrentFiling(filing)
-          this.setFileCorrectionDialog(true)
-          return
-        }
-        break
-    }
-
-    // correction is not supported for all other filings
-    // eslint-disable-next-line no-console
-    console.log('correctThisFiling(), invalid correction type for filing =', this.filing)
+    // show file correction dialog, which will then route to Edit UI
+    this.setCurrentFiling(filing)
+    this.setFileCorrectionDialog(true)
   }
 }
 </script>

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -1878,12 +1878,6 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
 
   /** Resumes a draft filing. */
   doResumeFiling (item: TodoItemIF): void {
-    function navigateToCorrectionEditUi (editUrl: string, identifier: string): void {
-      // resume correction via Edit UI
-      const correctionUrl = `${editUrl}${identifier}/correction/?correction-id=${item.filingId}`
-      navigate(correctionUrl)
-    }
-
     switch (item.name) {
       case FilingTypes.AMALGAMATION_APPLICATION: {
         // navigate to Create UI to resume this Amalgamation
@@ -1928,32 +1922,12 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
         this.$router.push({ name: Routes.CONTINUATION_OUT, params: { filingId: item.filingId.toString() } })
         return
 
-      case FilingTypes.CORRECTION:
-        // see also ItemHeaderActions.vue:correctThisFiling()
-        switch (item.correctedFilingType) {
-          case FilingNames.ALTERATION:
-          case FilingNames.CHANGE_OF_REGISTRATION:
-          case FilingNames.CORRECTION:
-          case FilingNames.INCORPORATION_APPLICATION:
-          case FilingNames.REGISTRATION:
-          case FilingNames.SPECIAL_RESOLUTION:
-            // resume correction via Edit UI
-            navigateToCorrectionEditUi(this.getEditUrl, this.getIdentifier)
-            return
-
-          case FilingNames.CHANGE_OF_ADDRESS:
-          case FilingNames.CHANGE_OF_DIRECTORS:
-            if (this.isBaseCompany || this.isCoop) {
-              // resume correction via Edit UI if current type is BEN/BC/CC/ULC/C/CBEN/CCC/CUL or CP
-              navigateToCorrectionEditUi(this.getEditUrl, this.getIdentifier)
-              return
-            }
-            break
-        }
-        // resuming correction is not supported for all other filings
-        // eslint-disable-next-line no-console
-        console.log('doResumeFiling(), invalid correction type for item =', item)
+      case FilingTypes.CORRECTION: {
+        // resume correction via Edit UI
+        const correctionUrl = `${this.getEditUrl}${this.getIdentifier}/correction/?correction-id=${item.filingId}`
+        navigate(correctionUrl)
         return
+      }
 
       case FilingTypes.INCORPORATION_APPLICATION: {
         // navigate to Create UI to resume this Incorporation Application
@@ -2011,7 +1985,7 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, E
     }
 
     // eslint-disable-next-line no-console
-    console.log('doResumeFiling(), invalid type item =', item)
+    console.log('doResumeFiling(), invalid filing type =', item)
   }
 
   /* Handles the restoration flow inside of doResumeFiling */


### PR DESCRIPTION
*Issue #:* bcgov/entity#21928

*Description of changes:*
- app version = 7.3.7
- enabled resume for all correction filing types
- enabled correction for all correction filing types (that are not disabled)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).