### PR TITLE
28541 - Do not Prepopulate Folio Number field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/TransactionalFolioNumber.vue
+++ b/src/components/common/TransactionalFolioNumber.vue
@@ -51,9 +51,6 @@ export default class TransactionalFolioNumber extends Vue {
     folioNumberInput: any
   }
 
-  /** Account Folio Number prop. */
-  @Prop({ default: null }) readonly accountFolioNumber!: string
-
   /** Transactional Folio Number prop. */
   @Prop({ default: null }) readonly transactionalFolioNumber!: string
 

--- a/src/components/common/TransactionalFolioNumber.vue
+++ b/src/components/common/TransactionalFolioNumber.vue
@@ -62,8 +62,8 @@ export default class TransactionalFolioNumber extends Vue {
 
   /** Called when component is mounted. */
   mounted (): void {
-    // restore transactional FN if it exists, otherwise use account FN
-    this.localFolioNumber = this.transactionalFolioNumber || this.accountFolioNumber
+    // restore transactional FN from draft if it exists, otherwise leave field empty
+    this.localFolioNumber = this.transactionalFolioNumber || ''
     // Emit initial validity
     this.emitValid(this.isValid)
   }

--- a/src/views/AgmExtension.vue
+++ b/src/views/AgmExtension.vue
@@ -465,7 +465,8 @@ export default class AgmExtension extends Mixins(CommonMixin, DateMixin, FilingM
         name: FilingTypes.AGM_EXTENSION,
         certifiedBy: this.certifiedBy || '',
         date: this.getCurrentDate, // NB: API will reassign this date according to its clock
-        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined
+        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined,
+        isTransactionalFolioNumber: !!this.getTransactionalFolioNumber
       }
     }
 

--- a/src/views/AgmExtension.vue
+++ b/src/views/AgmExtension.vue
@@ -84,7 +84,6 @@
                 :class="{ 'invalid-section': !folioNumberValid && showErrors }"
               >
                 <TransactionalFolioNumber
-                  :accountFolioNumber="getFolioNumber"
                   :transactionalFolioNumber="getTransactionalFolioNumber"
                   @change="onTransactionalFolioNumberChange"
                   @valid="folioNumberValid = $event"

--- a/src/views/AgmLocationChg.vue
+++ b/src/views/AgmLocationChg.vue
@@ -577,7 +577,8 @@ export default class AgmLocationChg extends Mixins(CommonMixin, DateMixin, Filin
         name: FilingTypes.AGM_LOCATION_CHANGE,
         certifiedBy: this.certifiedBy || '',
         date: this.getCurrentDate, // NB: API will reassign this date according to its clock
-        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined
+        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined,
+        isTransactionalFolioNumber: !!this.getTransactionalFolioNumber
       }
     }
 

--- a/src/views/AgmLocationChg.vue
+++ b/src/views/AgmLocationChg.vue
@@ -190,7 +190,6 @@
                 :class="{ 'invalid-section': !folioNumberValid && showErrors }"
               >
                 <TransactionalFolioNumber
