### PR TITLE
26914 - Update Consent Amalgamation Out Filing Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.30",
+  "version": "7.4.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.30",
+      "version": "7.4.31",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.30",
+  "version": "7.4.31",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/ConsentAmalgamationOut.vue
+++ b/src/views/ConsentAmalgamationOut.vue
@@ -109,7 +109,7 @@
               <header>
                 <h2>Documents Delivery</h2>
                 <p class="grey-text">
-                  Copies of the consent to continue out documents will be sent to the email addresses listed below.
+                  Copies of the consent to amalgamate out documents will be sent to the email addresses listed below.
                 </p>
               </header>
               <div
@@ -452,7 +452,7 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
       this.certifiedBy = this.getUserInfo.firstname + ' ' + this.getUserInfo.lastname
     }
 
-    // always include consent continue out code
+    // always include consent amalgamate out code
     // use existing Priority and Waive Fees flags
     this.updateFilingData('add', FilingCodes.CONSENT_AMALGAMATION_OUT, this.staffPaymentData.isPriority,
       (this.staffPaymentData.option === StaffPaymentOptions.NO_FEE))
@@ -811,7 +811,7 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
     // open confirmation dialog and wait for response
     this.$refs.confirm.open(
       'Unsaved Changes',
-      'You have unsaved changes in your Consent to Continue Out. Do you want to exit your filing?',
+      'You have unsaved changes in your Consent to Amalgamate Out. Do you want to exit your filing?',
       {
         width: '45rem',
         persistent: true,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26914

*Description of changes:*
- Verify the Jurisdiction selection works as expected:
   a. list Canada and United States of America at the top
   b. repeat them in the list alphabetically
   c. has a type ahead and should show the matching entries in an abbreviated list
(This was done in the previous ticket, updated the shared component)

- Updated Documents Delivery text and Unsaved Changes text
![image](https://github.com/user-attachments/assets/536695f8-8a68-4290-95ea-25e822ff3e4c)
![image](https://github.com/user-attachments/assets/3fc9ef76-1232-47be-bb15-0b6f7391f9a5)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
