### PR TITLE
31833 - Fix NoW Authorization Component Display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.6",
+  "version": "8.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.6",
+      "version": "8.3.7",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.6",
+  "version": "8.3.7",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -339,6 +339,7 @@ export default class App extends Mixins(
         // fetch the bootstrap filing and store the bootstrap item
         const response = await BusinessServices.fetchBootstrapFiling(this.tempRegNumber)
         this.storeBootstrapItem(response)
+        this.storeConfigObject()
 
         // if it is a todo or a pending filing, and it has a NR, load it
         // (this is to display the NR details in the Todo List/Pending List)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31833 

*Description of changes:*
- The business config wasn't being stored for bootstrap filings so the values (entity display, message and confirm variant) weren't populating for a NoW of an IA

NoW of a boostrap filing (On Dev):
<img width="533" height="230" alt="image" src="https://github.com/user-attachments/assets/98fa313e-a480-4088-bbe2-6c41035ca8d1" />

NoW of a boostrap filing (After Change):
<img width="674" height="214" alt="image" src="https://github.com/user-attachments/assets/73641758-dd53-4d9a-9cba-ee2fc0b9a4c8" />

NoW of a regular filing:
<img width="532" height="185" alt="image" src="https://github.com/user-attachments/assets/ca6230c2-7977-4400-9315-33c9426c8797" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