-                  :accountFolioNumber="getFolioNumber"
                   :transactionalFolioNumber="getTransactionalFolioNumber"
                   @change="onTransactionalFolioNumberChange"
                   @valid="folioNumberValid = $event"

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -736,7 +736,9 @@ export default class AnnualReport extends Mixins(CommonMixin, DateMixin, FilingM
       this.certifiedBy = header.certifiedBy
 
       // restore Transactional Folio Number
-      if (filing.header.folioNumber) this.setTransactionalFolioNumber(filing.header.folioNumber)
+      if (filing.header.isTransactionalFolioNumber && filing.header.folioNumber) {
+        this.setTransactionalFolioNumber(filing.header.folioNumber)
+      }
 
       // restore Staff Payment data
       if (header.routingSlipNumber) {
@@ -1077,7 +1079,8 @@ export default class AnnualReport extends Mixins(CommonMixin, DateMixin, FilingM
         date: this.getCurrentDate, // NB: API will reassign this date according to its clock
         ARFilingYear: this.ARFilingYear, // NB: used by TodoList when loading draft AR
         effectiveDate: this.yyyyMmDdToApi(this.asOfDate),
-        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined
+        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined,
+        isTransactionalFolioNumber: !!this.getTransactionalFolioNumber
       }
     }
 

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -265,7 +265,6 @@
                 :class="{ 'invalid-section': !folioNumberValid && showErrors }"
               >
                 <TransactionalFolioNumber
-                  :accountFolioNumber="getFolioNumber"
                   :transactionalFolioNumber="getTransactionalFolioNumber"
                   @change="onTransactionalFolioNumberChange"
                   @valid="folioNumberValid = $event"

--- a/src/views/ConsentAmalgamationOut.vue
+++ b/src/views/ConsentAmalgamationOut.vue
@@ -146,7 +146,6 @@
                 :class="{ 'invalid-section': !folioNumberValid && showErrors }"
               >
                 <TransactionalFolioNumber
-                  :accountFolioNumber="getFolioNumber"
                   :transactionalFolioNumber="getTransactionalFolioNumber"
                   @change="onTransactionalFolioNumberChange"
                   @valid="folioNumberValid = $event"

--- a/src/views/ConsentAmalgamationOut.vue
+++ b/src/views/ConsentAmalgamationOut.vue
@@ -520,7 +520,9 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
       this.certifiedBy = filing.header.certifiedBy
 
       // restore Transactional Folio Number
-      if (filing.header.folioNumber) this.setTransactionalFolioNumber(filing.header.folioNumber)
+      if (filing.header.isTransactionalFolioNumber && filing.header.folioNumber) {
+        this.setTransactionalFolioNumber(filing.header.folioNumber)
+      }
 
       // load Staff Payment properties
       if (filing.header.routingSlipNumber) {
@@ -768,7 +770,8 @@ export default class ConsentAmalgamationOut extends Mixins(CommonMixin, DateMixi
         certifiedBy: this.certifiedBy || '',
         email: this.getBusinessEmail || undefined,
         date: this.getCurrentDate, // NB: API will reassign this date according to its clock
-        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined
+        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined,
+        isTransactionalFolioNumber: !!this.getTransactionalFolioNumber
       }
     }
 

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -520,7 +520,9 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
       this.certifiedBy = filing.header.certifiedBy
 
       // restore Transactional Folio Number
-      if (filing.header.folioNumber) this.setTransactionalFolioNumber(filing.header.folioNumber)
+      if (filing.header.isTransactionalFolioNumber && filing.header.folioNumber) {
+        this.setTransactionalFolioNumber(filing.header.folioNumber)
+      }
 
       // load Staff Payment properties
       if (filing.header.routingSlipNumber) {
@@ -768,7 +770,8 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
         certifiedBy: this.certifiedBy || '',
         email: this.getBusinessEmail || undefined,
         date: this.getCurrentDate, // NB: API will reassign this date according to its clock
-        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined
+        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined,
+        isTransactionalFolioNumber: !!this.getTransactionalFolioNumber
       }
     }
 

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -146,7 +146,6 @@
                 :class="{ 'invalid-section': !folioNumberValid && showErrors }"
               >
                 <TransactionalFolioNumber
-                  :accountFolioNumber="getFolioNumber"
                   :transactionalFolioNumber="getTransactionalFolioNumber"
                   @change="onTransactionalFolioNumberChange"
                   @valid="folioNumberValid = $event"

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -612,7 +612,9 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
       this.certifiedBy = filing.header.certifiedBy
 
       // restore Transactional Folio Number
-      if (filing.header.folioNumber) this.setTransactionalFolioNumber(filing.header.folioNumber)
+      if (filing.header.isTransactionalFolioNumber && filing.header.folioNumber) {
+        this.setTransactionalFolioNumber(filing.header.folioNumber)
+      }
 
       // restore Staff Payment data
       if (filing.header.routingSlipNumber) {
@@ -877,7 +879,8 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
         email: 'no_one@never.get',
         date: this.getCurrentDate, // NB: API will reassign this date according to its clock
         effectiveDate: this.yyyyMmDdToApi(this.codDate),
-        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined
+        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined,
+        isTransactionalFolioNumber: !!this.getTransactionalFolioNumber
       }
     }
 

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -269,7 +269,6 @@
                 <!-- Folio Number -->
                 <section v-if="!IsAuthorized(AuthorizedActions.STAFF_PAYMENT)">
                   <TransactionalFolioNumber
-                    :accountFolioNumber="getFolioNumber"
                     :transactionalFolioNumber="getTransactionalFolioNumber"
                     @change="onTransactionalFolioNumberChange"
                     @valid="folioNumberValid = $event"

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -141,7 +141,6 @@
             <!-- Folio Number -->
             <section v-if="!IsAuthorized(AuthorizedActions.STAFF_PAYMENT)">
               <TransactionalFolioNumber
-                :accountFolioNumber="getFolioNumber"
                 :transactionalFolioNumber="getTransactionalFolioNumber"
                 @change="onTransactionalFolioNumberChange"
                 @valid="folioNumberValid = $event"

