### PR TITLE
34355 - AGM Location Change Year Cannot be Before Incorporation Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.24",
+  "version": "8.3.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-filings-ui",
-      "version": "8.3.24",
+      "version": "8.3.25",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/base-address": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-filings-ui",
-  "version": "8.3.24",
+  "version": "8.3.25",
   "private": true,
   "appName": "Business Filings UI",
   "sbcName": "SBC Common Components",

--- a/src/views/AgmLocationChg.vue
+++ b/src/views/AgmLocationChg.vue
@@ -426,9 +426,13 @@ export default class AgmLocationChg extends Mixins(CommonMixin, DateMixin, Filin
     return rules
   }
 
-  get minAgmYear () : number {
+  get minAgmYear (): number {
     const today = new Date()
-    return (today.getFullYear() - 2)
+    const defaultMinYear = today.getFullYear() - 2
+
+    // AGM year can never be before the founding date of the business
+    const recognitionYear = this.getFoundingDate ? new Date(this.getFoundingDate).getFullYear() : defaultMinYear
+    return Math.max(defaultMinYear, recognitionYear)
   }
 
   get maxAgmYear () : number {

--- a/src/views/AgmLocationChg.vue
+++ b/src/views/AgmLocationChg.vue
@@ -426,7 +426,7 @@ export default class AgmLocationChg extends Mixins(CommonMixin, DateMixin, Filin
     return rules
   }
 
-  get minAgmYear (): number {
+  get minAgmYear () : number {
     const today = new Date()
     const defaultMinYear = today.getFullYear() - 2
 

--- a/tests/unit/AgmLocationChg.spec.ts
+++ b/tests/unit/AgmLocationChg.spec.ts
@@ -235,3 +235,77 @@ describe('AGM Location Chg view', () => {
     wrapper.destroy()
   })
 })
+
+describe('AGM year min/max boundaries', () => {
+  const mountComponent = () => {
+    const $route = { query: { filingId: '0' } }
+    return shallowMount(AgmLocationChg, { mocks: { $route }, vuetify })
+  }
+
+  const currentYear = new Date().getFullYear()
+  const lookbackFloor = currentYear - 2
+
+  it('uses the default 2-year lookback floor when founding date is older', () => {
+    businessStore.setFoundingDate('1971-05-12T00:00:00-00:00')
+
+    const wrapper = mountComponent()
+    const vm: any = wrapper.vm
+
+    // founding year (1971) is older than the lookback floor
+    expect(vm.minAgmYear).toBe(lookbackFloor)
+
+    wrapper.destroy()
+  })
+
+  it('uses the founding year as the floor when it is more recent than the default lookback window', () => {
+    const foundingYear = lookbackFloor + 1
+    businessStore.setFoundingDate(`${foundingYear}-06-01T00:00:00-00:00`)
+
+    const wrapper = mountComponent()
+    const vm: any = wrapper.vm
+
+    // founding year is later than the lookback floor
+    expect(vm.minAgmYear).toBe(foundingYear)
+
+    wrapper.destroy()
+  })
+
+  it('uses the founding year as the floor when the business was founded this year', () => {
+    businessStore.setFoundingDate(`${currentYear}-01-15T00:00:00-00:00`)
+
+    const wrapper = mountComponent()
+    const vm: any = wrapper.vm
+
+    expect(vm.minAgmYear).toBe(currentYear)
+
+    wrapper.destroy()
+  })
+
+  it('computes maxAgmYear as one year in the future regardless of founding date', () => {
+    businessStore.setFoundingDate('1971-05-12T00:00:00-00:00')
+
+    const wrapper = mountComponent()
+    const vm: any = wrapper.vm
+
+    expect(vm.maxAgmYear).toBe(currentYear + 1)
+
+    wrapper.destroy()
+  })
+
+  it('fails agmYearRules validation for a year before the founding date', () => {
+    const foundingYear = lookbackFloor + 1
+    businessStore.setFoundingDate(`${foundingYear}-06-01T00:00:00-00:00`)
+
+    const wrapper = mountComponent()
+    const vm: any = wrapper.vm
+
+    const rules = vm.agmYearRules
+    const belowFloorResult = rules[2](String(foundingYear - 1))
+    expect(belowFloorResult).toBe(`Must be on or after ${foundingYear}`)
+
+    const atFloorResult = rules[2](String(foundingYear))
+    expect(atFloorResult).toBe(true)
+
+    wrapper.destroy()
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34355

*Description of changes:*
- Update logic that calculates the `minAgmYear`
- Add unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
