### PR TITLE
33519 - add optional ledger Detail field to Consent to Continue Out filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.14",
+  "version": "8.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.14",
+      "version": "8.3.15",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.14",
+  "version": "8.3.15",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -85,6 +85,46 @@
               </h1>
             </header>
 
+            <!-- Detail -->
+            <section>
+              <header>
+                <h2>Detail</h2>
+              </header>
+              <div
+                id="detail-section"
+                :class="{ 'invalid-section': !detailValid && showErrors }"
+              >
+                <v-card
+                  flat
+                  class="py-8 px-5"
+                >
+                  <v-row no-gutters>
+                    <v-col
+                      cols="12"
+                      sm="3"
+                      class="pr-4"
+                    >
+                      <strong :class="{ 'app-red': !detailValid && showErrors }">Detail</strong>
+                    </v-col>
+                    <v-col
+                      cols="12"
+                      sm="9"
+                    >
+                      <DetailComment
+                        v-model="detail"
+                        placeholder="Add a Detail that will appear on the ledger for this business (Optional)"
+                        :maxLength="1900"
+                        :rows="1"
+                        optional
+                        :validateForm="showErrors"
+                        @valid="detailValid=$event"
+                      />
+                    </v-col>
+                  </v-row>
+                </v-card>
+              </div>
+            </section>
+
             <!-- Jurisdiction Information -->
             <section>
               <header>
@@ -317,7 +357,7 @@ import { Action, Getter } from 'pinia-class'
 import { StatusCodes } from 'http-status-codes'
 import { IsAuthorized, Navigate } from '@/utils'
 import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
-import { Certify, ForeignJurisdiction, TransactionalFolioNumber } from '@/components/common'
+import { Certify, DetailComment, ForeignJurisdiction, TransactionalFolioNumber } from '@/components/common'
 import { AuthErrorDialog, ConfirmDialog, PaymentErrorDialog, ResumeErrorDialog, SaveErrorDialog, StaffPaymentDialog }
   from '@/components/dialogs'
 import { CommonMixin, DateMixin, FilingMixin, ResourceLookupMixin } from '@/mixins'
@@ -335,6 +375,7 @@ import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
     Certify,
     ConfirmDialog,
     CourtOrderPoa,
+    DetailComment,
     DocumentDelivery,
     ForeignJurisdiction,
     PaymentErrorDialog,
@@ -378,6 +419,10 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
   fileNumber = ''
   hasPlanOfArrangement = false
   courtOrderValid = true
+
+  // variables for DetailComment component
+  detail = ''
+  detailValid = true
 
   // variables for Foreign Jurisdiction component
   draftCountry = ''
