### PR TITLE
25294 - Submit NoW for Bootstrap Filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.13",
+  "version": "7.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.13",
+      "version": "7.4.14",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.13",
+  "version": "7.4.14",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -168,7 +168,8 @@ import {
 import { BreadcrumbIF } from '@bcrs-shared-components/interfaces'
 import { FilingStatus, NameRequestStates, NigsMessage, Routes } from '@/enums'
 import { FilingTypes } from '@bcrs-shared-components/enums'
-import { CorpTypeCd, GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module'
+import { CorpTypeCd, GetCorpFullDescription, GetCorpNumberedDescription }
+  from '@bcrs-shared-components/corp-type-module'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { useBusinessStore, useConfigurationStore, useFilingHistoryListStore, useRootStore } from './stores'
 
@@ -670,7 +671,10 @@ export default class App extends Mixins(
     if (nameRequest.nrNumber) this.localNrNumber = nameRequest.nrNumber
 
     // store Legal Name if present
-    this.setLegalName(nameRequest.legalName || 'Unknown Name')
+    // special case to identify numbered amalgamations
+    if (filingName === FilingTypes.AMALGAMATION_APPLICATION) {
+      this.setLegalName(nameRequest.legalName || 'Numbered Amalgamated Company')
+    } else { this.setLegalName(nameRequest.legalName || GetCorpNumberedDescription(this.getLegalType)) }
 
     // store the bootstrap item in the right list
     if (this.isBootstrapTodo) this.storeBootstrapTodo(response)

--- a/src/App.vue
+++ b/src/App.vue
@@ -171,7 +171,6 @@ import { FilingTypes } from '@bcrs-shared-components/enums'
 import { CorpTypeCd, GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { useBusinessStore, useConfigurationStore, useFilingHistoryListStore, useRootStore } from './stores'
-import { createConsoleLogger } from 'launchdarkly-js-client-sdk'
 
 @Component({
   components: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -626,12 +626,12 @@ export default class App extends Mixins(
     const filing = response?.filing
     const filingName = filing.header?.name as FilingTypes
     const status = filing.header.status as FilingStatus
-    const foundingDate = filing.header?.effectiveDate // use the FE date as the founding date
+    const foundingDate = filing.header?.effectiveDate || null// use the FE date as the founding date
     const email =
-        filing?.incorporationApplication?.contactPoint?.email ||
-        filing?.amalgamationApplication?.contactPoint?.email ||
-        filing?.continuationIn?.contactPoint?.email ||
-        filing?.registration?.contactPoint?.email
+        filing.incorporationApplication?.contactPoint?.email ||
+        filing.amalgamationApplication?.contactPoint?.email ||
+        filing.continuationIn?.contactPoint?.email ||
+        filing.registration?.contactPoint?.email || null
 
     if (!filing || !filing.business || !filing.header || !filingName || !status) {
       throw new Error(`Invalid boostrap filing - missing required property = ${filing}`)

--- a/src/App.vue
+++ b/src/App.vue
@@ -626,7 +626,7 @@ export default class App extends Mixins(
     const filing = response?.filing
     const filingName = filing.header?.name as FilingTypes
     const status = filing.header.status as FilingStatus
-    const foundingDate = filing.header?.effectiveDate || null// use the FE date as the founding date
+    const foundingDate = filing.header?.effectiveDate || null // use the FE date as the founding date
     const email =
         filing.incorporationApplication?.contactPoint?.email ||
         filing.amalgamationApplication?.contactPoint?.email ||

--- a/src/views/AmalgamationOut.vue
+++ b/src/views/AmalgamationOut.vue
@@ -795,7 +795,7 @@ export default class AmalgamationOut extends Mixins(CommonMixin, DateMixin, Fili
       header: {
         name: FilingTypes.AMALGAMATION_OUT,
         certifiedBy: this.certifiedBy || '',
-        email: this.getBusinessEmail || '',
+        email: this.getBusinessEmail || undefined,
         date: this.getCurrentDate // NB: API will reassign this date according to its clock
       }
     }

--- a/src/views/ConsentAmalgamationOut.vue
+++ b/src/views/ConsentAmalgamationOut.vue
@@ -721,7 +721,7 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
       header: {
         name: FilingTypes.CONSENT_AMALGAMATION_OUT,
         certifiedBy: this.certifiedBy || '',
-        email: this.getBusinessEmail || '',
+        email: this.getBusinessEmail || undefined,
         date: this.getCurrentDate // NB: API will reassign this date according to its clock
       }
     }

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -721,7 +721,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
       header: {
         name: FilingTypes.CONSENT_CONTINUATION_OUT,
         certifiedBy: this.certifiedBy || '',
-        email: this.getBusinessEmail || '',
+        email: this.getBusinessEmail || undefined,
         date: this.getCurrentDate // NB: API will reassign this date according to its clock
       }
     }

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -725,7 +725,7 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
       header: {
         name: FilingTypes.CONTINUATION_OUT,
         certifiedBy: this.certifiedBy || '',
-        email: this.getBusinessEmail || '',
+        email: this.getBusinessEmail || undefined,
         date: this.getCurrentDate // NB: API will reassign this date according to its clock
       }
     }

--- a/src/views/NoticeOfWithdrawal.vue
+++ b/src/views/NoticeOfWithdrawal.vue
@@ -729,7 +729,7 @@ export default class NoticeOfWithdrawal extends Mixins(CommonMixin, DateMixin, F
         header: {
           name: FilingTypes.NOTICE_OF_WITHDRAWAL,
           certifiedBy: this.certifiedBy || '',
-          email: this.getBusinessEmail || '',
+          email: this.getBusinessEmail || undefined,
           date: this.getCurrentDate // NB: API will reassign this date according to its clock
         }
       }
@@ -761,7 +761,7 @@ export default class NoticeOfWithdrawal extends Mixins(CommonMixin, DateMixin, F
 
       const business: any = {
         business: {
-          foundingDate: this.dateToApi(this.getFoundingDate),
+          foundingDate: this.dateToApi(this.getFoundingDate) || undefined,
           identifier: this.getIdentifier,
           legalName: this.getLegalName,
           legalType: this.getLegalType

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -2319,7 +2319,7 @@ describe('App as a draft numbered regular amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBe('Unknown Name')
+    expect(businessStore.getLegalName).toBe('Numbered Amalgamated Company')
     expect(rootStore.isAmalgamationTodo).toBe(true)
     expect(rootStore.isBootstrapTodo).toBe(true)
 
@@ -2533,7 +2533,7 @@ describe('App as a completed regular amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBe('Unknown Name')
+    expect(businessStore.getLegalName).toBe('Numbered Amalgamated Company')
     expect(rootStore.isAmalgamationFiling).toBe(true)
     expect(rootStore.isBootstrapFiling).toBe(true)
 
@@ -2632,7 +2632,7 @@ describe('App as a draft horizontal amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBe('Unknown Name')
+    expect(businessStore.getLegalName).toBe('Numbered Amalgamated Company')
     expect(rootStore.isAmalgamationTodo).toBe(true)
     expect(rootStore.isBootstrapTodo).toBe(true)
 
@@ -2736,7 +2736,7 @@ describe('App as a completed horizontal amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBe('Unknown Name')
+    expect(businessStore.getLegalName).toBe('Numbered Amalgamated Company')
     expect(rootStore.isAmalgamationFiling).toBe(true)
     expect(rootStore.isBootstrapFiling).toBe(true)
 
@@ -2835,7 +2835,7 @@ describe('App as a draft vertical amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBe('Unknown Name')
+    expect(businessStore.getLegalName).toBe('Numbered Amalgamated Company')
     expect(rootStore.isAmalgamationTodo).toBe(true)
     expect(rootStore.isBootstrapTodo).toBe(true)
 
@@ -2939,7 +2939,7 @@ describe('App as a completed vertical amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBe('Unknown Name')
+    expect(businessStore.getLegalName).toBe('Numbered Amalgamated Company')
     expect(rootStore.isAmalgamationFiling).toBe(true)
     expect(rootStore.isBootstrapFiling).toBe(true)
 
@@ -3033,7 +3033,7 @@ describe('App as a draft numbered continuation in', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityContinueIn).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBe('Unknown Name')
+    expect(businessStore.getLegalName).toBe('Numbered Limited Company')
     expect(rootStore.isContinuationInTodo).toBe(true)
     expect(rootStore.isBootstrapTodo).toBe(true)
 
@@ -3130,13 +3130,13 @@ describe('App as a completed continuation in', () => {
     wrapper.destroy()
   })
 
-  it('fetches continuation in  filing properly', () => {
+  it('fetches continuation in filing properly', () => {
     expect(rootStore.getNameRequest).toBeNull()
     expect(rootStore.isContinuationInFiling).toBe(true)
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityContinueIn).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBe('Unknown Name')
+    expect(businessStore.getLegalName).toBe('Numbered Limited Company')
     expect(rootStore.isContinuationInFiling).toBe(true)
     expect(rootStore.isBootstrapFiling).toBe(true)
 

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -2319,7 +2319,7 @@ describe('App as a draft numbered regular amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBeNull()
+    expect(businessStore.getLegalName).toBe('Unknown Name')
     expect(rootStore.isAmalgamationTodo).toBe(true)
     expect(rootStore.isBootstrapTodo).toBe(true)
 
@@ -2533,7 +2533,7 @@ describe('App as a completed regular amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBeNull()
+    expect(businessStore.getLegalName).toBe('Unknown Name')
     expect(rootStore.isAmalgamationFiling).toBe(true)
     expect(rootStore.isBootstrapFiling).toBe(true)
 
@@ -2632,7 +2632,7 @@ describe('App as a draft horizontal amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBeNull()
+    expect(businessStore.getLegalName).toBe('Unknown Name')
     expect(rootStore.isAmalgamationTodo).toBe(true)
     expect(rootStore.isBootstrapTodo).toBe(true)
 
@@ -2736,7 +2736,7 @@ describe('App as a completed horizontal amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBeNull()
+    expect(businessStore.getLegalName).toBe('Unknown Name')
     expect(rootStore.isAmalgamationFiling).toBe(true)
     expect(rootStore.isBootstrapFiling).toBe(true)
 
@@ -2835,7 +2835,7 @@ describe('App as a draft vertical amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBeNull()
+    expect(businessStore.getLegalName).toBe('Unknown Name')
     expect(rootStore.isAmalgamationTodo).toBe(true)
     expect(rootStore.isBootstrapTodo).toBe(true)
 
@@ -2939,7 +2939,7 @@ describe('App as a completed vertical amalgamation application', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityBcCompany).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBeNull()
+    expect(businessStore.getLegalName).toBe('Unknown Name')
     expect(rootStore.isAmalgamationFiling).toBe(true)
     expect(rootStore.isBootstrapFiling).toBe(true)
 
@@ -3033,7 +3033,7 @@ describe('App as a draft numbered continuation in', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityContinueIn).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBeNull()
+    expect(businessStore.getLegalName).toBe('Unknown Name')
     expect(rootStore.isContinuationInTodo).toBe(true)
     expect(rootStore.isBootstrapTodo).toBe(true)
 
@@ -3136,7 +3136,7 @@ describe('App as a completed continuation in', () => {
     expect(businessStore.getIdentifier).toBe('T123456789')
     expect(businessStore.isEntityContinueIn).toBe(true)
     expect(businessStore.isGoodStanding).toBe(true)
-    expect(businessStore.getLegalName).toBeNull()
+    expect(businessStore.getLegalName).toBe('Unknown Name')
     expect(rootStore.isContinuationInFiling).toBe(true)
     expect(rootStore.isBootstrapFiling).toBe(true)
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25294

*Description of changes:*
- Fixed the issue: can't submit NoW for Bootstrap Filings
  Reason: Bootstrap filings don't have those 3 properties set up - founding date, legal name and Registered Office email.
- Now stores the 3 properties in a bootstrap item's data fields in Filing UI
- Still can't Save/ Save and Resume, probably a bug in Legal API

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
