### PR TITLE
Fix 27097 - Fix the Invalid Section Logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.32",
+  "version": "7.4.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.4.32",
+      "version": "7.4.33",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.4.32",
+  "version": "7.4.33",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -405,6 +405,7 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
     })
   }
 
+  @Watch('courtOrderValid')
   updateCourtOrderSectionValid (): void {
     this.courtOrderSectionValid = this.courtOrderValid && this.isNotationFormValid && this.isFileComponentValid
   }

--- a/tests/unit/CourtOrder.spec.ts
+++ b/tests/unit/CourtOrder.spec.ts
@@ -95,6 +95,7 @@ describe('Court Order View', () => {
     await Vue.nextTick()
 
     // Check for validation error
+    expect(wrapper.vm.showErrors).toBe(true)
     expect(wrapper.vm.isPageValid).toBe(false)
   })
 
@@ -107,7 +108,7 @@ describe('Court Order View', () => {
       data () {
         return {
           filingData: ['0'], // Non-empty array
-          courtOrderValid: true, // courtOrderValid is true
+          courtOrderSectionValid: true, // courtOrderSectionValid is true
           staffPaymentValid: true // staffPaymentValid is true
         }
       } })
@@ -121,12 +122,12 @@ describe('Court Order View', () => {
 
     // verify "validated" - invalid Staff Payment form
     vm.staffPaymentValid = false
-    vm.courtOrderValid = true
+    vm.courtOrderSectionValid = true
     expect(vm.isPageValid).toBe(false)
 
     // verify "validated" - invalid Court Order section
     vm.staffPaymentValid = true
-    vm.courtOrderValid = false
+    vm.courtOrderSectionValid = false
     expect(vm.isPageValid).toBe(false)
 
     wrapper.destroy()
@@ -151,7 +152,7 @@ describe('Court Order View', () => {
 
     // make sure form is validated
     await wrapper.setData({
-      courtOrderValid: true,
+      courtOrderSectionValid: true,
       staffPaymentValid: true,
       staffPaymentData: { option: StaffPaymentOptions.NO_FEE }
     })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27097

*Description of changes:*
- Before: the logic in determing whether 1.Court Order section is valid is problematic
  Its validity solely depends on the Court Order Number section

- After update: the  validity depends Court Order Number section + File upload + input Text

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
