### PR TITLE
22084 Clear data before reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.8",
+  "version": "7.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.3.8",
+      "version": "7.3.9",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.8",
+  "version": "7.3.9",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -348,7 +348,12 @@ export default class App extends Mixins(
   /** Called when component is created. */
   created (): void {
     // listen for reload data events
-    this.$root.$on('reloadData', () => this.fetchData())
+    this.$root.$on('reloadData', async () => {
+      // clear Todo List / Filing History List before fetching new data
+      this.setTasks([])
+      this.setFilings([])
+      await this.fetchData()
+    })
   }
 
   /** Called when component is mounted. */
@@ -856,7 +861,7 @@ export default class App extends Mixins(
   }
 
   /** Handles Retry click event from dialogs. */
-  onClickRetry (hard = false): void {
+  async onClickRetry (hard = false): Promise<void> {
     if (hard) {
       // clear session variables and hard-reload the page
       // to force new login and try again
@@ -868,7 +873,7 @@ export default class App extends Mixins(
       this.businessAuthErrorDialog = false
       this.nameRequestAuthErrorDialog = false
       this.nameRequestInvalidDialog = false
-      this.fetchData()
+      await this.fetchData()
     }
   }
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#22084

*Description of changes:*
- app version = 7.3.9
- clear existing tasks/filings before fetching new data
- added missing await in retry method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).