@@ -433,6 +478,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
   get isPageValid (): boolean {
     return (
       this.certifyFormValid &&
+      this.detailValid &&
       this.foreignJurisdictionValid &&
       this.documentDeliveryValid &&
       this.courtOrderValid &&
@@ -575,6 +621,11 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
       if (foreignJurisdiction) {
         this.draftCountry = foreignJurisdiction.country
         this.draftRegion = foreignJurisdiction.region
+      }
+
+      const details = filing.consentContinuationOut.details
+      if (details) {
+        this.detail = details
       }
 
       if (filing.header.documentOptionalEmail) {
@@ -835,6 +886,10 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
       }
     }
 
+    if (this.detail !== '') {
+      data.consentContinuationOut.details = this.detail
+    }
+
     if (this.fileNumber !== '') {
       data.consentContinuationOut.courtOrder = {
         fileNumber: this.fileNumber,
@@ -956,6 +1011,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
 
   /** Array of valid components. Must match validFlags. */
   readonly validComponents = [
+    'detail-section',
     'foreign-jurisdiction-section',
     'document-delivery-section',
     'certify-form-section',
@@ -966,6 +1022,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
   /** Object of valid flags. Must match validComponents. */
   get validFlags (): object {
     return {
+      detail: this.detailValid,
       foreignJurisdiction: this.foreignJurisdictionValid,
       documentDelivery: this.documentDeliveryValid,
       certifyForm: this.certifyFormValid,
@@ -976,6 +1033,7 @@ export default class ConsentContinuationOut extends Mixins(CommonMixin, DateMixi
 
   @Watch('certifyFormValid')
   @Watch('courtOrderValid')
+  @Watch('detail')
   @Watch('documentDeliveryValid')
   @Watch('foreignJurisdictionValid')
   @Watch('folioNumberValid')

--- a/src/views/ConsentContinuationOut.vue
+++ b/src/views/ConsentContinuationOut.vue
@@ -88,7 +88,10 @@
             <!-- Detail -->
             <section>
               <header>
-                <h2>Detail</h2>
+                <h2>Ledger Detail</h2>
+                <p class="grey-text">
+                  Enter a detail that will appear on the ledger for this business
+                </p>
               </header>
               <div
                 id="detail-section"

--- a/tests/unit/ConsentContinuationOut.spec.ts
+++ b/tests/unit/ConsentContinuationOut.spec.ts
@@ -203,6 +203,7 @@ describe('Consent to Continuation Out view', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
+        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -266,6 +267,7 @@ describe('Consent to Continuation Out view', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
+        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -432,6 +434,7 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
+        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,
@@ -468,6 +471,7 @@ describe('Consent to Continue Out for general user and IAs only', () => {
       router,
       stubs: {
         CourtOrderPoa: true,
+        DetailComment: true,
         DocumentDelivery: true,
         Certify: true,
         ForeignJurisdiction: true,

--- a/tests/unit/ConsentContinuationOut.spec.ts
+++ b/tests/unit/ConsentContinuationOut.spec.ts
@@ -171,6 +171,15 @@ describe('Consent to Continuation Out view', () => {
     vm.folioNumberValid = false
     expect(vm.isPageValid).toBe(false)
 
+    // verify "validated" - invalid Detail form
+    vm.certifyFormValid = true
+    vm.courtOrderValid = true
+    vm.documentDeliveryValid = true
+    vm.foreignJurisdictionValid = true
+    vm.folioNumberValid = true
+    vm.detailValid = false
+    expect(vm.isPageValid).toBe(false)
+
     wrapper.destroy()
   })
 
@@ -224,6 +233,103 @@ describe('Consent to Continuation Out view', () => {
 
     // verify that detail comment from Legal API is not null
     expect(vm.savedFiling.consentContinuationOut.details).toBe('test')
+
+    vi.restoreAllMocks()
+    wrapper.destroy()
+  })
+
+  it('includes the ledger detail in the consent to continuation out filing', async () => {
+    // mock "has pending tasks" legal service
+    vi.spyOn(BusinessServices, 'hasPendingTasks').mockImplementation((): any => {
+      return Promise.resolve(false)
+    })
+
+    // mock "create filing" legal service and capture the filing payload
+    let filingArg: any = null
+    vi.spyOn(BusinessServices, 'createFiling').mockImplementation((...args: any[]): any => {
+      filingArg = args[1] // (businessId, filing, isDraft)
+      return Promise.resolve({ business: {}, header: { filingId: 789 }, consentContinuationOut: {} })
+    })
+
+    // mock $route
+    const $route = { query: { filingId: '0' } }
+
+    // create local Vue and mock router
+    createLocalVue().use(VueRouter)
+    const router = mockRouter.mock()
+    router.push({ name: 'consent-continuation-out' })
+
+    const wrapper = shallowMount(ConsentContinuationOut, {
+      router,
+      stubs: {
+        CourtOrderPoa: true,
+        DetailComment: true,
+        DocumentDelivery: true,
+        Certify: true,
+        ForeignJurisdiction: true,
+        SbcFeeSummary: true
+      },
+      mocks: { $route }
+    })
+    const vm: any = wrapper.vm
+
+    // wait for fetch to complete
+    await flushPromises()
+
+    // set a ledger detail and save
+    vm.detail = 'My ledger detail'
+    await vm.onClickSave()
+
+    // verify the detail was included in the built filing payload
+    expect(filingArg.consentContinuationOut.details).toBe('My ledger detail')
+
+    vi.restoreAllMocks()
+    wrapper.destroy()
+  })
+
+  it('omits the ledger detail from the filing when it is empty', async () => {
+    // mock "has pending tasks" legal service
+    vi.spyOn(BusinessServices, 'hasPendingTasks').mockImplementation((): any => {
+      return Promise.resolve(false)
+    })
+
+    // mock "create filing" legal service and capture the filing payload
+    let filingArg: any = null
+    vi.spyOn(BusinessServices, 'createFiling').mockImplementation((...args: any[]): any => {
+      filingArg = args[1] // (businessId, filing, isDraft)
+      return Promise.resolve({ business: {}, header: { filingId: 789 }, consentContinuationOut: {} })
+    })
+
+    // mock $route
+    const $route = { query: { filingId: '0' } }
+
+    // create local Vue and mock router
+    createLocalVue().use(VueRouter)
+    const router = mockRouter.mock()
+    router.push({ name: 'consent-continuation-out' })
+
+    const wrapper = shallowMount(ConsentContinuationOut, {
+      router,
+      stubs: {
+        CourtOrderPoa: true,
+        DetailComment: true,
+        DocumentDelivery: true,
+        Certify: true,
+        ForeignJurisdiction: true,
+        SbcFeeSummary: true
+      },
+      mocks: { $route }
+    })
+    const vm: any = wrapper.vm
+
+    // wait for fetch to complete
+    await flushPromises()
+
+    // leave detail empty and save
+    await vm.onClickSave()
+
+    // verify the (optional) detail is not included when empty
+    expect(filingArg.consentContinuationOut.details).toBeUndefined()
 
     vi.restoreAllMocks()
     wrapper.destroy()
@@ -284,7 +390,8 @@ describe('Consent to Continuation Out view', () => {
     expect(vm.staffPaymentData.option).toBe(1) // FAS
     expect(vm.staffPaymentData.routingSlipNumber).toBe('123456789')
     expect(vm.staffPaymentData.isPriority).toBe(true)
-    // NB: line 1 (default comment) should be removed
+    // ledger detail is loaded as-is (no default-comment prefix for this filing)
+    expect(vm.detail).toBe('Line 1\nLine 2\nLine 3')
     expect(vm.draftCountry).toBe('CA')
     expect(vm.draftRegion).toBe('AB')
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33519

*Description of changes:*
Reused the existing DetailComment component from Amalgamation Out for the Consent to Continue Out filing, adding optional and rows props (both defaulting to the original behavior so existing imports/views aren't affected) so the field can be optional and start at 1 row per the Figma design.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
