### PR TITLE
31833 - Update Font Size for Certify/Authorization Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.5",
+  "version": "8.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.5",
+      "version": "8.3.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.5",
+  "version": "8.3.6",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Certify.vue
+++ b/src/components/common/Certify.vue
@@ -236,13 +236,13 @@ export default class Certify extends Vue {
   padding-bottom: 0.5rem;
   padding-top: 1rem;
   line-height: 1.2rem;
-  font-size: $px-14;
+  font-size: $px-16;
 }
 
 .certify-clause {
   padding-left: 0;
   color: black;
-  font-size: $px-14;
+  font-size: $px-16;
 }
 
 .signature-date {
@@ -251,13 +251,14 @@ export default class Certify extends Vue {
 
 .certify-stmt {
   display: inline;
-  font-size: $px-14;
+  font-size: $px-16;
   color: black;
 }
 
 .title-label {
   color: $gray9;
   font-weight: bold;
+  font-size: $px-16;
 }
 
 .v-input--checkbox::v-deep {

--- a/src/components/common/Certify.vue
+++ b/src/components/common/Certify.vue
@@ -241,7 +241,7 @@ export default class Certify extends Vue {
 
 .certify-clause {
   padding-left: 0;
-  color: black;
+  color: $gray7;
   font-size: $px-16;
 }
 
@@ -252,7 +252,7 @@ export default class Certify extends Vue {
 .certify-stmt {
   display: inline;
   font-size: $px-16;
-  color: black;
+  color: $gray7;
 }
 
 .title-label {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31833 

*Description of changes:*
- Request from Scott to increase the font size to 16px/1rem
- Updated text colour
<img width="617" height="233" alt="image" src="https://github.com/user-attachments/assets/425357a6-3a46-4614-8677-ba94abb47f35" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
