### PR TITLE
34201 annual report - omit offices and directors for corps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.21",
+  "version": "8.3.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.21",
+      "version": "8.3.22",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.21",
+  "version": "8.3.22",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/AnnualReport.vue
+++ b/src/views/AnnualReport.vue
@@ -1162,13 +1162,7 @@ export default class AnnualReport extends Mixins(CommonMixin, DateMixin, FilingM
       annualReport = {
         [FilingTypes.ANNUAL_REPORT]: {
           annualReportDate: this.asOfDate,
-          nextARDate: this.nextARDate, // used by BEN/BC/CC/ULC and CBEN/C/CCC/CUL only
-          // NB: there was an enrichment ticket to populate offices and directors here
-          offices: {
-            registeredOffice: this.originalAddresses.registeredOffice,
-            recordsOffice: this.originalAddresses.recordsOffice
-          },
-          directors: this.originalDirectors
+          nextARDate: this.nextARDate // used by BEN/BC/CC/ULC and CBEN/C/CCC/CUL only
         }
       }
     }

--- a/tests/unit/AnnualReport.spec.ts
+++ b/tests/unit/AnnualReport.spec.ts
@@ -1927,9 +1927,8 @@ describe('Annual Report - Part 5B - Data (BCOMP)', () => {
     expect(payload.filing).toBeDefined()
     expect(payload.filing.annualReport).toBeDefined()
 
-    expect(payload.filing.annualReport.directors).toBeDefined()
-    expect(payload.filing.annualReport.offices.registeredOffice).toBeDefined()
-    expect(payload.filing.annualReport.offices.recordsOffice).toBeDefined()
+    expect(payload.filing.annualReport.directors).not.toBeDefined()
+    expect(payload.filing.annualReport.offices).not.toBeDefined()
   })
 
   it('includes authorization data in the header', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34201

*Description of changes:*
- confirmed this is not used for corps in the filer or report generation
- dependent on schema change in review (will need to update the API afterwards)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
