### PR TITLE
21824 Used textareas for latest review comments to preserve formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.18",
+  "version": "7.3.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.3.18",
+      "version": "7.3.19",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",
@@ -45,6 +45,7 @@
         "sbc-common-components": "3.0.13",
         "vue": "2.7.14",
         "vue-affix": "^0.5.2",
+        "vue-auto-resize": "^1.0.1",
         "vue-hotjar": "^1.4.0",
         "vue-router": "^3.6.5",
         "vue2-filters": "^0.14.0",
@@ -6394,6 +6395,11 @@
     "node_modules/vue-affix": {
       "version": "0.5.2",
       "license": "MIT"
+    },
+    "node_modules/vue-auto-resize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vue-auto-resize/-/vue-auto-resize-1.0.1.tgz",
+      "integrity": "sha512-sZK8uBGT8VXRxV2nI9MpBlxBA/qaK5gKxevK2AxldaeNl4Yumtb085ECLmneCtuBpzbcbfqWPBCpaeMmm1hQ6w=="
     },
     "node_modules/vue-class-component": {
       "version": "7.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.18",
+  "version": "7.3.19",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",
@@ -50,6 +50,7 @@
     "sbc-common-components": "3.0.13",
     "vue": "2.7.14",
     "vue-affix": "^0.5.2",
+    "vue-auto-resize": "^1.0.1",
     "vue-hotjar": "^1.4.0",
     "vue-router": "^3.6.5",
     "vue2-filters": "^0.14.0",

--- a/src/components/Dashboard/FilingHistoryList.vue
+++ b/src/components/Dashboard/FilingHistoryList.vue
@@ -196,12 +196,12 @@ export default class FilingHistoryList extends Mixins(FilingMixin) {
    * If there is a filing ID to highlight then it finds it and expands its panel.
    */
   @Watch('getFilings', { immediate: true })
-  onFilingsChange (): void {
+  async onFilingsChange (): Promise<void> {
     // if needed, highlight a specific filing
     if (this.highlightId) {
       const index = this.getFilings.findIndex(f => (f.filingId === this.highlightId))
       if (index >= 0) { // safety check
-        this.toggleFilingHistoryItem(index)
+        await this.toggleFilingHistoryItem(index)
       }
     }
   }

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -609,9 +609,13 @@
               <p class="list-item__subtitle">
                 This {{ item.title }} is paid but requires you to make the following changes:
               </p>
-              <p class="list-item__subtitle font-italic">
-                {{ item.latestReviewComment || '[undefined staff change request message]' }}
-              </p>
+              <textarea
+                v-auto-resize
+                class="font-16 font-italic"
+                readonly
+                rows="1"
+                :value="item.latestReviewComment || '[undefined staff change request message]'"
+              />
             </div>
           </template>
 
@@ -686,6 +690,7 @@ import {
 import { GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module'
 import { useAuthenticationStore, useBusinessStore, useConfigurationStore, useFilingHistoryListStore,
   useRootStore } from '@/stores'
+import AutoResize from 'vue-auto-resize'
 
 @Component({
   components: {
@@ -706,6 +711,9 @@ import { useAuthenticationStore, useBusinessStore, useConfigurationStore, useFil
     PaymentPending,
     PaymentPendingOnlineBanking,
     PaymentUnsuccessful
+  },
+  directives: {
+    AutoResize
   }
 })
 export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin) {
@@ -2464,5 +2472,14 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin) {
 
 .pay-error {
   border-top: solid #a94442 3px;
+}
+
+textarea {
+  color: $gray7;
+  width: 100%;
+  resize: none;
+  // FUTURE: use field-sizing instead of "v-auto-resize" directive
+  // ref: https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing
+  // field-sizing: content;
 }
 </style>

--- a/tests/unit/ContinuationIn.spec.ts
+++ b/tests/unit/ContinuationIn.spec.ts
@@ -112,7 +112,7 @@ describe('Continuation In - in To Do list', () => {
     // verify expansion panel content
     expect(wrapper.find('.v-expansion-panel-content').text()).toContain('This BC Limited Company Continuation Application is')
     expect(wrapper.find('.v-expansion-panel-content').text()).toContain('paid but requires you to make the following changes:')
-    expect(wrapper.find('.v-expansion-panel-content').text()).toContain('Authorization document is not legible.')
+    expect((wrapper.find('textarea').element as any)._value).toBe('Authorization document is not legible.')
 
     // cleanup
     wrapper.destroy()
@@ -279,7 +279,8 @@ describe('Continuation In - in Recent Filing History list', () => {
     // verify expansion panel content
     expect(wrapper.find('.v-expansion-panel-content').text()).toContain('This BC Limited Company Continuation Application is')
     expect(wrapper.find('.v-expansion-panel-content').text()).toContain('rejected for the following reasons:')
-    expect(wrapper.find('.v-expansion-panel-content').text()).toContain('Authorization is invalid.')
+    expect((wrapper.find('textarea').element as any)._value).toBe('Authorization is invalid.')
+
     expect(wrapper.find('.v-expansion-panel-content').text()).toContain('You will receive a refund within 10 business days.')
     expect(wrapper.find('.v-expansion-panel-content').text()).toContain('Please submit a new application if you would like to')
     expect(wrapper.find('.v-expansion-panel-content').text()).toContain('continue your business into B.C.')


### PR DESCRIPTION
*Issue #:* bcgov/entity#21824

*Description of changes:*
- app version = 7.3.19
- added vue-auto-resize package (for textareas)
- awaited async function in FilingHistoryList.vue
- replaced paragraph with textarea in TodoList.vue
- replaced paragraph with textarea in ContinuationIn.vue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).