### PR TITLE
29925 - Cannot Complete Multiple Address Changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.0.8a",
+  "version": "8.0.8b",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.0.8a",
+      "version": "8.0.8b",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.0.8a",
+  "version": "8.0.8b",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -1351,12 +1351,11 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
     if (mainFormIsValid && addressFormIsValid && (!this.editFormShowHide.showName || this.legalNameConfirmed)) {
       // save data from BaseAddress component
       // - only save address if a change was made, ie there is an in-progress address from the component
-      console.log('inProgressMailAddress1:', this.inProgressMailAddress)
+
       if (!Object.values(this.inProgressDelivAddress).every(el => el === undefined)) {
         director.deliveryAddress = this.inProgressDelivAddress
       }
 
-     console.log('inProgressMailAddress2:', this.inProgressMailAddress)
       if (this.isBaseCompany) {
         if (!Object.values(this.inProgressMailAddress).every(el => el === undefined)) {
           director.mailingAddress = this.inProgressMailAddress

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -1351,7 +1351,6 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
     if (mainFormIsValid && addressFormIsValid && (!this.editFormShowHide.showName || this.legalNameConfirmed)) {
       // save data from BaseAddress component
       // - only save address if a change was made, ie there is an in-progress address from the component
-
       if (!Object.values(this.inProgressDelivAddress).every(el => el === undefined)) {
         director.deliveryAddress = this.inProgressDelivAddress
       }

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -1268,6 +1268,7 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
     // clear in-progress director data from form in BaseAddress component - ie: start fresh
     this.inProgressDelivAddress = null
     this.inProgressMailAddress = null
+    this.inheritDeliveryAddress = false
     this.directorEditInProgress = true
     this.activeIndex = index
     this.messageIndex = index
@@ -1350,10 +1351,12 @@ export default class Directors extends Mixins(CommonMixin, DateMixin, DirectorMi
     if (mainFormIsValid && addressFormIsValid && (!this.editFormShowHide.showName || this.legalNameConfirmed)) {
       // save data from BaseAddress component
       // - only save address if a change was made, ie there is an in-progress address from the component
+      console.log('inProgressMailAddress1:', this.inProgressMailAddress)
       if (!Object.values(this.inProgressDelivAddress).every(el => el === undefined)) {
         director.deliveryAddress = this.inProgressDelivAddress
       }
 
+     console.log('inProgressMailAddress2:', this.inProgressMailAddress)
       if (this.isBaseCompany) {
         if (!Object.values(this.inProgressMailAddress).every(el => el === undefined)) {
           director.mailingAddress = this.inProgressMailAddress


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29925 

*Description of changes:*
- updateMailingAddress is linked to the inheritDeliveryAddress checkbox which wasn't being reset after editing the first director

https://github.com/user-attachments/assets/456946bf-1ad7-4255-b2c3-55d2c8e84ec6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
