### PR TITLE
32919 Skip future-ceased directors on filing submit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.0",
+      "version": "8.3.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/SummaryDirectors.vue
+++ b/src/components/common/SummaryDirectors.vue
@@ -263,7 +263,8 @@ export default class SummaryDirectors extends Mixins(CommonMixin, DateMixin) {
   @Watch('directors', { deep: true, immediate: true })
   onDirectorsChanged (): void {
     // NOTE: CEASED action only exists if director was ceased in this filing.
-    // This means future-ceased directors will appear in current directors list.
+    // This means future-ceased directors will appear in current directors list
+    // (which makes sense because, as of this filing, they are still active).
     this.directorSummary = this.directors.filter(dir => !this.isCeased(dir))
     this.directorsCeased = this.directors.filter(dir => this.isCeased(dir))
   }
@@ -302,6 +303,8 @@ export default class SummaryDirectors extends Mixins(CommonMixin, DateMixin) {
    * @returns True if director is future-ceased.
    */
   isFutureCeased (director: DirectorIF): boolean {
+    // no need to check if not ceased because this method is only used in summary list,
+    // which contains only unceased directors
     return !!director.cessationDate
   }
   /**

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -1261,10 +1261,6 @@ export default class AnnualReport extends Mixins(CommonMixin, DateMixin, FilingM
     return (!!this.agmDate && this.compareYyyyMmDd(this.agmDate, earliestAllowedDate, '>='))
   }
 
-  hasAction (director, action): boolean {
-    return (director.actions.indexOf(action) >= 0)
-  }
-
   /** Handles Exit event from Payment Error dialog. */
   onPaymentErrorDialogExit (): void {
     if (IsAuthorized(AuthorizedActions.STAFF_PAYMENT)) {

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -987,13 +987,9 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
    * Use this for final submission only (not draft saving).
    */
   fixDirectors (directors: DirectorIF[]): DirectorIF[] {
-    function isCeased (director: DirectorIF): boolean {
-      return director.actions?.includes(Actions.CEASED) || false
-    }
-
     // directors with a cease date but no cease action are future-ceased
     // return directors with no cease date or with a cease action
-    return directors.filter(director => !director.cessationDate || isCeased(director))
+    return directors.filter(director => !director.cessationDate || this.hasAction(director, Actions.CEASED))
   }
 
   /**

--- a/src/views/StandaloneDirectorsFiling.vue
+++ b/src/views/StandaloneDirectorsFiling.vue
@@ -441,7 +441,7 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
 
   // variables
   authErrorDialog = false
-  updatedDirectors = []
+  updatedDirectors: DirectorIF[] = []
   fetchErrorDialog = false
   resumeErrorDialog = false
   saveErrorReason: SaveErrorReasons = null
@@ -954,7 +954,9 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
     if (this.hasFilingCode(this.feeCode) || this.hasFilingCode(this.freeFeeCode)) {
       changeOfDirectors = {
         [FilingTypes.CHANGE_OF_DIRECTORS]: {
-          directors: this.updatedDirectors
+          // if draft, save directors as they are
+          // otherwise, remove any future ceased directors
+          directors: isDraft ? this.updatedDirectors : this.fixDirectors(this.updatedDirectors)
         }
       }
     }
@@ -978,6 +980,20 @@ export default class StandaloneDirectorsFiling extends Mixins(CommonMixin, DateM
       this.saveWarnings = error?.response?.data?.warnings || []
       throw error
     }
+  }
+
+  /**
+   * Returns a list of directors with future-ceased directors removed (as API would reject this).
+   * Use this for final submission only (not draft saving).
+   */
+  fixDirectors (directors: DirectorIF[]): DirectorIF[] {
+    function isCeased (director: DirectorIF): boolean {
+      return director.actions?.includes(Actions.CEASED) || false
+    }
+
+    // directors with a cease date but no cease action are future-ceased
+    // return directors with no cease date or with a cease action
+    return directors.filter(director => !director.cessationDate || isCeased(director))
   }
 
   /**

--- a/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -2016,10 +2016,10 @@ describe('Standalone Directors Filing - future-ceased directors', () => {
     vm = wrapper.vm
 
     // mock hasPendingTasks()
-    BusinessServices.hasPendingTasks = vi.fn().mockResolvedValue(false)
+    vi.spyOn(BusinessServices, 'hasPendingTasks').mockResolvedValue(false)
 
     // mock createFiling()
-    BusinessServices.createFiling = vi.fn()
+    vi.spyOn(BusinessServices, 'createFiling').mockResolvedValue(undefined as any)
 
     // set up in-memory director data
     await wrapper.setData({

--- a/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -21,6 +21,7 @@ import { FilingCodes } from '@bcrs-shared-components/enums'
 import * as utils from '@/utils'
 import * as FeatureFlags from '@/utils/feature-flags'
 import { BusinessRegistryStaffActions, PublicUserActions } from './test-data/authorizedActions'
+import { BusinessServices } from '@/services'
 
 // suppress various warnings:
 // - "Unknown custom element <affix>" warnings
@@ -1931,5 +1932,135 @@ describe('Standalone Directors Filing - date computation', () => {
     expect(wrapper.vm.earliestDateToSet).toBe('March 1, 2018')
 
     wrapper.destroy()
+  })
+})
+
+describe('Standalone Directors Filing - future-ceased directors', () => {
+  let wrapper: Wrapper<Vue>
+  let vm: any
+
+  const UNCHANGED_DIRECTOR = {
+    actions: [],
+    appointmentDate: '2026-01-01',
+    cessationDate: null,
+    deliveryAddress: {
+      addressCity: 'City',
+      addressCountry: 'CA',
+      addressRegion: 'BC',
+      postalCode: 'V8V 8V8',
+      streetAddress: 'Street'
+    },
+    officer: {
+      firstName: 'Unchanged',
+      lastName: 'Lastname'
+    }
+  }
+
+  const FUTURE_CEASED_DIRECTOR = {
+    actions: [],
+    appointmentDate: '2026-01-01',
+    cessationDate: '2026-04-01',
+    deliveryAddress: {
+      addressCity: 'City',
+      addressCountry: 'CA',
+      addressRegion: 'BC',
+      postalCode: 'V8V 8V8',
+      streetAddress: 'Street'
+    },
+    officer: {
+      firstName: 'Future-Ceased',
+      lastName: 'Lastname'
+    }
+  }
+
+  const CEASED_DIRECTOR = {
+    actions: ['ceased'],
+    appointmentDate: '2026-01-01',
+    cessationDate: '2019-03-30',
+    deliveryAddress: {
+      addressCity: 'City',
+      addressCountry: 'CA',
+      addressRegion: 'BC',
+      postalCode: 'V8V 8V8',
+      streetAddress: 'Street'
+    },
+    officer: {
+      firstName: 'Ceased',
+      lastName: 'Lastname'
+    }
+  }
+
+  beforeAll(() => {
+    // set configurations
+    configurationStore.setConfiguration({
+      'VUE_APP_BUSINESS_API_URL': 'https://business-api.url/',
+      'VUE_APP_BUSINESS_API_VERSION_2': 'v2'
+    })
+
+    // init store
+    businessStore.setIdentifier('BC1234567')
+    businessStore.setLegalName('Legal Name - BC1234567')
+    businessStore.setLegalType(CorpTypeCd.BENEFIT_COMPANY)
+    rootStore.setAuthorizedActions(PublicUserActions)
+    rootStore.setCurrentDate('2026-03-30')
+  })
+
+  beforeEach(async () => {
+    // create local Vue and mock router
+    const localVue = createLocalVue()
+    localVue.use(VueRouter)
+    const router = mockRouter.mock()
+    router.push({ name: 'standalone-directors', query: { filingId: '0' } }) // new filing id
+
+    wrapper = shallowMount(StandaloneDirectorsFiling, { localVue, router })
+    vm = wrapper.vm
+
+    // mock hasPendingTasks()
+    BusinessServices.hasPendingTasks = vi.fn().mockResolvedValue(false)
+
+    // mock createFiling()
+    BusinessServices.createFiling = vi.fn()
+
+    // set up in-memory director data
+    await wrapper.setData({
+      updatedDirectors: [UNCHANGED_DIRECTOR, FUTURE_CEASED_DIRECTOR, CEASED_DIRECTOR]
+    })
+
+    // make sure form is validated
+    await wrapper.setData({
+      codDateValid: true,
+      directorFormValid: true,
+      certifyFormValid: true,
+      folioNumberValid: true
+    })
+
+    // add paid change code
+    vm.onDirectorsPaidChange(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    wrapper.destroy()
+  })
+
+  it('Includes complete list of directors in draft data', async () => {
+    // trigger "save draft" action
+    await vm.onClickSave()
+
+    // verify filing body -- should include all directors
+    expect(BusinessServices.createFiling).toHaveBeenCalledWith('BC1234567', expect.objectContaining(
+      { changeOfDirectors: { directors: [UNCHANGED_DIRECTOR, FUTURE_CEASED_DIRECTOR, CEASED_DIRECTOR] } }
+    ), true)
+  })
+
+  it('Includes non-future-ceased directors in submitted data', async () => {
+    // trigger "submit filing" action
+    await vm.onClickFilePay()
+
+    // verify filing body - should include unchanged and ceased director but not future-ceased director
+
+    expect(BusinessServices.createFiling).toHaveBeenCalledWith('BC1234567', expect.objectContaining(
+      { changeOfDirectors: { directors: [UNCHANGED_DIRECTOR, CEASED_DIRECTOR] } }
+    ), false)
   })
 })


### PR DESCRIPTION
*Issue #:* bcgov/entity#32919

*Description of changes:*
- app version = 8.3.1
- expanded some code comments
- filtered out future-ceased directors when submitting (ie, not draft)
- added unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).