### PR TITLE
25745-Fix NoW Resbumit Bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.16",
+  "version": "7.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.16",
+      "version": "7.4.17",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.16",
+  "version": "7.4.17",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/NoticeOfWithdrawal.vue
+++ b/src/views/NoticeOfWithdrawal.vue
@@ -600,8 +600,13 @@ export default class NoticeOfWithdrawal extends Mixins(CommonMixin, DateMixin, F
       const filing = Object.assign({}, header, business, data)
       try {
         let ret
-        // filing id is 0, so create a new filing
-        ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
+        if (this.filingId > 0) {
+          // we have a filing id, so update an existing filing
+          ret = await LegalServices.updateFiling(this.getIdentifier, filing, this.filingId, isDraft)
+        } else {
+          // filing id is 0, so create a new filing
+          ret = await LegalServices.createFiling(this.getIdentifier, filing, isDraft)
+        }
         return ret
       } catch (error: any) {
         // save errors or warnings, if any


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25745

*Description of changes:*
- A bug due to recent changes: code allowing re-submit when filinId>0 was removed
- Fixed now
- Happens when payment is invalid, correct it, and re-submit - reproduce:
First, enter some invalid BC online account information, the click Submit;
Show the Pay error message;
Switch to "No Pay", try to submit again, trigger the error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
