### PR TITLE
23337 - Add Court Order to Limited Restoration Extension Filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.24",
+  "version": "7.3.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.3.24",
+      "version": "7.3.25",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.3.24",
+  "version": "7.3.25",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/FilingHistoryList/filings/LimitedRestorationExtension.vue
+++ b/src/components/Dashboard/FilingHistoryList/filings/LimitedRestorationExtension.vue
@@ -16,6 +16,20 @@
       </p>
 
       <ContactInfo class="mt-4" />
+
+      <p
+        v-if="fileNumber"
+        class="mt-4 mb-0"
+      >
+        Court Order Number: {{ fileNumber }}
+      </p>
+
+      <p
+        v-if="hasEffectOfOrder"
+        class="mt-0"
+      >
+        Pursuant to a Plan of Arrangement
+      </p>
     </template>
   </FilingTemplate>
 </template>
@@ -42,6 +56,16 @@ export default class LimitedRestorationExtension extends Vue {
     const expiry = this.filing.data?.restoration?.expiry
     const date = DateUtilities.yyyyMmDdToDate(expiry)
     return (DateUtilities.dateToPacificDate(date, true) || '[unknown]')
+  }
+
+  /** The court order file number. */
+  get fileNumber (): string {
+    return this.filing.data?.order?.fileNumber
+  }
+
+  /** Whether the court order has an effect of order. */
+  get hasEffectOfOrder (): boolean {
+    return Boolean(this.filing.data?.order?.effectOfOrder)
   }
 }
 </script>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23337

*Description of changes:*
- Fixed: A Limited Restoration Extension was filed with a court order. The ledger should display the court order number.
- Tested A limit Restoration to full shows the court order properly.
- Tested other filing types where staff can enter a court order number (and POA) and verify that the respective ledger items show it.
   **Issue: Future Effective Voluntary Dissolution didn't show court order number.**
  Other types show properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
