### PR TITLE
28814 - Fix Information Icon Colour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.0.7",
+      "version": "8.0.8",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -1911,8 +1911,4 @@ ul {
   color: $gray9 !important;
 }
 
-.mdi-information-outline::before {
-  color: $BCgovIconBlue !important;
-}
-
 </style>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28814 

*Description of changes:*
- Sorry this PR was merged early: https://github.com/bcgov/business-filings-ui/pull/763 - just one more request from Jacqueline to update the icon colour

Before:
<img width="1270" height="440" alt="image" src="https://github.com/user-attachments/assets/f129ac54-e333-4952-99ca-bdbdff63dfd6" />

After:
<img width="1402" height="492" alt="image" src="https://github.com/user-attachments/assets/9fa9083b-b71a-4d3a-b77c-6d5c79e41531" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
