### PR TITLE
33001 show completing party to non-staff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.3",
+  "version": "8.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.3",
+      "version": "8.3.4",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.3",
+  "version": "8.3.4",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -128,7 +128,7 @@
                   class="py-8 px-5"
                 >
                   <DocumentDelivery
-                    :editableCompletingParty="IsAuthorized(AuthorizedActions.EDITABLE_COMPLETING_PARTY)"
+                    :editableCompletingParty="true"
                     :contactValue="getBusinessEmail"
                     contactLabel="Business Office"
                     :documentOptionalEmail="documentOptionalEmail"

--- a/tests/unit/ConsentContinuationOut.spec.ts
+++ b/tests/unit/ConsentContinuationOut.spec.ts
@@ -392,6 +392,7 @@ describe('Consent to Continue Out for general user and IAs only', () => {
     expect(wrapper.findComponent(ConfirmDialog).exists()).toBe(true)
     expect(wrapper.findComponent(CourtOrderPoa).exists()).toBe(false) // staff only
     expect(wrapper.findComponent(DocumentDelivery).exists()).toBe(true)
+    expect(wrapper.findComponent(DocumentDelivery).props('editableCompletingParty')).toBe(true)
     expect(wrapper.findComponent(ForeignJurisdiction).exists()).toBe(true)
     expect(wrapper.findComponent(PaymentErrorDialog).exists()).toBe(true)
     expect(wrapper.findComponent(ResumeErrorDialog).exists()).toBe(true)


### PR DESCRIPTION
#33001 : /bcgov/entity#33001

*Description of changes:*
Adjusted editableCompletingParty="ture"

The parent passes editableCompletingParty="IsAuthorized(AuthorizedActions.EDITABLE_COMPLETING_PARTY)". That action is granted only to Business Registry Staff and SBC Field Office Staff, which conflicts with the figma design, as Non staff members should also be able to input Completing Party email address.

Currently, for non-staff users IsAuthorized(...) returns false, and DocumentDelivery dose not display. Only showing span "(Not entered)"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
