### PR TITLE
33408 add document upload component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.15",
+  "version": "8.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.15",
+      "version": "8.3.16",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.15",
+  "version": "8.3.16",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/FileUploadPdf.vue
+++ b/src/components/common/FileUploadPdf.vue
@@ -1,5 +1,10 @@
 <template>
+  <!--
+    Single-file mode (default, maxFiles <= 1).
+    NB: unchanged from the original component - existing consumers (eg, CourtOrder) rely on this.
+  -->
   <v-file-input
+    v-if="!isMultiple"
     :key="count"
     class="file-upload-pdf"
     dense
@@ -13,6 +18,68 @@
     :error-messages="errorMessages"
     @change="onChange($event)"
   />
+
+  <!-- Multi-file mode (maxFiles > 1). -->
+  <div
+    v-else
+    class="file-upload-pdf-multiple"
+  >
+    <ul
+      v-if="documents.length"
+      class="documents-list pl-0 mb-3"
+    >
+      <li
+        v-for="(doc, index) in documents"
+        :key="index"
+        class="d-flex align-center py-1"
+      >
+        <v-icon
+          small
+          class="mr-2"
+        >
+          mdi-paperclip
+        </v-icon>
+        <span class="document-name">{{ doc.fileName }}</span>
+        <v-btn
+          icon
+          small
+          class="ml-2 remove-document-button"
+          @click="removeFile(index)"
+        >
+          <v-icon small>
+            mdi-delete
+          </v-icon>
+        </v-btn>
+      </li>
+    </ul>
+
+    <!-- hidden picker, triggered by the Add-a-Document button -->
+    <v-file-input
+      v-show="false"
+      :key="count"
+      ref="picker"
+      accept=".pdf"
+      @change="onAddFile($event)"
+    />
+
+    <v-btn
+      id="add-document-button"
+      outlined
+      color="primary"
+      :disabled="documents.length >= maxFiles"
+      @click="openFileDialog"
+    >
+      <v-icon>mdi-plus</v-icon>
+      <span>Add a Document</span>
+    </v-btn>
+
+    <p
+      v-if="errorMessages.length"
+      class="error--text mb-0 mt-2"
+    >
+      {{ errorMessages[0] }}
+    </p>
+  </div>
 </template>
 
 <script lang="ts">
