### PR TITLE
31804 - Prevent COA Form Submission for Invalid Whitespaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.0.17",
+  "version": "8.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.0.17",
+      "version": "8.0.18",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.0.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.0.17",
+  "version": "8.0.18",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/schemas/office-address-schema.ts
+++ b/src/schemas/office-address-schema.ts
@@ -3,13 +3,13 @@ import { required, maxLength } from 'vuelidate/lib/validators'
 // The Address schema containing Vuelidate rules.
 // NB: This should match the subject JSON schema.
 
-const requiredNoWhitespace = (val) => {
+export const requiredNoWhitespace = (val) => {
   if (!val) return true
   const trimmed = val.trim()
   return trimmed.length > 0 && trimmed === val
 }
 
-const noLeadingTrailingSpaces = (val) => {
+export const noLeadingTrailingSpaces = (val) => {
   if (!val) return true
   return val.trim() === val
 }

--- a/src/schemas/office-address-schema.ts
+++ b/src/schemas/office-address-schema.ts
@@ -3,12 +3,14 @@ import { required, maxLength } from 'vuelidate/lib/validators'
 // The Address schema containing Vuelidate rules.
 // NB: This should match the subject JSON schema.
 
+/** Validator for required fields to reject whitespace-only strings and leading/trailing spaces */
 export const requiredNoWhitespace = (val) => {
   if (!val) return true
   const trimmed = val.trim()
   return trimmed.length > 0 && trimmed === val
 }
 
+/** Validator for optional fields to reject leading/trailing spaces */
 export const noLeadingTrailingSpaces = (val) => {
   if (!val) return true
   return val.trim() === val

--- a/src/schemas/office-address-schema.ts
+++ b/src/schemas/office-address-schema.ts
@@ -2,17 +2,32 @@ import { required, maxLength } from 'vuelidate/lib/validators'
 
 // The Address schema containing Vuelidate rules.
 // NB: This should match the subject JSON schema.
+
+const requiredNoWhitespace = (val) => {
+  if (!val) return true
+  const trimmed = val.trim()
+  return trimmed.length > 0 && trimmed === val
+}
+
+const noLeadingTrailingSpaces = (val) => {
+  if (!val) return true
+  return val.trim() === val
+}
+
 export const officeAddressSchema = {
   streetAddress: {
     required,
-    maxLength: maxLength(50)
+    maxLength: maxLength(50),
+    requiredNoWhitespace
   },
   streetAddressAdditional: {
-    maxLength: maxLength(50)
+    maxLength: maxLength(50),
+    noLeadingTrailingSpaces
   },
   addressCity: {
     required,
-    maxLength: maxLength(40)
+    maxLength: maxLength(40),
+    requiredNoWhitespace
   },
   addressCountry: {
     required,
@@ -26,9 +41,11 @@ export const officeAddressSchema = {
   },
   postalCode: {
     required,
-    maxLength: maxLength(15)
+    maxLength: maxLength(15),
+    requiredNoWhitespace
   },
   deliveryInstructions: {
-    maxLength: maxLength(80)
+    maxLength: maxLength(80),
+    noLeadingTrailingSpaces
   }
 }

--- a/tests/unit/officeAddressSchema.spec.ts
+++ b/tests/unit/officeAddressSchema.spec.ts
@@ -1,0 +1,45 @@
+import { requiredNoWhitespace, noLeadingTrailingSpaces } from '@/schemas'
+
+describe('office-address-schema whitespace validators', () => {
+  describe('requiredNoWhitespace', () => {
+    it('fails for whitespace only', () => {
+      expect(requiredNoWhitespace('   ')).toBe(false)
+    })
+
+    it('fails for leading whitespace', () => {
+      expect(requiredNoWhitespace(' test')).toBe(false)
+    })
+
+    it('fails for trailing whitespace', () => {
+      expect(requiredNoWhitespace('test ')).toBe(false)
+    })
+
+    it('passes for trimmed non-empty value', () => {
+      expect(requiredNoWhitespace('test')).toBe(true)
+    })
+
+    it('passes for empty value (required handles emptiness)', () => {
+      expect(requiredNoWhitespace('')).toBe(true)
+      expect(requiredNoWhitespace(null)).toBe(true)
+    })
+  })
+
+  describe('noLeadingTrailingSpaces', () => {
+    it('fails when value has leading spaces', () => {
+      expect(noLeadingTrailingSpaces(' test')).toBe(false)
+    })
+
+    it('fails when value has trailing spaces', () => {
+      expect(noLeadingTrailingSpaces('test ')).toBe(false)
+    })
+
+    it('passes for trimmed value', () => {
+      expect(noLeadingTrailingSpaces('test')).toBe(true)
+    })
+
+    it('passes for empty value', () => {
+      expect(noLeadingTrailingSpaces('')).toBe(true)
+      expect(noLeadingTrailingSpaces(null)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31804 

*Description of changes:*
- Add no leading/trailing/whitespace only validation for required fields
- Add no leading/trailing whitespace for optional fields
- Prevent form submission when there are whitespace validation errors and force users to fix the input - consistent with other filings (i.e. Change of Director)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
