### PR TITLE
22373 - COD Data Lost after Selecting New Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "7.5.5",
+  "version": "7.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "7.5.5",
+      "version": "7.5.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "7.5.5",
+  "version": "7.5.6",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/StandaloneDirectorChange/CODDate.vue
+++ b/src/components/StandaloneDirectorChange/CODDate.vue
@@ -24,18 +24,11 @@
               label="Enter your Director Change Date"
               hint="YYYY/MM/DD"
               filled
+              append-icon="mdi-calendar"
               v-bind="attrs"
               v-on="on"
-            >
-              <template #append>
-                <v-icon
-                  class="calendar-icon"
-                  @click.stop="menu = true"
-                >
-                  mdi-calendar
-                </v-icon>
-              </template>
-            </v-text-field>
+              @click:append="menu = true"
+            />
           </template>
           <v-date-picker
             id="cod-datepicker"

--- a/src/components/StandaloneDirectorChange/CODDate.vue
+++ b/src/components/StandaloneDirectorChange/CODDate.vue
@@ -23,8 +23,8 @@
               :rules="codDateRules"
               label="Enter your Director Change Date"
               hint="YYYY/MM/DD"
-              filled
               append-icon="mdi-calendar"
+              filled
               v-bind="attrs"
               v-on="on"
               @click:append="menu = true"

--- a/src/components/StandaloneDirectorChange/CODDate.vue
+++ b/src/components/StandaloneDirectorChange/CODDate.vue
@@ -15,7 +15,7 @@
           offset-y
           min-width="18rem"
         >
-          <template #activator="{ on }">
+          <template #activator="{ on, attrs }">
             <v-text-field
               id="cod-textfield"
               v-model="dateFormatted"
@@ -23,10 +23,19 @@
               :rules="codDateRules"
               label="Enter your Director Change Date"
               hint="YYYY/MM/DD"
-              append-icon="mdi-calendar"
               filled
+              v-bind="attrs"
               v-on="on"
-            />
+            >
+              <template #append>
+                <v-icon
+                  class="calendar-icon"
+                  @click.stop="menu = true"
+                >
+                  mdi-calendar
+                </v-icon>
+              </template>
+            </v-text-field>
           </template>
           <v-date-picker
             id="cod-datepicker"

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -1308,8 +1308,9 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
   /**
    * Updates the appointment/cessation date for directors that were changed in this filing.
    * @param newDate The new date.
+   * @param oldDate The old date.
    */
-  updateNewDirectorDates (newDate: string, oldDate: string): void {
+  updateChangedDirectorDates (newDate: string, oldDate: string): void {
     if (oldDate === newDate) return
 
     this.allDirectors.forEach(dir => {
@@ -1499,7 +1500,7 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
     this.asOfDate = newVal
 
     // update the appointment/cessation dates for applicable directors
-    this.updateNewDirectorDates(newVal, oldVal)
+    this.updateChangedDirectorDates(newVal, oldVal)
   }
 
   /** Emits an event containing the earliest director change date. */

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -728,11 +728,6 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
    */
   @Prop({ default: () => [] }) readonly directors!: DirectorIF[]
 
-  /**
-   * Change of Director date from parent page, used to set our 'asOfDate' when a new date is selected.
-   */
-  @Prop({ default: '' }) readonly codDate!: string
-
   @Getter(useRootStore) getCurrentDate!: string
   @Getter(useRootStore) getFoundingDate!: Date
   @Getter(useBusinessStore) getIdentifier!: string
@@ -741,7 +736,7 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
   // @Getter(useBusinessStore) isBaseCompany!: boolean
 
   /** Effective date for fetching and appointing/ceasing directors. */
-  asOfDate: string
+  asOfDate: string = null
 
   /** Original directors from Legal API. */
   original: DirectorIF[] = []
@@ -1494,11 +1489,8 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
     this.emitcomplianceDialogMsg()
   }
 
-  @Watch('codDate', { immediate: true })
-  onCodDateChanged (newVal: string, oldVal: string): void {
-    // update asOfDate with the new date
-    this.asOfDate = newVal
-
+  @Watch('asOfDate', { immediate: true })
+  onAsOfDateChanged (newVal: string, oldVal: string): void {
     // update the appointment/cessation dates for applicable directors
     this.updateChangedDirectorDates(newVal, oldVal)
   }

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -1280,12 +1280,11 @@ export default class AnnualReport extends Mixins(CommonMixin, DateMixin, FilingM
     // ignore changes before data is loaded
     if (!this.dataLoaded) return null
 
-    // fetch original office addresses and directors with new date + update working data
-    // (this will overwrite the current data)
+    // fetch original office addresses and directors with new date
     this.isFetching = true
     if (!this.isVitestRunning) {
-      await this.$refs.officeAddressesComponent.getOrigAddresses(this.asOfDate, true)
-      await this.$refs.directorsComponent.getOrigDirectors(this.asOfDate, true)
+      await this.$refs.officeAddressesComponent.getOrigAddresses(this.asOfDate, false)
+      await this.$refs.directorsComponent.getOrigDirectors(this.asOfDate, false)
     }
     this.isFetching = false
   }

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -132,6 +132,7 @@
                   <Directors
                     ref="directorsComponent"
                     :directors.sync="updatedDirectors"
+                    :codDate="codDate"
                     @directorsPaidChange="onDirectorsPaidChange($event)"
                     @directorsFreeChange="onDirectorsFreeChange($event)"
                     @directorFormValid="directorFormValid=$event"

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -1003,20 +1003,6 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
     }
   }
 
-  @Watch('codDate')
-  async onCodDateChanged (): Promise<void> {
-    // ignore changes before data is loaded
-    if (!this.dataLoaded) return null
-
-    // fetch original directors with new date + update working data
-    // (this will overwrite the current data)
-    this.isFetching = true
-    if (!this.isVitestRunning) {
-      await this.$refs.directorsComponent.getOrigDirectors(this.codDate, true)
-    }
-    this.isFetching = false
-  }
-
   @Watch('isCertified')
   onIsCertifiedChanged (): void {
     // only record changes once the initial data is loaded

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -132,7 +132,6 @@
                   <Directors
                     ref="directorsComponent"
                     :directors.sync="updatedDirectors"
-                    :codDate="codDate"
                     @directorsPaidChange="onDirectorsPaidChange($event)"
                     @directorsFreeChange="onDirectorsFreeChange($event)"
                     @directorFormValid="directorFormValid=$event"
@@ -1002,6 +1001,19 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
         this.onClickFilePayFinish()
         break
     }
+  }
+
+  @Watch('codDate')
+  async onCodDateChanged (): Promise<void> {
+    // ignore changes before data is loaded
+    if (!this.dataLoaded) return null
+
+    // fetch original directors with new date
+    this.isFetching = true
+    if (!this.isVitestRunning) {
+      await this.$refs.directorsComponent.getOrigDirectors(this.codDate, false)
+    }
+    this.isFetching = false
   }
 
   @Watch('isCertified')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22373 

*Description of changes:*
- Retain changes entered for COD even after a new date has been selected
- Update the appointment/cessation date in the directors list for _directors with new changes_ when a new date is selected
- Make the calendar icon clickable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
