### PR TITLE
23969 do not authorize button spinner disabled after clicking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.1",
+      "version": "7.4.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -310,6 +310,8 @@
               <v-btn
                 class="ma-1 affiliation-invitation-action-button"
                 color="primary"
+                :loading="isAuthorizeLoading"
+                :disabled="isAuthorizeLoading || isDoNotAuthorizeLoading"
                 @click.native.stop="authorizeAffiliationInvitation(true, item)"
               >
                 <span>Authorize</span>
@@ -318,8 +320,8 @@
                 class="ma-1 affiliation-invitation-action-button"
                 outlined
                 color="primary"
-                :loading="isAffiliationLoading"
-                :disabled="isAffiliationLoading"
+                :loading="isDoNotAuthorizeLoading"
+                :disabled="isDoNotAuthorizeLoading || isAuthorizeLoading"
                 @click.native.stop="authorizeAffiliationInvitation(false, item)"
               >
                 <span>Do not authorize</span>
@@ -791,7 +793,8 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, N
   panel: number = null // currently expanded panel
   checkTimer = null // may be type number or NodeJS.Timeout
   inProcessFiling: number = null
-  isAffiliationLoading = false
+  isAuthorizeLoading = false
+  isDoNotAuthorizeLoading = false
   fetchAffiliationInvitationsErrorDialog = false
   authorizeAffiliationInvitationErrorDialog = false
 
@@ -1102,8 +1105,10 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, N
   }
 
   async authorizeAffiliationInvitation (isAuthorized: boolean, affiliationInvitationTodo: TodoItemIF) {
-    if (!isAuthorized) {
-      this.isAffiliationLoading = true
+    if (isAuthorized) {
+      this.isAuthorizeLoading = true
+    } else {
+      this.isDoNotAuthorizeLoading = true
     }
     const response = await AuthServices.authorizeAffiliationInvitation(
       this.getAuthApiUrl,
@@ -1115,7 +1120,8 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, N
       this.authorizeAffiliationInvitationErrorDialog = true
       return null
     }).finally(() => {
-      this.isAffiliationLoading = false
+      this.isAuthorizeLoading = false
+      this.isDoNotAuthorizeLoading = false
     })
 
     const index = this.todoItems.indexOf(affiliationInvitationTodo)

--- a/src/components/Dashboard/TodoList.vue
+++ b/src/components/Dashboard/TodoList.vue
@@ -318,6 +318,8 @@
                 class="ma-1 affiliation-invitation-action-button"
                 outlined
                 color="primary"
+                :loading="isAffiliationLoading"
+                :disabled="isAffiliationLoading"
                 @click.native.stop="authorizeAffiliationInvitation(false, item)"
               >
                 <span>Do not authorize</span>
@@ -789,6 +791,7 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, N
   panel: number = null // currently expanded panel
   checkTimer = null // may be type number or NodeJS.Timeout
   inProcessFiling: number = null
+  isAffiliationLoading = false
   fetchAffiliationInvitationsErrorDialog = false
   authorizeAffiliationInvitationErrorDialog = false
 
@@ -1099,6 +1102,9 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, N
   }
 
   async authorizeAffiliationInvitation (isAuthorized: boolean, affiliationInvitationTodo: TodoItemIF) {
+    if (!isAuthorized) {
+      this.isAffiliationLoading = true
+    }
     const response = await AuthServices.authorizeAffiliationInvitation(
       this.getAuthApiUrl,
       affiliationInvitationTodo.affiliationInvitationDetails.id,
@@ -1108,6 +1114,8 @@ export default class TodoList extends Mixins(AllowableActionsMixin, DateMixin, N
       console.log('failed the call for authorization of affiliation invitation', err)
       this.authorizeAffiliationInvitationErrorDialog = true
       return null
+    }).finally(() => {
+      this.isAffiliationLoading = false
     })
 
     const index = this.todoItems.indexOf(affiliationInvitationTodo)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23969

*Description of changes:*

When clicking on either button, both 2 buttons will be disabled, and the clicked one will have a loading spinner.
- To clearly communicate with users of the system status: something is being processed
- To prevent users clicking on the same button multiple times

#### "Do Not Authorize" Button (After clicking)
**Before**:
![image](https://github.com/user-attachments/assets/b7fd6a21-89ab-4318-85dd-31c66d05d7ff)
**After**:
![image](https://github.com/user-attachments/assets/5c19f234-a714-4bc6-8629-04db43d9d50e)

#### "Authorize" Button (After clicking)
**Before**:
![image](https://github.com/user-attachments/assets/fe2c7647-4b66-4a42-85b5-d537b3ad55f9)
**After**:
![image](https://github.com/user-attachments/assets/5cd278e6-5765-4a40-af38-940e8274642d)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
