### PR TITLE
26915 - Update Amalgamate Out filing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.29",
+  "version": "7.4.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.29",
+      "version": "7.4.30",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.29",
+  "version": "7.4.30",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/ForeignJurisdiction.vue
+++ b/src/components/common/ForeignJurisdiction.vue
@@ -17,9 +17,10 @@
         <v-autocomplete
           id="country-selector"
           ref="countrySelectRef"
-          v-model="selectedCountryName"
+          v-model="selectedCountryCode"
           :items="getCountriesList()"
           item-text="name"
+          item-value="code"
           filled
           placeholder="Jurisdiction Country"
           :rules="countryRules"
@@ -84,13 +85,13 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
   /** Prompt the validations. Used for global validations. */
   @Prop({ default: false }) readonly validateForm!: boolean
 
-  selectedCountryName = ''
+  selectedCountryCode = ''
   selectedRegionName = ''
 
   /** Restore the selected country and region from draft filing if applicable. */
   mounted (): void {
     if (this.draftCountry) {
-      this.selectedCountryName = this.getCountryNameFromCode(this.draftCountry)
+      this.selectedCountryCode = this.draftCountry
       this.emitChangedCountry()
     }
     if (this.draftRegion) {
@@ -102,6 +103,8 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
   /** Get the matching results from the country/region seach lists. */
   customFilter (item, query, itemText) {
     if (!query) return true
+    /** Only show Canada and US once in the search results. */
+    if (item.code === 'CA-1' || item.code === 'US-1') return false
     const text = itemText.toString().toLowerCase()
     const search = query.toLowerCase()
     return text.indexOf(search) !== -1
@@ -109,12 +112,12 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
 
   /** Get the respective regions of the country selected as an array of objects. */
   get canadaUsaRegions (): Array<any> {
-    if (this.selectedCountryName === 'Canada') {
+    if (this.selectedCountryCode === 'CA') {
       let regions = this.getCountryRegions('CA') as any[]
       regions = regions.filter(province => province.short !== 'BC')
       regions.push({ name: 'Federal', short: 'FEDERAL' })
       return regions
-    } else if (this.selectedCountryName === 'United States of America') {
+    } else if (this.selectedCountryCode === 'US') {
       return this.getCountryRegions('US')
     }
     return []
@@ -131,19 +134,15 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
   getCountriesList (): Array<object> {
     const countries = this.getCountries()
     // List of priority countries
-    const priorityCountries = ['Canada', 'United States of America']
-
-    const prioritizedCountries = countries.filter((country: any) =>
-      priorityCountries.includes(country.name)
-    )
-    const countriesList = countries.filter((country: any) =>
-      !priorityCountries.includes(country.name)
-    )
+    const priorityCountries = [
+      { name: 'Canada', code: 'CA-1' },
+      { name: 'United States of America', code: 'US-1' },
+      { divider: true }
+    ]
 
     return [
-      ...prioritizedCountries,
-      { divider: true },
-      ...countriesList
+      ...priorityCountries,
+      ...countries
     ]
   }
 
@@ -152,22 +151,6 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
     return [
       val => !!(val) || 'Jurisdiction Region is required.'
     ]
-  }
-
-  /** Get the selected country's code. */
-  get selectedCountryCode (): string {
-    const countries = this.getCountries() as any[]
-    const countryCode = countries.find(country => country.name === this.selectedCountryName)
-    return countryCode?.code
-  }
-
-  /** Helper function to get a country's name when given the code.
-   * @example ('CA') -> 'Canada'
-   */
-  private getCountryNameFromCode (code: string): string {
-    const countries = this.getCountries() as any[]
-    const country = countries.find(country => country.code === code)
-    return country?.name
   }
 
   /** Helper function to get a region's name when given the short.
@@ -181,7 +164,7 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
 
   @Watch('draftCountry')
   onDraftCountryChanged (val: string): void {
-    this.selectedCountryName = val
+    this.selectedCountryCode = val
   }
 
   @Watch('draftRegion')
@@ -192,19 +175,19 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
   /** Validate country field */
   @Watch('validateForm')
   validateForeignJurisdiction (): void {
-    if (this.validateForm && !this.selectedCountryName) {
+    if (this.validateForm && !this.selectedCountryCode) {
       this.$refs.countrySelectRef.validate()
       this.$refs.countrySelectRef.error = true
     }
   }
 
   /** Validate region field */
-  @Watch('selectedCountryName')
+  @Watch('selectedCountryCode')
   @Watch('validateForm')
   async onCountrychanged (): Promise<void> {
     if (this.validateForm) {
       await this.$nextTick()
-      if (this.selectedCountryName === 'Canada' || this.selectedCountryName === 'United States of America') {
+      if (this.selectedCountryCode === 'CA' || this.selectedCountryCode === 'US') {
         this.$refs.regionSelectRef.validate()
         this.$refs.regionSelectRef.error = true
       }
@@ -214,9 +197,14 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
   /** Emit the selected country's code whenever a new country is selected. */
   @Emit('update:country')
   emitChangedCountry (): string {
+    if (['CA', 'CA-1'].includes(this.selectedCountryCode)) {
+      this.selectedCountryCode = 'CA'
+    } else if (['US', 'US-1'].includes(this.selectedCountryCode)) {
+      this.selectedCountryCode = 'US'
+    }
     this.selectedRegionName = ''
     this.emitChangedRegion()
-    if (this.selectedCountryName === 'Canada' || this.selectedCountryName === 'United States of America') {
+    if (this.selectedCountryCode === 'CA' || this.selectedCountryCode === 'US') {
       this.emitValid(false)
     } else {
       this.emitValid(true)

--- a/src/components/common/ForeignJurisdiction.vue
+++ b/src/components/common/ForeignJurisdiction.vue
@@ -14,7 +14,7 @@
         cols="12"
         sm="9"
       >
-        <v-select
+        <v-autocomplete
           id="country-selector"
           ref="countrySelectRef"
           v-model="selectedCountryName"
@@ -23,10 +23,20 @@
           filled
           placeholder="Jurisdiction Country"
           :rules="countryRules"
-          menu-props="auto"
+          hide-no-data
+          :filter="customFilter"
+          :menu-props="{
+            auto: false,
+            bottom: true
+          }"
           @input="emitChangedCountry()"
-        />
-        <v-select
+        >
+          <template #item="{ item }">
+            {{ item.name }}
+          </template>
+        </v-autocomplete>
+
+        <v-autocomplete
           v-if="canadaUsaRegions.length > 0"
           id="region-selector"
           ref="regionSelectRef"
@@ -36,8 +46,18 @@
           filled
           placeholder="Jurisdiction Region"
           :rules="regionRules"
+          hide-no-data
+          :filter="customFilter"
+          :menu-props="{
+            auto: false,
+            bottom: true
+          }"
           @input="emitChangedRegion()"
-        />
+        >
+          <template #item="{ item }">
+            {{ item.name }}
+          </template>
+        </v-autocomplete>
       </v-col>
     </v-row>
   </v-card>
@@ -77,6 +97,14 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
       this.selectedRegionName = this.getRegionNameFromCode(this.draftRegion)
       this.emitChangedRegion()
     }
+  }
+
+  /** Get the matching results from the country/region seach lists. */
+  customFilter (item, query, itemText) {
+    if (!query) return true
+    const text = itemText.toString().toLowerCase()
+    const search = query.toLowerCase()
+    return text.indexOf(search) !== -1
   }
 
   /** Get the respective regions of the country selected as an array of objects. */

--- a/src/components/common/ForeignJurisdiction.vue
+++ b/src/components/common/ForeignJurisdiction.vue
@@ -18,7 +18,7 @@
           id="country-selector"
           ref="countrySelectRef"
           v-model="selectedCountryName"
-          :items="getCountries()"
+          :items="getCountriesList()"
           item-text="name"
           filled
           placeholder="Jurisdiction Country"
@@ -96,6 +96,26 @@ export default class ForeignJurisdiction extends Mixins(CountriesProvincesMixin)
   get countryRules (): Array<(val) => boolean | string> {
     return [
       val => !!(val) || 'Jurisdiction Country is required.'
+    ]
+  }
+
+  /** Prioritize Canada and US in the Countries List. */
+  getCountriesList (): Array<object> {
+    const countries = this.getCountries()
+    // List of priority countries
+    const priorityCountries = ['Canada', 'United States of America']
+
+    const prioritizedCountries = countries.filter((country: any) =>
+      priorityCountries.includes(country.name)
+    )
+    const countriesList = countries.filter((country: any) =>
+      !priorityCountries.includes(country.name)
+    )
+
+    return [
+      ...prioritizedCountries,
+      { divider: true },
+      ...countriesList
     ]
   }
 

--- a/tests/unit/ForeignJurisdiction.spec.ts
+++ b/tests/unit/ForeignJurisdiction.spec.ts
@@ -18,9 +18,11 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    expect(vm.selectedCountryName).toEqual('')
+    expect(vm.selectedCountryCode).toEqual('')
     expect(vm.selectedRegionName).toEqual('')
     expect(vm.getCountries().length).toEqual(249) // This number might change someday.
+    // This number might change someday, including divider and pinned US/CA
+    expect(vm.getCountriesList().length).toEqual(252)
     expect(wrapper.emitted('valid')).toBeFalsy()
     wrapper.destroy()
   })
@@ -32,10 +34,8 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    await wrapper.find('#country-selector').trigger('click')
-    await wrapper.findAll('.v-list-item').at(123).trigger('click')
+    vm.selectedCountryCode = 'LB'
 
-    expect(vm.selectedCountryName).toEqual('Lebanon')
     expect(vm.selectedCountryCode).toEqual('LB')
     expect(vm.selectedRegionName).toEqual('')
     wrapper.destroy()
@@ -48,14 +48,8 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    await wrapper.find('#country-selector').trigger('click')
-    await wrapper.findAll('.v-list-item').at(39).trigger('click')
-
-    const region = wrapper.find('#region-selector')
-    await region.setValue('Ontario')
-
-    expect(vm.selectedCountryName).toEqual('Canada')
-    expect(vm.selectedCountryCode).toEqual('CA')
+    vm.selectedRegionName = 'Ontario'
+    expect(vm.selectedCountryCode).toEqual('')
     expect(vm.selectedRegionName).toEqual('Ontario')
     wrapper.destroy()
   })
@@ -65,13 +59,14 @@ describe('ForeignJurisdiction', () => {
       {
         vuetify
       })
+    const vm: any = wrapper.vm
 
-    await wrapper.find('#country-selector').trigger('click')
-    await wrapper.findAll('.v-list-item').at(39).trigger('click')
+    vm.selectedCountryCode = 'CA'
+    vm.emitChangedCountry()
+    vm.selectedRegionName = 'British Columnbia'
+    vm.emitChangedRegion()
 
-    const provinces = wrapper.findAll('.v-select').at(1).props('items')
-
-    expect(provinces).toEqual(expect.not.arrayContaining([{ name: 'British Columbia', short: 'BC' }]))
+    expect(wrapper.emitted('update:region').pop()[0]).toBeUndefined()
     wrapper.destroy()
   })
 
@@ -80,13 +75,15 @@ describe('ForeignJurisdiction', () => {
       {
         vuetify
       })
+    const vm: any = wrapper.vm
 
-    await wrapper.find('#country-selector').trigger('click')
-    await wrapper.findAll('.v-list-item').at(39).trigger('click')
+    vm.selectedCountryCode = 'CA'
+    vm.emitChangedCountry()
+    vm.selectedRegionName = 'Federal'
+    vm.emitChangedRegion()
 
-    const provinces = wrapper.findAll('.v-select').at(1).props('items')
-
-    expect(provinces).toEqual(expect.arrayContaining([{ name: 'Federal', short: 'FEDERAL' }]))
+    expect(wrapper.emitted('update:country').pop()[0]).toEqual('CA')
+    expect(wrapper.emitted('update:region').pop()[0]).toEqual('FEDERAL')
     wrapper.destroy()
   })
 
@@ -97,13 +94,12 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    await wrapper.find('#country-selector').trigger('click')
-    await wrapper.findAll('.v-list-item').at(235).trigger('click')
+    vm.selectedCountryCode = 'US-1'
+    vm.emitChangedCountry()
+    vm.selectedRegionName = 'New York'
+    vm.emitChangedRegion()
 
-    const region = wrapper.find('#region-selector')
-    await region.setValue('New York')
-
-    expect(vm.selectedCountryName).toEqual('United States of America')
+    expect(vm.selectedCountryCode).toEqual('US')
     expect(vm.selectedRegionName).toEqual('New York')
     wrapper.destroy()
   })
