### PR TITLE
27097 - Fix Cancel Button for Court Order Filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.31",
+  "version": "7.4.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.31",
+      "version": "7.4.32",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.31",
+  "version": "7.4.32",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -158,7 +158,7 @@
                 class="pt-6 px-4"
               >
                 <StaffPaymentShared
-                  validate="true"
+                  :validate="true"
                   :staffPaymentData.sync="staffPaymentData"
                   @valid="staffPaymentValid=$event"
                 />

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -158,9 +158,9 @@
                 class="pt-6 px-4"
               >
                 <StaffPaymentShared
-                  :validate="staffPaymentValid"
+                  :validate="true"
                   :staffPaymentData.sync="staffPaymentData"
-                  @staffPaymentFormValid="staffPaymentValid=$event"
+                  @valid="staffPaymentValid=$event"
                 />
               </v-card>
             </div>
@@ -454,7 +454,6 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
     // add Waive Fees flag to all filing codes
     this.updateFilingData('add', FilingCodes.COURT_ORDER, val.isPriority, waiveFees)
     this.haveChanges = true
-    this.staffPaymentValid = true
   }
 
   @Watch('dialog')

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -158,7 +158,7 @@
                 class="pt-6 px-4"
               >
                 <StaffPaymentShared
-                  :validate="true"
+                  validate="true"
                   :staffPaymentData.sync="staffPaymentData"
                   @valid="staffPaymentValid=$event"
                 />
@@ -202,7 +202,7 @@
                     solid
                     color="primary"
                     class="btn-outlined-primary mt-4"
-                    :disabled="!isPageValid || saving"
+                    :loading="saving"
                     @click.native="onSave()"
                   >
                     {{ isPayRequired ? "File and Pay" : "File Now (no fee)" }}

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -536,6 +536,7 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
     // if any component is invalid, don't save
     if (!isNotationFormValid || !isFileComponentValid || !isCourtOrderPoaValid) {
       this.saving = false
+      this.showErrors = true
       return
     }
 

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -201,7 +201,7 @@
                     solid
                     color="primary"
                     class="btn-outlined-primary mt-4"
-                    :disabled="!isPageValid || saving"
+                    :loading="!isPageValid || saving"
                     @click.native="onSave()"
                   >
                     {{ isPayRequired ? "File and Pay" : "File Now (no fee)" }}
@@ -313,6 +313,11 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
   staffPaymentData = { option: StaffPaymentOptions.NONE } as StaffPaymentIF
 
   paymentErrorDialog = false