--- a/src/views/StandaloneOfficeAddressFiling.vue
+++ b/src/views/StandaloneOfficeAddressFiling.vue
@@ -473,7 +473,9 @@ export default class StandaloneOfficeAddressFiling extends Mixins(CommonMixin, D
       this.certifiedBy = filing.header.certifiedBy
 
       // restore Transactional Folio Number
-      if (filing.header.folioNumber) this.setTransactionalFolioNumber(filing.header.folioNumber)
+      if (filing.header.isTransactionalFolioNumber && filing.header.folioNumber) {
+        this.setTransactionalFolioNumber(filing.header.folioNumber)
+      }
 
       // restore Staff Payment data
       if (filing.header.routingSlipNumber) {
@@ -737,7 +739,8 @@ export default class StandaloneOfficeAddressFiling extends Mixins(CommonMixin, D
         email: 'no_one@never.get',
         date: this.getCurrentDate, // NB: API will reassign this date according to its clock
         effectiveDate: this.yyyyMmDdToApi(this.coaDate),
-        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined
+        folioNumber: this.getTransactionalFolioNumber || this.getFolioNumber || undefined,
+        isTransactionalFolioNumber: !!this.getTransactionalFolioNumber
       }
     }
 

--- a/tests/unit/AgmExtension.spec.ts
+++ b/tests/unit/AgmExtension.spec.ts
@@ -272,7 +272,8 @@ describe('AGM Extension view', () => {
         certifiedBy: 'Full Name',
         date: '2023-11-06',
         name: 'agmExtension',
-        folioNumber: undefined
+        folioNumber: undefined,
+        isTransactionalFolioNumber: false
       }
     }
     expect(LegalServices.createFiling).toHaveBeenCalledWith('BC1234567', data, false)

--- a/tests/unit/TransactionalFolioNumber.spec.ts
+++ b/tests/unit/TransactionalFolioNumber.spec.ts
@@ -28,25 +28,25 @@ describe('TransactionalFolioNumber', () => {
   })
 
   it('shows an empty field if transactionalFolioNumber is not set', () => {
-    wrapper = factory({ accountFolioNumber: '1234', transactionalFolioNumber: null })
+    wrapper = factory({ transactionalFolioNumber: null })
     expect(wrapper.vm.$data.localFolioNumber).toBe('')
   })
 
   it('shows transactionalFolioNumber if set', () => {
-    wrapper = factory({ accountFolioNumber: '1234', transactionalFolioNumber: '4321' })
+    wrapper = factory({ transactionalFolioNumber: '4321' })
     expect(wrapper.vm.$data.localFolioNumber).toBe('4321')
   })
 
   it('updates localFolioNumber when transactionalFolioNumber prop changes', async () => {
-    wrapper = factory({ accountFolioNumber: 'A', transactionalFolioNumber: 'B' })
-    expect(wrapper.vm.$data.localFolioNumber).toBe('B')
-    await wrapper.setProps({ transactionalFolioNumber: 'C' })
+    wrapper = factory({ transactionalFolioNumber: 'A' })
+    expect(wrapper.vm.$data.localFolioNumber).toBe('A')
+    await wrapper.setProps({ transactionalFolioNumber: 'B' })
     await Vue.nextTick()
-    expect(wrapper.vm.$data.localFolioNumber).toBe('C')
+    expect(wrapper.vm.$data.localFolioNumber).toBe('B')
   })
 
   it('has update event for transactionalFolioNumber when a user changes the folio number', async () => {
-    wrapper = factory({ accountFolioNumber: '1234', transactionalFolioNumber: null })
+    wrapper = factory({ transactionalFolioNumber: null })
     const input = wrapper.find('input')
     await input.setValue('NEWFOLIO')
     expect(wrapper.emitted('change')).toBeTruthy()
@@ -57,7 +57,7 @@ describe('TransactionalFolioNumber', () => {
   })
 
   it('limits input to 50 characters', async () => {
-    wrapper = factory({ accountFolioNumber: '', transactionalFolioNumber: '' })
+    wrapper = factory({ transactionalFolioNumber: '' })
     const input = wrapper.find('input')
     const longValue = 'x'.repeat(51)
     await input.setValue(longValue)
@@ -72,7 +72,7 @@ describe('TransactionalFolioNumber', () => {
   })
 
   it('accepts input up to 50 characters', async () => {
-    wrapper = factory({ accountFolioNumber: '', transactionalFolioNumber: '' })
+    wrapper = factory({ transactionalFolioNumber: '' })
     const input = wrapper.find('input')
     const validValue = 'x'.repeat(50)
     await input.setValue(validValue)

--- a/tests/unit/TransactionalFolioNumber.spec.ts
+++ b/tests/unit/TransactionalFolioNumber.spec.ts
@@ -27,9 +27,9 @@ describe('TransactionalFolioNumber', () => {
     expect(wrapper.find('input').exists()).toBe(true)
   })
 
-  it('shows accountFolioNumber if transactionalFolioNumber is not set', () => {
+  it('shows an empty field if transactionalFolioNumber is not set', () => {
     wrapper = factory({ accountFolioNumber: '1234', transactionalFolioNumber: null })
-    expect(wrapper.vm.$data.localFolioNumber).toBe('1234')
+    expect(wrapper.vm.$data.localFolioNumber).toBe('')
   })
 
   it('shows transactionalFolioNumber if set', () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28541

*Description of changes:*
- Updated requirement: Do not prepopulate the account folio number (we will restore the TFN when resuming a draft filing, when applicable)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
