### PR TITLE
26394 - Set Country back to Canada after Cancelling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.24",
+  "version": "7.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.24",
+      "version": "7.4.25",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.42",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.24",
+  "version": "7.4.25",
   "private": true,
   "appName": "Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -116,6 +116,7 @@
                   <div class="address-wrapper">
                     <BaseAddress
                       ref="baseAddressNew"
+                      :key="baseAddressKey"
                       :editing="true"
                       :schema="addressSchema"
                       @update:address="updateDeliveryAddress"
@@ -136,6 +137,7 @@
                       <div class="address-wrapper">
                         <BaseAddress
                           ref="mailAddressNew"
+                          :key="mailAddressKey"
                           :editing="true"
                           :schema="addressSchema"
                           @update:address="updateMailingAddress"
@@ -755,6 +757,10 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
   isEditingDirector = false
   messageIndex = -1
 
+  // This will hold a dynamic key for re-rendering the BaseAddress component
+  baseAddressKey = 0
+  mailAddressKey = 0
+
   /** V-model for new director form. */
   newDirector = cloneDeep(EmptyDirector)
 
@@ -1023,6 +1029,11 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
     this.directorEditInProgress = true
   }
 
+  resetBaseAddressKey (): void {
+    this.baseAddressKey++
+    this.mailAddressKey++
+  }
+
   /** Local helper to cancel adding a new director. */
   cancelNewDirector (): void {
     this.showNewDirectorForm = false
@@ -1036,6 +1047,7 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
     this.newDirector = cloneDeep(EmptyDirector)
     this.newDirector.appointmentDate = this.asOfDate
     this.directorEditInProgress = false
+    this.resetBaseAddressKey()
   }
 
   // REMOVED UNTIL FUTURE RELEASE

--- a/src/interfaces/address-interfaces.ts
+++ b/src/interfaces/address-interfaces.ts
@@ -30,6 +30,6 @@ export const EmptyAddress: AddressIF = {
   addressCity: '',
   addressRegion: '',
   postalCode: '',
-  addressCountry: '',
+  addressCountry: 'CA',
   deliveryInstructions: ''
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26394 

*Description of changes:*
- bump app version
- re-render component so that the country default back to Canada after cancelling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
