### PR TITLE
33467 - require Latin-1 on editable director address fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.11",
+  "version": "8.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.11",
+      "version": "8.3.12",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.11",
+  "version": "8.3.12",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Directors.vue
+++ b/src/components/common/Directors.vue
@@ -79,6 +79,7 @@
                       ref="baseAddressNew"
                       :key="baseAddressKey"
                       :editing="true"
+                      :require-latin1="true"
                       :schema="directorAddressSchema"
                       @update:address="updateDeliveryAddress"
                     />
@@ -100,6 +101,7 @@
                           ref="mailAddressNew"
                           :key="mailAddressKey"
                           :editing="true"
+                          :require-latin1="true"
                           :schema="directorAddressSchema"
                           @update:address="updateMailingAddress"
                         />
@@ -398,6 +400,7 @@
                         :key="activeIndex"
                         :address="dir.deliveryAddress"
                         :editing="true"
+                        :require-latin1="true"
                         :schema="directorAddressSchema"
                         @update:address="updateDeliveryAddress"
                       />
@@ -420,6 +423,7 @@
                             :key="activeIndex"
                             :address="dir.mailingAddress"
                             :editing="true"
+                            :require-latin1="true"
                             :schema="directorAddressSchema"
                             @update:address="updateMailingAddress"
                           />

--- a/src/components/common/OfficeAddresses.vue
+++ b/src/components/common/OfficeAddresses.vue
@@ -28,6 +28,7 @@
                   v-else
                   :address="deliveryAddress"
                   :editing="showAddressForm"
+                  :require-latin1="true"
                   :schema="officeAddressSchema"
                   @update:address="updateBaseAddress(deliveryAddress, $event)"
                   @valid="deliveryAddressValid=$event"
@@ -96,6 +97,7 @@
                   v-if="!showAddressForm || !inheritDeliveryAddress"
                   :address="mailingAddress"
                   :editing="showAddressForm"
+                  :require-latin1="true"
                   :schema="officeAddressSchema"
                   @update:address="updateBaseAddress(mailingAddress, $event)"
                   @valid="mailingAddressValid=$event"
@@ -137,6 +139,7 @@
                     <delivery-address
                       :address="recDeliveryAddress"
                       :editing="showAddressForm"
+                      :require-latin1="true"
                       :schema="officeAddressSchema"
                       @update:address="updateBaseAddress(recDeliveryAddress, $event)"
                       @valid="recDeliveryAddressValid=$event"
@@ -176,6 +179,7 @@
                       v-if="!showAddressForm || !inheritRecDeliveryAddress"
                       :address="recMailingAddress"
                       :editing="showAddressForm"
+                      :require-latin1="true"
                       :schema="officeAddressSchema"
                       @update:address="updateBaseAddress(recMailingAddress, $event)"
                       @valid="recMailingAddressValid=$event"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33467

*Description of changes:*
Add :require-latin1="true" to Directors.vue and OfficeAddress.vue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