+
+  /** Called when component is mounted. */
+  async mounted (): Promise<void> {
+    this.updateFilingData('add', FilingCodes.COURT_ORDER, undefined, false)
+  }
 
   /** Whether this filing is a Court Order. */
   get isCourtOrder (): boolean {

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -1,5 +1,8 @@
 <template>
   <div id="court-order">
+    <ConfirmDialog
+      ref="confirm"
+    />
     <v-container
       id="court-order-container"
       class="view-container"
@@ -198,7 +201,7 @@
                     solid
                     color="primary"
                     class="btn-outlined-primary mt-4"
-                    :loading="!isPageValid || saving"
+                    :disabled="!isPageValid || saving"
                     @click.native="onSave()"
                   >
                     {{ isPayRequired ? "File and Pay" : "File Now (no fee)" }}
@@ -220,9 +223,10 @@
 import { Component, Emit, Mixins, Prop, Vue, Watch } from 'vue-property-decorator'
 import { Getter } from 'pinia-class'
 import { DateMixin, FilingMixin, CommonMixin } from '@/mixins'
+import { ConfirmDialog } from '@/components/dialogs'
 import { CourtOrderPoa } from '@bcrs-shared-components/court-order-poa'
 import FileUploadPdf from '@/components/common/FileUploadPdf.vue'
-import { FormIF, StaffPaymentIF } from '@/interfaces'
+import { ConfirmDialogType, FormIF, StaffPaymentIF } from '@/interfaces'
 import { EffectOfOrderTypes, PageSizes } from '@/enums'
 import { FilingCodes, FilingNames, FilingTypes, StaffPaymentOptions } from '@bcrs-shared-components/enums'
 import { EnumUtilities, LegalServices } from '@/services'
@@ -233,6 +237,7 @@ import { StaffPayment as StaffPaymentShared } from '@bcrs-shared-components/staf
 
 @Component({
   components: {
+    ConfirmDialog,
     CourtOrderPoa,
     FileUploadPdf,
     SbcFeeSummary,
@@ -241,6 +246,7 @@ import { StaffPayment as StaffPaymentShared } from '@bcrs-shared-components/staf
 })
 export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, CommonMixin) {
   $refs!: Vue['$refs'] & {
+    confirm: ConfirmDialogType,
     courtOrderPoaRef: FormIF,
     fileUploadRef: FormIF,
     notationFormRef: FormIF
@@ -304,7 +310,7 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
 
   // variables for staff payment
   staffPaymentValid = true
-  staffPaymentData = { option: StaffPaymentOptions.NO_FEE } as StaffPaymentIF
+  staffPaymentData = { option: StaffPaymentOptions.NONE } as StaffPaymentIF
 
   paymentErrorDialog = false
 
@@ -370,7 +376,7 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
     // open confirmation dialog and wait for response
     this.$refs.confirm.open(
       'Unsaved Changes',
-      'You have unsaved changes in your Continue Out. Do you want to exit your filing?',
+      'You have unsaved changes in your Court Order. Do you want to exit your filing?',
       {
         width: '45rem',
         persistent: true,

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -522,6 +522,10 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
     this.enableValidation = true
     await this.$nextTick() // wait for form to update
 
+    const isNotationFormValid = (!this.$refs.notationFormRef || this.$refs.notationFormRef.validate())
+    const isFileComponentValid = (!this.$refs.fileUploadRef || this.$refs.fileUploadRef.validate())
+    const isCourtOrderPoaValid = (!this.$refs.courtOrderPoaRef || this.$refs.courtOrderPoaRef.validate())
+
     if (!this.isPageValid) {
       this.showErrors = true
       this.saving = false
@@ -530,10 +534,6 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
     }
 
     // if any component is invalid, don't save
-    const isNotationFormValid = (!this.$refs.notationFormRef || this.$refs.notationFormRef.validate())
-    const isFileComponentValid = (!this.$refs.fileUploadRef || this.$refs.fileUploadRef.validate())
-    const isCourtOrderPoaValid = (!this.$refs.courtOrderPoaRef || this.$refs.courtOrderPoaRef.validate())
-
     if (!isNotationFormValid || !isFileComponentValid || !isCourtOrderPoaValid) {
       this.saving = false
       return

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -158,6 +158,7 @@
                 class="pt-6 px-4"
               >
                 <StaffPaymentShared
+                  :validate="staffPaymentValid"
                   :staffPaymentData.sync="staffPaymentData"
                   @staffPaymentFormValid="staffPaymentValid=$event"
                 />
@@ -201,7 +202,7 @@
                     solid
                     color="primary"
                     class="btn-outlined-primary mt-4"
-                    :loading="!isPageValid || saving"
+                    :disabled="!isPageValid || saving"
                     @click.native="onSave()"
                   >
                     {{ isPayRequired ? "File and Pay" : "File Now (no fee)" }}
@@ -309,7 +310,7 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
   haveChanges = false
 
   // variables for staff payment
-  staffPaymentValid = true
+  staffPaymentValid = false
   staffPaymentData = { option: StaffPaymentOptions.NONE } as StaffPaymentIF
 
   paymentErrorDialog = false
@@ -453,6 +454,7 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
     // add Waive Fees flag to all filing codes
     this.updateFilingData('add', FilingCodes.COURT_ORDER, val.isPriority, waiveFees)
     this.haveChanges = true
+    this.staffPaymentValid = true
   }
 
   @Watch('dialog')

--- a/tests/unit/CourtOrder.spec.ts
+++ b/tests/unit/CourtOrder.spec.ts
@@ -92,9 +92,9 @@ describe('Court Order View', () => {
     // Trigger save action
     const saveButton = wrapper.find('#dialog-save-button')
     await saveButton.trigger('click')
+    await Vue.nextTick()
 
     // Check for validation error
-    expect(wrapper.vm.showErrors).toBe(true)
     expect(wrapper.vm.isPageValid).toBe(false)
   })
 

--- a/tests/unit/CourtOrder.spec.ts
+++ b/tests/unit/CourtOrder.spec.ts
@@ -5,6 +5,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
 import CourtOrder from '@/views/CourtOrder.vue'
 import { FileUploadPdf } from '@/components/common'
+import { StaffPaymentOptions } from '@bcrs-shared-components/enums'
 import { CourtOrderPoa } from '@bcrs-shared-components/court-order-poa'
 import mockRouter from './mockRouter'
 import VueRouter from 'vue-router'
@@ -150,16 +151,15 @@ describe('Court Order View', () => {
 
     // make sure form is validated
     await wrapper.setData({
-      courtOrderValid: true
+      courtOrderValid: true,
+      staffPaymentValid: true,
+      staffPaymentData: { option: StaffPaymentOptions.NO_FEE }
     })
 
     wrapper.vm.$data.dataLoaded = true
     await Vue.nextTick()
 
     expect(vm.isPageValid).toEqual(true)
-
-    // make sure a fee is required
-    vm.totalFee = 20
 
     const saveButton = wrapper.find('#dialog-save-button')
     expect(saveButton.attributes('disabled')).toBeUndefined()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27097

*Description of changes:*
- Add the Cancel Confirm Dialog
- Change the initial Payment option to None
- Disable the File button when page is invalid, instead of loading
- When page is loaded, show fee
- Add validate to Staff Payment Section

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
