### PR TITLE
34057 court order certified by empty string validation fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.19",
+  "version": "8.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.19",
+      "version": "8.3.20",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.19",
+  "version": "8.3.20",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/CourtOrder.vue
+++ b/src/views/CourtOrder.vue
@@ -539,8 +539,9 @@ export default class CourtOrderView extends Mixins(DateMixin, FilingMixin, Commo
     const filing: any = {
       header: {
         name: this.name,
-        date: this.getCurrentDate, // NB: API will reassign this date according to its clock
-        certifiedBy: ''
+        date: this.getCurrentDate // NB: API will reassign this date according to its clock
+        // NB: certifiedBy is optional and omitted here (no Certify component in this staff-only filing);
+        // sending '' fails the schema's non-empty pattern (\S). See bcgov/entity#34057, #32771.
       },
       business: {
         identifier: this.getIdentifier,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34057

*Description of changes:*
Fixed the hardcoded empty certifiedBy in the Court Order filing to resolve the 422 Unprocessable Content error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
