### PR TITLE
23967 Make spinner pre-empt action button for in-process filings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.0",
+      "version": "7.4.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -352,7 +352,7 @@
                 </template>
 
                 <!-- default task -->
-                <template v-if="item.isDefaultTask">
+                <template v-else-if="item.isDefaultTask">
                   <!-- no action button in this case -->
                 </template>
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23967 and /bcgov/entity#23636

*Description of changes:*
- Fixed bug where spinner would show along with action button for in process filings.

_Before_
<img width="884" alt="Screenshot 2024-11-05 at 3 55 21 PM" src="https://github.com/user-attachments/assets/2fa1a006-4b35-4e7d-b1a4-054e94f08f07">

_After_
<img width="884" alt="Screenshot 2024-11-05 at 4 08 51 PM" src="https://github.com/user-attachments/assets/61a10157-b9ac-4401-a00c-6e341bb0d01c">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