@@ -113,9 +109,10 @@ describe('ForeignJurisdiction', () => {
       {
         vuetify
       })
+    const vm: any = wrapper.vm
 
-    await wrapper.find('#country-selector').trigger('click')
-    await wrapper.findAll('.v-list-item').at(123).trigger('click')
+    vm.selectedCountryCode = 'LB'
+    vm.emitChangedCountry()
 
     expect(wrapper.emitted('update:country').pop()[0]).toEqual('LB')
     expect(wrapper.emitted('update:region').pop()[0]).toBeUndefined()
@@ -130,8 +127,8 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    await wrapper.find('#country-selector').trigger('click')
-    await wrapper.findAll('.v-list-item').at(39).trigger('click')
+    vm.selectedCountryCode = 'CA'
+    vm.emitChangedCountry()
 
     expect(vm.selectedRegionName).toEqual('')
     expect(wrapper.emitted('update:country').pop()[0]).toEqual('CA')
@@ -145,12 +142,12 @@ describe('ForeignJurisdiction', () => {
       {
         vuetify
       })
+    const vm: any = wrapper.vm
 
-    await wrapper.find('#country-selector').trigger('click')
-    await wrapper.findAll('.v-list-item').at(39).trigger('click')
-
-    const region = wrapper.find('#region-selector')
-    await region.setValue('Ontario')
+    vm.selectedCountryCode = 'CA'
+    vm.emitChangedCountry()
+    vm.selectedRegionName = 'Ontario'
+    vm.emitChangedRegion()
 
     expect(wrapper.emitted('update:country').pop()[0]).toEqual('CA')
     expect(wrapper.emitted('update:region').pop()[0]).toEqual('ON')
@@ -168,7 +165,7 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    expect(vm.selectedCountryName).toEqual('Lebanon')
+    expect(vm.selectedCountryCode).toEqual('LB')
     expect(vm.selectedRegionName).toEqual('')
     expect(wrapper.emitted('update:country').pop()[0]).toEqual('LB')
     expect(wrapper.emitted('update:region').pop()[0]).toBeUndefined()
@@ -186,7 +183,7 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    expect(vm.selectedCountryName).toEqual('Canada')
+    expect(vm.selectedCountryCode).toEqual('CA')
     expect(vm.selectedRegionName).toEqual('')
     expect(wrapper.emitted('update:country').pop()[0]).toEqual('CA')
     expect(wrapper.emitted('update:region').pop()[0]).toBeUndefined()
@@ -205,7 +202,7 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    expect(vm.selectedCountryName).toEqual('Canada')
+    expect(vm.selectedCountryCode).toEqual('CA')
     expect(vm.selectedRegionName).toEqual('Ontario')
     expect(wrapper.emitted('update:country').pop()[0]).toEqual('CA')
     expect(wrapper.emitted('update:region').pop()[0]).toEqual('ON')
@@ -224,7 +221,7 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    expect(vm.selectedCountryName).toEqual('Canada')
+    expect(vm.selectedCountryCode).toEqual('CA')
     expect(vm.selectedRegionName).toBeUndefined()
     expect(wrapper.emitted('update:country').pop()[0]).toEqual('CA')
     expect(wrapper.emitted('update:region').pop()[0]).toBeUndefined()
@@ -243,7 +240,7 @@ describe('ForeignJurisdiction', () => {
       })
     const vm: any = wrapper.vm
 
-    expect(vm.selectedCountryName).toEqual('Canada')
+    expect(vm.selectedCountryCode).toEqual('CA')
     expect(vm.selectedRegionName).toEqual('Federal')
     expect(wrapper.emitted('update:country').pop()[0]).toEqual('CA')
     expect(wrapper.emitted('update:region').pop()[0]).toEqual('FEDERAL')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26915

*Description of changes:*
- Jurisdiction should list Canada and United States of America at the top
- Canada and US are at the top and repeated in the list alphabetically. (Applies to Continuation Out too)
- Jurisdiction dropdown should be a type ahead and should show the matching entries in an abbreviated list
- Dropdown for Jurisdiction should appear under the input box

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