@@ -24,6 +91,11 @@ import { BusinessServices } from '@/services'
 
 @Component({})
 export default class FileUploadPdf extends Vue {
+  // Refs
+  $refs!: {
+    picker: any
+  }
+
   @Prop({ default: null }) readonly customErrorMSg!: string
   @Prop({ default: null }) readonly file!: File
   @Prop({ default: null }) readonly fileKey!: string
@@ -32,13 +104,30 @@ export default class FileUploadPdf extends Vue {
   @Prop({ default: null }) readonly pageSize!: PageSizes
   @Prop({ required: true }) readonly userId!: string
 
+  /** Maximum number of files. When > 1, the component runs in multi-file mode. */
+  @Prop({ default: 1 }) readonly maxFiles!: number
+
+  /** (Multi-file mode) the uploaded File objects (use with .sync). */
+  @Prop({ default: () => [] }) readonly files!: File[]
+
+  /** (Multi-file mode) the uploaded file keys (use with .sync). */
+  @Prop({ default: () => [] }) readonly fileKeys!: string[]
+
   /** Component key, used to force it to re-render. */
   count = 0
 
   /** Custom errors messages, use to put component into manual error mode. */
   errorMessages = [] as Array<string>
 
+  /** (Multi-file mode) the list of uploaded documents. */
+  documents: Array<{ fileName: string, file: File, fileKey: string }> = []
+
   pdfjsLib: any
+
+  /** Whether the component runs in multi-file mode. */
+  get isMultiple (): boolean {
+    return this.maxFiles > 1
+  }
 
   async created () {
     /**
@@ -47,10 +136,27 @@ export default class FileUploadPdf extends Vue {
      */
     this.pdfjsLib = pdfjs
     this.pdfjsLib.GlobalWorkerOptions.workerSrc = await import('pdfjs-dist/legacy/build/pdf.worker.entry')
+
+    // (multi-file mode) initialize the list from props (eg, on first render)
+    if (this.isMultiple && this.files.length) {
+      this.documents = this.files.map((file, i) => ({
+        fileName: file?.name || '',
+        file,
+        fileKey: this.fileKeys[i] || null
+      }))
+    }
   }
 
   /** Clears data and local state. */
   public reset (): void {
+    if (this.isMultiple) {
+      this.documents = []
+      this.emitDocuments()
+      this.errorMessages = []
+      this.count++
+      return
+    }
+
     // update parent
     this.updateFile(null)
     this.updateFileKey(null)
@@ -74,6 +180,16 @@ export default class FileUploadPdf extends Vue {
   public validate (): boolean {
     // force re-render to clear file input
     this.count++
+
+    // (multi-file mode) valid if not required, or if at least one file was uploaded
+    if (this.isMultiple) {
+      if (this.isRequired && this.documents.length === 0) {
+        this.errorMessages = [this.customErrorMSg || 'At least one file is required']
+        return false
+      }
+      this.errorMessages = []
+      return true
+    }
 
     // Logic is as follows:
     // if (no file) and (required) => error
@@ -138,6 +254,51 @@ export default class FileUploadPdf extends Vue {
 
     // if we get this far then everything succeeded
     this.errorMessages = []
+  }
+
+  /** (Multi-file mode) Opens the file picker dialog. */
+  openFileDialog (): void {
+    const input = this.$refs.picker?.$el?.querySelector('input')
+    input?.click()
+  }
+
+  /** (Multi-file mode) Validates and uploads a newly selected file, then adds it to the list. */
+  async onAddFile (file: File): Promise<void> {
+    if (!file) return
+
+    if (this.documents.length >= this.maxFiles) {
+      this.errorMessages = [`Maximum ${this.maxFiles} files`]
+      return
+    }
+
+    // validate the file
+    this.errorMessages = ['Processing...']
+    const validFile = await this.validateFile(file)
+    if (!validFile) { this.count++; return }
+
+    // upload the file
+    this.errorMessages = ['Uploading...']
+    const fileKey = await this.uploadFile(file)
+    if (!fileKey) { this.count++; return }
+
+    // add to the list and inform parent
+    this.documents.push({ fileName: file.name, file, fileKey })
+    this.emitDocuments()
+    this.errorMessages = []
+    this.count++ // clear the picker for the next file
+  }
+
+  /** (Multi-file mode) Removes a file from the list. */
+  removeFile (index: number): void {
+    this.documents.splice(index, 1)
+    this.emitDocuments()
+    this.errorMessages = []
+  }
+
+  /** (Multi-file mode) Emits the current files and file keys to the parent. */
+  emitDocuments (): void {
+    this.updateFiles(this.documents.map(d => d.file))
+    this.updateFileKeys(this.documents.map(d => d.fileKey))
   }
 
   /**
@@ -269,6 +430,14 @@ export default class FileUploadPdf extends Vue {
   @Emit('update:fileKey')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   updateFileKey (fileKey: string): void {}
+
+  @Emit('update:files')
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  updateFiles (files: File[]): void {}
+
+  @Emit('update:fileKeys')
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  updateFileKeys (fileKeys: string[]): void {}
 }
 </script>
 
@@ -300,6 +469,16 @@ export default class FileUploadPdf extends Vue {
   // less whitespace when file input is invalid
   .v-text-field__details {
     margin-bottom: -2px !important;
+  }
+}
+
+// Multi-file mode
+.documents-list {
+  list-style: none;
+
+  .document-name {
+    color: $gray9;
+    font-size: $px-14;
   }
 }
 </style>

--- a/src/views/ContinuationOut.vue
+++ b/src/views/ContinuationOut.vue
@@ -126,30 +126,51 @@
               </div>
             </section>
 
-            <!-- Documents Delivery -->
+            <!-- Documents Upload -->
             <section>
               <header>
-                <h2>Documents Delivery</h2>
-                <p class="grey-text">
-                  Copies of the continue out documents will be sent to the email addresses listed below.
-                </p>
+                <h2>Documents Upload</h2>
               </header>
               <div
-                id="document-delivery-section"
-                :class="{ 'invalid-section': !documentDeliveryValid && showErrors }"
+                id="document-upload-section"
+                :class="{ 'invalid-section': !documentUploadValid && showErrors }"
               >
                 <v-card
                   flat
                   class="py-8 px-5"
                 >
-                  <DocumentDelivery
-                    :editableCompletingParty="IsAuthorized(AuthorizedActions.EDITABLE_COMPLETING_PARTY)"
-                    :contactValue="getBusinessEmail"
-                    contactLabel="Business Office"
-                    :documentOptionalEmail="documentOptionalEmail"
-                    @update:optionalEmail="documentOptionalEmail=$event"
-                    @valid="documentDeliveryValid=$event"
-                  />
+                  <v-row no-gutters>
+                    <v-col
+                      cols="12"
+                      sm="3"
+                      class="pr-4"
+                    >
+                      <strong :class="{ 'app-red': !documentUploadValid && showErrors }">Upload a File</strong>
+                    </v-col>
+                    <v-col
+                      cols="12"
+                      sm="9"
+                    >
+                      <p class="mb-1 grey-text">
+                        Upload any supporting documents confirming this continuation out.
+                      </p>
+                      <ul class="ml-2 mb-4 grey-text">
+                        <li>Use a white background and a legible font with contrasting font colour</li>
+                        <li>PDF file type (maximum {{ MAX_FILE_SIZE }} MB file size)</li>
+                        <li>Maximum {{ MAX_FILES }} files</li>
+                      </ul>
+                      <FileUploadPdf
+                        ref="fileUploadRef"
+                        :maxFiles="MAX_FILES"
+                        :files.sync="files"
+                        :fileKeys.sync="fileKeys"
+                        :isRequired="true"
+                        :maxSize="MAX_FILE_SIZE"
+                        :pageSize="PageSizes.LETTER_PORTRAIT"
+                        :userId="getUserInfo?.keycloakGuid"
+                      />
+                    </v-col>
+                  </v-row>
                 </v-card>
               </div>
             </section>
@@ -190,6 +211,34 @@
                       />
                     </v-col>
                   </v-row>
+                </v-card>
+              </div>
+            </section>
+
+            <!-- Documents Delivery -->
+            <section>
+              <header>
+                <h2>Documents Delivery</h2>
+                <p class="grey-text">
+                  Copies of the continue out documents will be sent to the email addresses listed below.
+                </p>
+              </header>
+              <div
+                id="document-delivery-section"
+                :class="{ 'invalid-section': !documentDeliveryValid && showErrors }"
+              >
+                <v-card
+                  flat
+                  class="py-8 px-5"
+                >
+                  <DocumentDelivery
+                    :editableCompletingParty="IsAuthorized(AuthorizedActions.EDITABLE_COMPLETING_PARTY)"
+                    :contactValue="getBusinessEmail"
+                    contactLabel="Business Office"
+                    :documentOptionalEmail="documentOptionalEmail"
+                    @update:optionalEmail="documentOptionalEmail=$event"
+                    @valid="documentDeliveryValid=$event"
+                  />
                 </v-card>
               </div>
             </section>
@@ -357,14 +406,15 @@ import { Getter } from 'pinia-class'
 import { StatusCodes } from 'http-status-codes'
 import { IsAuthorized, Navigate } from '@/utils'
 import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
-import { BusinessNameForeign, Certify, DetailComment, EffectiveDate, ForeignJurisdiction } from '@/components/common'
+import { BusinessNameForeign, Certify, DetailComment, EffectiveDate, FileUploadPdf, ForeignJurisdiction }
+  from '@/components/common'
 import { ConfirmDialog, ResumeErrorDialog, SaveErrorDialog }
   from '@/components/dialogs'
 import { CommonMixin, DateMixin, FilingMixin, ResourceLookupMixin } from '@/mixins'
 import { BusinessServices, EnumUtilities } from '@/services'
-import { AuthorizedActions, EffectOfOrderTypes, FilingStatus, SaveErrorReasons } from '@/enums'
+import { AuthorizedActions, EffectOfOrderTypes, FilingStatus, PageSizes, SaveErrorReasons } from '@/enums'
 import { FilingCodes, FilingTypes } from '@bcrs-shared-components/enums'
-import { ConfirmDialogType } from '@/interfaces'
+import { ConfirmDialogType, UserInfoIF } from '@/interfaces'
 import { CourtOrderPoa } from '@bcrs-shared-components/court-order-poa'
 import { DocumentDelivery } from '@bcrs-shared-components/document-delivery'
 import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
@@ -378,6 +428,7 @@ import { useBusinessStore, useConfigurationStore, useRootStore } from '@/stores'
     DetailComment,
     DocumentDelivery,
     EffectiveDate,
+    FileUploadPdf,
     ForeignJurisdiction,
     ResumeErrorDialog,
     SaveErrorDialog,
@@ -391,6 +442,7 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
     confirm: ConfirmDialogType,
     certifyRef: Certify,
     effectiveDateRef: EffectiveDate,
+    fileUploadRef: FileUploadPdf,
     foreignJurisdictionRef: ForeignJurisdiction,
   }
 
@@ -399,6 +451,7 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
   @Getter(useConfigurationStore) getBusinessApiUrl!: string
   @Getter(useBusinessStore) getLegalName!: string
   @Getter(useConfigurationStore) getPayApiUrl!: string
+  @Getter(useRootStore) getUserInfo!: UserInfoIF
 
   // enum for template
   readonly FilingCodes = FilingCodes
@@ -421,6 +474,14 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
   initialBusinessName = ''
   businessName = ''
   businessNameValid = false
+
+  // variables for FileUploadPdf component (multi-file mode)
+  readonly MAX_FILE_SIZE = 30 // in MB
+  readonly MAX_FILES = 5
+  readonly PageSizes = PageSizes
+  files: File[] = [] // uploaded document file objects
+  fileKeys: string[] = [] // uploaded document file keys
+  documentUploadValid = false
 
   // variables for DetailComment component
   detail = ''
@@ -474,7 +535,8 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
   get isPageValid (): boolean {
     return (this.effectiveDateValid && this.certifyFormValid &&
       this.foreignJurisdictionValid && this.businessNameValid &&
-      this.detailValid && this.documentDeliveryValid && this.courtOrderValid)
+      this.documentUploadValid && this.detailValid &&
+      this.documentDeliveryValid && this.courtOrderValid)
   }
 
   /** True when saving, saving and resuming, or filing and paying. */
@@ -600,6 +662,9 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
         this.detail = details
       }
 
+      // NB: uploaded documents are not restored on draft resume (the File objects cannot be
+      // reconstructed from the stored file keys), so the user must re-add them. FUTURE: support this.
+
       if (filing.header.documentOptionalEmail) {
         this.documentOptionalEmail = filing.header.documentOptionalEmail
       }
@@ -708,6 +773,11 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
       if (!this.certifyFormValid && !this.isBaseCompany) {
         // Show error message of legal name text field if invalid (not applicable for corporations)
         this.$refs.certifyRef.$refs.certifyTextfieldRef.error = true
+      }
+
+      if (!this.documentUploadValid) {
+        // show the file upload component's error (eg, "File is required")
+        this.$refs.fileUploadRef.validate()
       }
 
       await this.validateAndScroll(this.validFlags, this.validComponents)
@@ -828,6 +898,15 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
       }
     }
 
+    if (this.fileKeys.length > 0) {
+      data[FilingTypes.CONTINUATION_OUT].documents = this.files.map((file, i) => ({
+        fileKey: this.fileKeys[i],
+        fileName: file.name,
+        fileLastModified: file.lastModified,
+        fileSize: file.size
+      }))
+    }
+
     if (this.detail !== '') {
       data[FilingTypes.CONTINUATION_OUT].details = this.detail
     }
@@ -942,6 +1021,7 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
     'effective-date-section',
     'jurisdiction-information-section',
     'business-information-section',
+    'document-upload-section',
     'detail-section',
     'document-delivery-section',
     'certify-form-section',
@@ -954,6 +1034,7 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
       effectiveDate: this.effectiveDateValid,
       foreignJurisdiction: this.foreignJurisdictionValid,
       businessInformation: this.businessNameValid,
+      documentUpload: this.documentUploadValid,
       detail: this.detailValid,
       documentDelivery: this.documentDeliveryValid,
       certifyForm: this.certifyFormValid,
@@ -961,10 +1042,17 @@ export default class ContinuationOut extends Mixins(CommonMixin, DateMixin, Fili
     }
   }
 
+  /** Updates document upload validity (valid once at least one document has been uploaded). */
+  @Watch('fileKeys')
+  onFileKeysChanged (): void {
+    this.documentUploadValid = this.fileKeys.length > 0
+  }
+
   @Watch('certifyFormValid')
   @Watch('courtOrderValid')
   @Watch('detail')
   @Watch('documentDeliveryValid')
+  @Watch('files')
   onHaveChanges (): void {
     this.haveChanges = true
   }

--- a/tests/unit/ContinuationOut.spec.ts
+++ b/tests/unit/ContinuationOut.spec.ts
@@ -131,6 +131,7 @@ describe('Continuation Out view', () => {
     vm.certifyFormValid = true
     vm.courtOrderValid = true
     vm.detailCommentValid = true
+    vm.documentUploadValid = true
     vm.documentDeliveryValid = true
     vm.effectiveDateValid = true
     vm.foreignJurisdictionValid = true
@@ -141,6 +142,7 @@ describe('Continuation Out view', () => {
     vm.certifyFormValid = false
     vm.courtOrderValid = true
     vm.detailCommentValid = true
+    vm.documentUploadValid = true
     vm.documentDeliveryValid = true
     vm.effectiveDateValid = true
     vm.foreignJurisdictionValid = true
@@ -151,6 +153,18 @@ describe('Continuation Out view', () => {
     vm.certifyFormValid = true
     vm.courtOrderValid = false
     vm.detailCommentValid = true
+    vm.documentUploadValid = true
+    vm.documentDeliveryValid = true
+    vm.effectiveDateValid = true
+    vm.foreignJurisdictionValid = true
+    expect(!!vm.isPageValid).toBe(false)
+
+    // verify "validated" - invalid Document Upload form
+    vm.businessNameValid = true
+    vm.certifyFormValid = true
+    vm.courtOrderValid = true
+    vm.detailCommentValid = true
+    vm.documentUploadValid = false
     vm.documentDeliveryValid = true
     vm.effectiveDateValid = true
     vm.foreignJurisdictionValid = true
@@ -161,6 +175,7 @@ describe('Continuation Out view', () => {
     vm.certifyFormValid = true
     vm.courtOrderValid = true
     vm.detailCommentValid = true
+    vm.documentUploadValid = true
     vm.documentDeliveryValid = false
     vm.effectiveDateValid = true
     vm.foreignJurisdictionValid = true
@@ -171,6 +186,7 @@ describe('Continuation Out view', () => {
     vm.certifyFormValid = true
     vm.courtOrderValid = true
     vm.detailCommentValid = true
+    vm.documentUploadValid = true
     vm.documentDeliveryValid = true
     vm.effectiveDateValid = true
     vm.foreignJurisdictionValid = false
@@ -182,6 +198,7 @@ describe('Continuation Out view', () => {
     vm.certifyFormValid = true
     vm.courtOrderValid = true
     vm.detailCommentValid = true
+    vm.documentUploadValid = true
     vm.documentDeliveryValid = true
     vm.effectiveDateValid = false
     vm.foreignJurisdictionValid = true
@@ -193,6 +210,7 @@ describe('Continuation Out view', () => {
     vm.certifyFormValid = true
     vm.courtOrderValid = true
     vm.detailCommentValid = true
+    vm.documentUploadValid = true
     vm.documentDeliveryValid = true
     vm.effectiveDateValid = true
     vm.foreignJurisdictionValid = true
@@ -241,6 +259,7 @@ describe('Continuation Out view', () => {
         DocumentDelivery: true,
         Certify: true,
         EffectiveDate: true,
+        FileUploadPdf: true,
         ForeignJurisdiction: true,
         SbcFeeSummary: true
       },
@@ -305,6 +324,7 @@ describe('Continuation Out view', () => {
         DocumentDelivery: true,
         Certify: true,
         EffectiveDate: true,
+        FileUploadPdf: true,
         ForeignJurisdiction: true,
         SbcFeeSummary: true
       },

--- a/tests/unit/FileUploadPdf.spec.ts
+++ b/tests/unit/FileUploadPdf.spec.ts
@@ -197,4 +197,98 @@ describe('FileUploadPdf component', () => {
 
     wrapper.destroy()
   })
+
+  // --- multi-file mode (maxFiles > 1) ---
+
+  it('renders the Add a Document button in multi-file mode', () => {
+    const wrapper = mount(FileUploadPdf, {
+      propsData: { maxFiles: 5, userId: 'user-1' },
+      vuetify
+    })
+
+    // shows the multi-file UI, not the single-file input
+    expect(wrapper.find('#add-document-button').exists()).toBe(true)
+    expect(wrapper.find('.file-upload-pdf').exists()).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('validate() is invalid when required with no documents (multi-file)', () => {
+    const wrapper = mount(FileUploadPdf, {
+      propsData: { maxFiles: 5, isRequired: true, userId: 'user-1' },
+      vuetify
+    })
+    const vm: any = wrapper.vm
+
+    expect(vm.validate()).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('validate() is valid when optional with no documents (multi-file)', () => {
+    const wrapper = mount(FileUploadPdf, {
+      propsData: { maxFiles: 5, isRequired: false, userId: 'user-1' },
+      vuetify
+    })
+    const vm: any = wrapper.vm
+
+    expect(vm.validate()).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('adds an uploaded document to the list and emits files/fileKeys (multi-file)', async () => {
+    const wrapper = mount(FileUploadPdf, {
+      propsData: { maxFiles: 5, userId: 'user-1' },
+      vuetify
+    })
+    const vm: any = wrapper.vm
+
+    // bypass the PDF validation and upload (covered by single-file tests / services)
+    vi.spyOn(vm, 'validateFile').mockResolvedValue(true)
+    vi.spyOn(vm, 'uploadFile').mockResolvedValue('test-key')
+
+    await vm.onAddFile(oneMBFile)
+
+    expect(vm.documents.length).toBe(1)
+    expect(wrapper.emitted('update:files').pop()[0]).toEqual([oneMBFile])
+    expect(wrapper.emitted('update:fileKeys').pop()[0]).toEqual(['test-key'])
+
+    wrapper.destroy()
+  })
+
+  it('does not add beyond maxFiles (multi-file)', async () => {
+    const wrapper = mount(FileUploadPdf, {
+      propsData: { maxFiles: 1, userId: 'user-1' },
+      vuetify
+    })
+    const vm: any = wrapper.vm
+
+    // NB: maxFiles=1 still renders single-file mode, so force multi-file state directly
+    vm.documents = [{ fileName: 'a.pdf', file: oneMBFile, fileKey: 'k1' }]
+    // attempt to add when already at the max
+    await vm.onAddFile(oneMBFile)
+
+    expect(vm.documents.length).toBe(1)
+    expect(vm.errorMessages[0]).toBe('Maximum 1 files')
+
+    wrapper.destroy()
+  })
+
+  it('removeFile removes a document and emits the updated arrays (multi-file)', () => {
+    const wrapper = mount(FileUploadPdf, {
+      propsData: { maxFiles: 5, userId: 'user-1' },
+      vuetify
+    })
+    const vm: any = wrapper.vm
+
+    vm.documents = [{ fileName: 'a.pdf', file: oneMBFile, fileKey: 'k1' }]
+    vm.removeFile(0)
+
+    expect(vm.documents.length).toBe(0)
+    expect(wrapper.emitted('update:fileKeys').pop()[0]).toEqual([])
+    expect(wrapper.emitted('update:files').pop()[0]).toEqual([])
+
+    wrapper.destroy()
+  })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33408

*Description of changes:*

- Reordered the sections in the DOM (moving Documents Delivery below Detail) so the view matches the Figma layout.
- Reusing the existing document-upload component from the Court Order view, but added an optional maxFiles prop that enables multi-file upload — keeping the Court Order view unchanged (single file) while giving Continuation Out the required multi-file functionality per the Figma design.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
