### PR TITLE
34469 - Bump base-address to 2.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.3.24",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
-        "@bcrs-shared-components/base-address": "2.2.8",
+        "@bcrs-shared-components/base-address": "2.2.9",
         "@bcrs-shared-components/breadcrumb": "2.1.76",
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
         "@bcrs-shared-components/corp-type-module": "1.0.16",
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@bcrs-shared-components/base-address": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/base-address/-/base-address-2.2.8.tgz",
-      "integrity": "sha512-Aogto96f1UfHPvkbm4wKqMUj1kDeHN3Psq77R7zo7rNWJx8S18TmsqJHL5d7ChFJ/Y40Fi6y19QIbLjMsjcXqw==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/base-address/-/base-address-2.2.9.tgz",
+      "integrity": "sha512-/CVh2dFC88IzecTQpQdL/vgFgDp6rtZMRMkERXpJWvgyjquBa2esnX19vJFzftdincgDMIfkj3vf5BU40UAPWw==",
       "dependencies": {
         "@bcrs-shared-components/mixins": "^1.2.8",
         "@bcrs-shared-components/validators": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.24",
+  "version": "8.3.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.24",
+      "version": "8.3.25",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.24",
+  "version": "8.3.25",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@babel/compat-data": "^7.21.5",
-    "@bcrs-shared-components/base-address": "2.2.8",
+    "@bcrs-shared-components/base-address": "2.2.9",
     "@bcrs-shared-components/breadcrumb": "2.1.76",
     "@bcrs-shared-components/confirm-dialog": "1.2.1",
     "@bcrs-shared-components/corp-type-module": "1.0.16",


### PR DESCRIPTION
Issue: bcgov/entity#34469 

Picks up the BaseAddress valid-emit fix from bcgov/bcrs-shared-components#317. Version bumped to 8.3.25.